### PR TITLE
Remove setting of autoReleaseAfterClose.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,6 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.target>1.7</maven.compiler.target>
-    <google-ads-java.autoRelease>false</google-ads-java.autoRelease>
   </properties>
 
   <build>
@@ -248,7 +247,6 @@
             <configuration>
               <serverId>sonatype-nexus-staging</serverId>
               <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-              <autoReleaseAfterClose>${google-ads-java.autoRelease}</autoReleaseAfterClose>
             </configuration>
           </plugin>
         </plugins>


### PR DESCRIPTION
The previous attempt to use a build property for this setting did not
work as expected. The `nexus-staging-maven-plugin` ignored the system
property passed on the command line.

In addition, it turns out that this property is not necessary for two
reasons:

1.  The `autoReleaseAfterClose` property defaults to `false`. See:
    https://help.sonatype.com/repomanager2/staging-releases/configuring-your-project-for-deployment#ConfiguringYourProjectforDeployment-DeploymentwiththeNexusStagingMavenPlugin
2.  The `autoReleaseAfterClose` property can be passed via the command
    line already, so there's no point in introducing an intermediate
    build property that mirros the existing property. See:
    https://github.com/sonatype/nexus-maven-plugins/tree/master/staging/maven-plugin#plugin-flags

[deployautorel]