### PR TITLE
Update maven coordinates to version 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This project hosts the Java client library for the Google Ads API.
     <dependency>
       <groupId>com.google.api-ads</groupId>
       <artifactId>google-ads</artifactId>
-      <version>0.6.0</version>
+      <version>1.0.0</version>
     </dependency>
 
 ## Getting started

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This project hosts the Java client library for the Google Ads API.
     <dependency>
       <groupId>com.google.api-ads</groupId>
       <artifactId>google-ads</artifactId>
-      <version>1.0.0</version>
+      <version>1.0.1</version>
     </dependency>
 
 ## Getting started


### PR DESCRIPTION
The readme should at least have the latest major version of the library for the maven coordinates. As 0.6.0 is not latest this PR bumps it to the latest version as claimed by [.google-ads-java/releases/latest](https://github.com/googleads/google-ads-java/releases/latest)

Of note - 1.0.1 is tagged but I don't know if its been "released". 