### PR TITLE
Update examples to 0.3.2-SNAPSHOT.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ This project hosts the Java client library for the Google Ads API.
     *   `google-ads-examples`: multiple examples that demonstrate how to use
         the library to execute common use cases via the Google Ads API.
 
-3.  To run examples, you'll need to compile the `google-ads-examples` code.
+3.  To run examples, you'll need to compile the `google-ads` and
+    `google-ads-examples` code.
 
     **If you are using an IDE...**
 
@@ -46,6 +47,11 @@ This project hosts the Java client library for the Google Ads API.
         builds the project successfully.
 
     **If you are using Maven from the command line...**
+
+    *   From the `google-ads-java` directory, install the snapshot version
+        of the library.
+
+            mvn install
 
     *   Change into the `google-ads-examples` directory.
 

--- a/google-ads-examples/pom.xml
+++ b/google-ads-examples/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.google.api-ads</groupId>
     <artifactId>google-ads-parent</artifactId>
-    <version>0.3.1-SNAPSHOT</version>
+    <version>0.3.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -30,7 +30,7 @@
   <groupId>com.google.api-ads</groupId>
   <artifactId>google-ads-examples</artifactId>
   <packaging>jar</packaging>
-  <version>0.3.1-SNAPSHOT</version>
+  <version>0.3.2-SNAPSHOT</version>
   <name>Google Ads API client library for Java examples</name>
   <description>
     Examples demonstrating the Google Ads API client library for Java.
@@ -55,7 +55,7 @@
     <dependency>
       <groupId>com.google.api-ads</groupId>
       <artifactId>google-ads</artifactId>
-      <version>0.3.1-SNAPSHOT</version>
+      <version>0.3.2-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.beust</groupId>


### PR DESCRIPTION
Update README.md to include `mvn install` step so users can run examples
that depend on the latest unreleased commits to `google-ads`.

[rel-0.3.1-post]