### PR TITLE
Fix example code readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,9 +208,10 @@ If your configuration file is not in your home directory, you can pass the
 file location to the `fromPropertiesFile` method as follows:
 
 ```java
+File propertiesFile = new File("/path/to/ads.properties"); 
 GoogleAdsClient googleAdsClient =
     GoogleAdsClient.newBuilder()
-        .fromPropertiesFile("/path/to/ads.properties").build();
+        .fromPropertiesFile(propertiesFile).build();
 ```
 
 You can also construct a `Credentials` object by specifying the client ID,


### PR DESCRIPTION
Fix manual location of config in readme as it needs to be a `File` not `String` (see  https://github.com/googleads/google-ads-java/blob/master/google-ads/src/main/java/com/google/ads/googleads/lib/GoogleAdsClient.java#L236 )