### PR TITLE
Shade Google Ads Java

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ The [shaded](https://maven.apache.org/plugins/maven-shade-plugin/) version reloc
 dependencies under `com.google.ads.googleads.shaded` and removes these from the POM. You can
 therefore depend on multiple versions of libraries such as Guava and Protobuf.
 
+Note that if using the shaded version, the imports of common protocol buffers (StringValue etc.)
+will need to be updated to `com.google.ads.googleads.shaded.protobuf.StringValue`.
+
 ## Getting started
 
 1.  Clone this project in the directory of your choice via:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ added to include the Google Ads Java library.
     </dependency>
 
 If you encounter dependency resolution issues, swapping `google-ads` for
-`google-ads-shaded` may help.
+`google-ads-shaded` may help resolve issues arising from this library.
 
     <dependency>
       <groupId>com.google.api-ads</groupId>
@@ -34,8 +34,8 @@ If you encounter dependency resolution issues, swapping `google-ads` for
     </dependency>
 
 The [shaded](https://maven.apache.org/plugins/maven-shade-plugin/) version relocates our
-dependencies under `com.google.ads.googleads.shaded` and removes the transitive dependencies. You
-can therefore depend on multiple versions of libraries such as Guava and Protobuf.
+dependencies under `com.google.ads.googleads.shaded` and removes these from the POM. You can
+therefore depend on multiple versions of libraries such as Guava and Protobuf.
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -15,11 +15,27 @@ This project hosts the Java client library for the Google Ads API.
 
 ## Maven artifacts
 
+The default maven artifact is `google-ads` at the latest version. The following dependency may be
+added to include the Google Ads Java library.
+
     <dependency>
       <groupId>com.google.api-ads</groupId>
       <artifactId>google-ads</artifactId>
       <version>4.0.0</version>
     </dependency>
+
+If you encounter dependency resolution issues, swapping `google-ads` for
+`google-ads-shaded` may help.
+
+    <dependency>
+      <groupId>com.google.api-ads</groupId>
+      <artifactId>google-ads-shaded</artifactId>
+      <version>1.1.0</version>
+    </dependency>
+
+The [shaded](https://maven.apache.org/plugins/maven-shade-plugin/) version relocates our
+dependencies under `com.google.ads.googleads.shaded` and removes the transitive dependencies. You
+can therefore depend on multiple versions of libraries such as Guava and Protobuf.
 
 ## Getting started
 

--- a/google-ads-examples/pom.xml
+++ b/google-ads-examples/pom.xml
@@ -1,17 +1,17 @@
 <!--
- * Copyright 2019 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+Copyright 2018 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 

--- a/google-ads-examples/pom.xml
+++ b/google-ads-examples/pom.xml
@@ -81,5 +81,11 @@
       <version>4.12</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+      <version>1.10.19</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/google-ads-examples/pom.xml
+++ b/google-ads-examples/pom.xml
@@ -27,7 +27,7 @@ limitations under the License.
   <artifactId>google-ads-examples</artifactId>
   <packaging>jar</packaging>
   <version>4.0.1-SNAPSHOT</version>
-  <name>Google Ads API client library for Java examples</name>
+  <name>Google Ads API client for Java - examples</name>
   <description>
     Examples demonstrating the Google Ads API client library for Java.
   </description>

--- a/google-ads-examples/pom.xml
+++ b/google-ads-examples/pom.xml
@@ -50,7 +50,7 @@ limitations under the License.
   <dependencies>
     <dependency>
       <groupId>com.google.api-ads</groupId>
-      <artifactId>google-ads</artifactId>
+      <artifactId>google-ads-shaded</artifactId>
       <version>4.0.1-SNAPSHOT</version>
     </dependency>
     <dependency>

--- a/google-ads-shaded/pom.xml
+++ b/google-ads-shaded/pom.xml
@@ -71,8 +71,7 @@
                   <include>com.google.auth:google-auth-library-oauth2-http</include>
                   <include>com.google.code.findbugs:jsr305</include>
                   <include>com.google.code.gson:gson</include>
-                  <include>com.google.errorprone:error_prone_annotations
-                  </include>
+                  <include>com.google.errorprone:error_prone_annotations</include>
                   <include>com.google.guava:guava</include>
                   <include>com.google.http-client:google-http-client-jackson2</include>
                   <include>com.google.http-client:google-http-client</include>
@@ -87,7 +86,6 @@
                   <include>io.grpc:grpc-protobuf</include>
                   <include>io.grpc:grpc-protobuf-lite</include>
                   <include>io.grpc:grpc-stub</include>
-                  <include>io.grpc:grpc-netty-shaded</include>
                   <include>io.grpc:grpc-netty</include>
 
                   <!-- Netty dependencies -->
@@ -111,8 +109,7 @@
                   <include>io.opencensus:opencensus-contrib-grpc-metrics</include>
                   <include>org.apache.httpcomponents:httpclient</include>
                   <include>org.apache.httpcomponents:httpcore</include>
-                  <include>org.codehaus.mojo:animal-sniffer-annotations
-                  </include> <!-- check if this is needed, it's for JDK compat testing -->
+                  <include>org.codehaus.mojo:animal-sniffer-annotations</include>
                   <include>org.checkerframework:checker-compat-qual</include>
                   <include>org.threeten:threetenbp</include>
                 </includes>
@@ -175,7 +172,6 @@
                   <pattern>com.google.type</pattern>
                   <shadedPattern>${shadedBase}.com.google.type</shadedPattern>
                 </relocation>
-
                 <relocation>
                   <pattern>io.grpc</pattern>
                   <shadedPattern>${shadedBase}.io.grpc</shadedPattern>

--- a/google-ads-shaded/pom.xml
+++ b/google-ads-shaded/pom.xml
@@ -1,21 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+Copyright 2019 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -273,14 +270,14 @@
       <artifactId>google-ads</artifactId>
       <version>1.1.1-SNAPSHOT</version>
       <exclusions>
+        <!-- Exclude grpc-netty-shaded and reshade. Shade plugin duplicates the shadedPattern when
+             pattern is found twice in classname. -->
         <exclusion>
           <groupId>io.grpc</groupId>
           <artifactId>grpc-netty-shaded</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
-    <!-- Exclude grpc-netty-shaded and reshade. Shade plugin duplicates the shadedPattern when
-         pattern is found twice in classname. -->
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-netty</artifactId>

--- a/google-ads-shaded/pom.xml
+++ b/google-ads-shaded/pom.xml
@@ -27,7 +27,7 @@ limitations under the License.
 
   <artifactId>google-ads-shaded</artifactId>
 
-  <name>Google Ads API client library for Java - shaded</name>
+  <name>Google Ads API client for Java - shaded</name>
 
   <properties>
     <shadedBase>com.google.ads.googleads.shaded</shadedBase>

--- a/google-ads-shaded/pom.xml
+++ b/google-ads-shaded/pom.xml
@@ -1,0 +1,309 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>google-ads-parent</artifactId>
+    <groupId>com.google.api-ads</groupId>
+    <version>1.1.1-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>google-ads-shaded</artifactId>
+
+  <name>Google Ads API client library for Java - shaded</name>
+
+  <properties>
+    <shadedBase>com.google.ads.googleads.shaded</shadedBase>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.2.1</version>
+        <executions>
+          <execution>
+            <id>create-shaded-jar</id>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <phase>package</phase>
+            <configuration>
+              <createSourcesJar>true</createSourcesJar>
+              <shadeSourcesContent>true</shadeSourcesContent>
+              <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
+              <createDependencyReducedPom>true</createDependencyReducedPom>
+              <artifactSet>
+                <includes>
+                  <!-- Explicit dependency inclusions are mandatory: do not use wildcards!
+                       Reason is compilation should fail when new dependencies are added.
+                       These should be carefully added to the shaded jar. -->
+                  <include>com.google.api-ads:google-ads</include>
+
+                  <!-- Google Dependencies -->
+                  <include>com.google.api:api-common</include>
+                  <include>com.google.api:gax-grpc</include>
+                  <include>com.google.api:gax</include>
+                  <include>com.google.api.grpc:grpc-google-common-protos</include>
+                  <include>com.google.api.grpc:proto-google-common-protos</include>
+                  <include>com.google.auth:google-auth-library-credentials</include>
+                  <include>com.google.auth:google-auth-library-oauth2-http</include>
+                  <include>com.google.code.findbugs:jsr305</include>
+                  <include>com.google.code.gson:gson</include>
+                  <include>com.google.errorprone:error_prone_annotations
+                  </include>
+                  <include>com.google.guava:guava</include>
+                  <include>com.google.http-client:google-http-client-jackson2</include>
+                  <include>com.google.http-client:google-http-client</include>
+                  <include>com.google.instrumentation:instrumentation-api</include>
+                  <include>com.google.j2objc:j2objc-annotations</include>
+                  <include>com.google.protobuf:protobuf-java</include>
+
+                  <include>io.grpc:grpc-stub</include>
+                  <include>io.grpc:grpc-core</include>
+                  <include>io.grpc:grpc-context</include>
+                  <include>io.grpc:grpc-auth</include>
+                  <include>io.grpc:grpc-protobuf</include>
+                  <include>io.grpc:grpc-protobuf-lite</include>
+                  <include>io.grpc:grpc-stub</include>
+                  <include>io.grpc:grpc-netty-shaded</include>
+                  <include>io.grpc:grpc-netty</include>
+
+                  <!-- Netty dependencies -->
+                  <include>io.netty:netty-buffer</include>
+                  <include>io.netty:netty-codec-http2</include>
+                  <include>io.netty:netty-codec-http</include>
+                  <include>io.netty:netty-codec</include>
+                  <include>io.netty:netty-codec-socks</include>
+                  <include>io.netty:netty-common</include>
+                  <include>io.netty:netty-handler</include>
+                  <include>io.netty:netty-handler-proxy</include>
+                  <include>io.netty:netty-resolver</include>
+                  <include>io.netty:netty-tcnative-boringssl-static</include>
+                  <include>io.netty:netty-transport</include>
+
+                  <!-- All others -->
+                  <include>com.fasterxml.jackson.core:jackson-core</include>
+                  <include>commons-codec:commons-codec</include>
+                  <include>commons-logging:commons-logging</include>
+                  <include>io.opencensus:opencensus-api</include>
+                  <include>io.opencensus:opencensus-contrib-grpc-metrics</include>
+                  <include>org.apache.httpcomponents:httpclient</include>
+                  <include>org.apache.httpcomponents:httpcore</include>
+                  <include>org.codehaus.mojo:animal-sniffer-annotations
+                  </include> <!-- check if this is needed, it's for JDK compat testing -->
+                  <include>org.checkerframework:checker-compat-qual</include>
+                  <include>org.threeten:threetenbp</include>
+                </includes>
+              </artifactSet>
+              <relocations>
+                <!-- Google relocations -->
+                <relocation>
+                  <pattern>com.google.api</pattern>
+                  <shadedPattern>${shadedBase}.api</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.google.auth</pattern>
+                  <shadedPattern>${shadedBase}.auth</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.google.cloud</pattern>
+                  <shadedPattern>${shadedBase}.com.google.cloud</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.google.common</pattern>
+                  <shadedPattern>${shadedBase}.guava</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.google.errorprone</pattern>
+                  <shadedPattern>${shadedBase}.com.google.errorprone</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.google.gax</pattern>
+                  <shadedPattern>${shadedBase}.gax</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.google.gson</pattern>
+                  <shadedPattern>${shadedBase}.gson</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.google.j2objc</pattern>
+                  <shadedPattern>${shadedBase}.j2objc</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.google.logging</pattern>
+                  <shadedPattern>${shadedBase}.com.google.logging</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.google.longrunning</pattern>
+                  <shadedPattern>${shadedBase}.longrunning</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.google.protobuf</pattern>
+                  <shadedPattern>${shadedBase}.protobuf</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.google.rpc</pattern>
+                  <shadedPattern>${shadedBase}.com.google.rpc</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.google.thirdparty</pattern>
+                  <shadedPattern>${shadedBase}.thirdparty</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.google.type</pattern>
+                  <shadedPattern>${shadedBase}.com.google.type</shadedPattern>
+                </relocation>
+
+                <relocation>
+                  <pattern>io.grpc</pattern>
+                  <shadedPattern>${shadedBase}.io.grpc</shadedPattern>
+                </relocation>
+
+                <!-- Netty relocations -->
+                <relocation>
+                  <pattern>io.netty</pattern>
+                  <shadedPattern>${shadedBase}.io.netty</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>META-INF/native/libnetty</pattern>
+                  <shadedPattern>META-INF/native/libcom_google_ads_googleads_shaded_netty
+                  </shadedPattern>
+                  <!-- Setting rawString to only change the file name, not the content. Also allows
+                       specifying the full path rather than just matching on the filename.
+
+                       For implementation details (undocumented), refer to:
+                         org.apache.maven.plugins.shade.relocation.SimpleRelocator -->
+                  <rawString>true</rawString>
+                  <includes>
+                    <include>META-INF/native/*</include>
+                  </includes>
+                </relocation>
+                <relocation>
+                  <pattern>META-INF/native/netty</pattern>
+                  <shadedPattern>META-INF/native/com_google_ads_googleads_shaded_netty
+                  </shadedPattern>
+                  <rawString>true</rawString>
+                  <includes>
+                    <include>META-INF/native/*</include>
+                  </includes>
+                </relocation>
+
+                <!-- Other relocations -->
+                <relocation>
+                  <pattern>com.fasterxml</pattern>
+                  <shadedPattern>${shadedBase}.fasterxml</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>io.opencensus</pattern>
+                  <shadedPattern>${shadedBase}.opencensus</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>javax.annotation</pattern>
+                  <shadedPattern>${shadedBase}.javax.annotation</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.commons</pattern>
+                  <shadedPattern>${shadedBase}.apache.commons</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.http</pattern>
+                  <shadedPattern>${shadedBase}.apache.http</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.checkerframework</pattern>
+                  <shadedPattern>${shadedBase}.checkerframework</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.codehaus.mojo.animal_sniffer</pattern>
+                  <shadedPattern>${shadedBase}.animal_sniffer</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.threeten</pattern>
+                  <shadedPattern>${shadedBase}.threeten</shadedPattern>
+                </relocation>
+              </relocations>
+              <transformers>
+                <transformer
+                    implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+              </transformers>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>3.0.0-M3</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+            <configuration>
+              <argLine>-DdependencyReducedPom=${basedir}/dependency-reduced-pom.xml</argLine>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.api-ads</groupId>
+      <artifactId>google-ads</artifactId>
+      <version>1.1.1-SNAPSHOT</version>
+      <exclusions>
+        <exclusion>
+          <groupId>io.grpc</groupId>
+          <artifactId>grpc-netty-shaded</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <!-- Exclude grpc-netty-shaded and reshade. Shade plugin duplicates the shadedPattern when
+         pattern is found twice in classname. -->
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-netty</artifactId>
+      <version>1.16.1</version>
+    </dependency>
+
+    <!-- Test dependencies -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-model</artifactId>
+      <version>3.6.0</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/google-ads-shaded/pom.xml
+++ b/google-ads-shaded/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
   <parent>
     <artifactId>google-ads-parent</artifactId>
     <groupId>com.google.api-ads</groupId>
-    <version>2.0.1-SNAPSHOT</version>
+      <version>4.0.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
@@ -268,7 +268,7 @@ limitations under the License.
     <dependency>
       <groupId>com.google.api-ads</groupId>
       <artifactId>google-ads</artifactId>
-      <version>1.1.1-SNAPSHOT</version>
+      <version>${project.version}</version>
       <exclusions>
         <!-- Exclude grpc-netty-shaded and reshade. Shade plugin duplicates the shadedPattern when
              pattern is found twice in classname. -->
@@ -281,7 +281,7 @@ limitations under the License.
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-netty</artifactId>
-      <version>1.16.1</version>
+      <version>${grpc.version}</version>
     </dependency>
 
     <!-- Test dependencies -->

--- a/google-ads-shaded/pom.xml
+++ b/google-ads-shaded/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
   <parent>
     <artifactId>google-ads-parent</artifactId>
     <groupId>com.google.api-ads</groupId>
-    <version>1.1.1-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/google-ads-shaded/src/test/java/com/google/ads/googleads/shaded/it/ShadeIT.java
+++ b/google-ads-shaded/src/test/java/com/google/ads/googleads/shaded/it/ShadeIT.java
@@ -1,0 +1,97 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.ads.googleads.shaded.it;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.common.collect.ImmutableSet;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
+import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Integration test suite which ensures that the shade plugin generates a valid shaded jar. */
+@RunWith(JUnit4.class)
+public class ShadeIT {
+
+  private static final String DEP_REDUCED_LOCATION = System.getProperty("dependencyReducedPom");
+  private static final ImmutableSet<ComparableDependency> allowedDependencies;
+
+  static {
+    ComparableDependency slf4j = new ComparableDependency();
+    slf4j.setGroupId("org.slf4j");
+    slf4j.setArtifactId("slf4j-api");
+    slf4j.setVersion("1.7.25");
+    slf4j.setType("jar");
+
+    ComparableDependency javaxAnnotationApi = new ComparableDependency();
+    javaxAnnotationApi.setGroupId("javax.annotation");
+    javaxAnnotationApi.setArtifactId("javax.annotation-api");
+    javaxAnnotationApi.setVersion("1.3.2");
+    javaxAnnotationApi.setType("jar");
+
+    allowedDependencies = ImmutableSet.of(slf4j, javaxAnnotationApi);
+  }
+
+  @Test
+  public void ensureOnlyExpectedDependenciesRemain() throws IOException, XmlPullParserException {
+    MavenXpp3Reader reader = new MavenXpp3Reader();
+    Model model = reader.read(new FileInputStream(DEP_REDUCED_LOCATION));
+    Set<Dependency> modelDependencies =
+        model.getDependencies().stream().map(ComparableDependency::new).collect(Collectors.toSet());
+    assertEquals("Invalid dependencies found after shade", allowedDependencies, modelDependencies);
+  }
+
+  /** Wrapper around Dependency which allows equals and hashcode for collections. */
+  private static class ComparableDependency extends Dependency {
+
+    public ComparableDependency() {}
+
+    public ComparableDependency(Dependency source) {
+      setGroupId(source.getGroupId());
+      setArtifactId(source.getArtifactId());
+      setVersion(source.getVersion());
+      setType(source.getType());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      ComparableDependency that = (ComparableDependency) o;
+      return Objects.equals(getArtifactId(), that.getArtifactId())
+          && Objects.equals(getVersion(), that.getVersion())
+          && Objects.equals(getType(), that.getType())
+          && Objects.equals(getGroupId(), that.getGroupId());
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(getArtifactId(), getVersion(), getType(), getGroupId());
+    }
+  }
+}

--- a/google-ads/pom.xml
+++ b/google-ads/pom.xml
@@ -34,13 +34,6 @@ limitations under the License.
     Google Ads API client library for Java.
   </description>
 
-  <properties>
-    <auto-value.version>1.4</auto-value.version>
-    <gax.version>1.45.0</gax.version>
-    <grpc.version>1.21.0</grpc.version>
-    <protobuf.version>3.5.1</protobuf.version>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/google-ads/pom.xml
+++ b/google-ads/pom.xml
@@ -1,17 +1,17 @@
 <!--
- * Copyright 2019 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+Copyright 2018 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -45,6 +45,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
+      <!-- Android version is used by GAX etc. for JDK7 compatibility. -->
       <version>26.0-android</version>
     </dependency>
     <dependency>

--- a/google-ads/pom.xml
+++ b/google-ads/pom.xml
@@ -29,7 +29,7 @@ limitations under the License.
   <artifactId>google-ads</artifactId>
   <packaging>jar</packaging>
   <version>4.0.1-SNAPSHOT</version>
-  <name>Google Ads API client library for Java</name>
+  <name>Google Ads API client for Java - core library</name>
   <description>
     Google Ads API client library for Java.
   </description>

--- a/google-ads/pom.xml
+++ b/google-ads/pom.xml
@@ -45,7 +45,7 @@ limitations under the License.
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <!-- Android version is used by GAX etc. for JDK7 compatibility. -->
+      <!-- Guava for Android is used by GAX etc. for JDK7 compatibility. -->
       <version>26.0-android</version>
     </dependency>
     <dependency>

--- a/google-ads/pom.xml
+++ b/google-ads/pom.xml
@@ -13,7 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
   <parent>
     <groupId>com.google.api-ads</groupId>
@@ -41,9 +43,9 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.api</groupId>
-      <artifactId>gax</artifactId>
-      <version>${gax.version}</version>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>26.0-android</version>
     </dependency>
     <dependency>
       <groupId>com.google.api</groupId>
@@ -70,11 +72,6 @@
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
       <version>${protobuf.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.grpc</groupId>
-      <artifactId>grpc-all</artifactId>
-      <version>${grpc.version}</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
@@ -119,7 +116,7 @@
     <dependency>
       <groupId>com.google.truth</groupId>
       <artifactId>truth</artifactId>
-      <version>0.27</version>
+      <version>0.42</version>
       <scope>test</scope>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -211,6 +211,7 @@
 
   <modules>
     <module>google-ads</module>
+    <module>google-ads-shaded</module>
   </modules>
 
   <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@ limitations under the License.
   <version>4.0.1-SNAPSHOT</version>
 
   <packaging>pom</packaging>
-  <name>Google Ads API client library for Java project</name>
+  <name>Google Ads API client for Java - parent</name>
   <url>https://github.com/googleads/google-ads-java</url>
   <description>
     Parent POM of the Google Ads API client library for Java.

--- a/pom.xml
+++ b/pom.xml
@@ -1,17 +1,17 @@
 <!--
- * Copyright 2019 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+Copyright 2018 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,15 @@ limitations under the License.
     Parent POM of the Google Ads API client library for Java.
   </description>
 
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <auto-value.version>1.4</auto-value.version>
+    <gax.version>1.45.0</gax.version>
+    <grpc.version>1.21.0</grpc.version>
+    <protobuf.version>3.5.1</protobuf.version>
+  </properties>
+
   <issueManagement>
     <system>github.com</system>
     <url>
@@ -70,11 +79,6 @@ limitations under the License.
       <timezone>-5</timezone>
     </developer>
   </developers>
-
-  <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.target>1.8</maven.compiler.target>
-  </properties>
 
   <build>
     <plugins>


### PR DESCRIPTION
Creates an Uber jar containing all dependencies except SLF4j and Javax annotation API.

This should avoid dependency resolution issues, particularly for common libraries such as protobuf, guava and gRPC.