### PR TITLE
Update service-level timeout and method-level idempotency configuration

### DIFF
--- a/google-ads/src/main/java/com/google/ads/googleads/v1/resources/Campaign.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/resources/Campaign.java
@@ -2774,52 +2774,65 @@ private static final long serialVersionUID = 0L;
 
   }
 
-  public interface TrackingSettingOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:google.ads.googleads.v1.resources.Campaign.TrackingSetting)
+  public interface VanityPharmaOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:google.ads.googleads.v1.resources.Campaign.VanityPharma)
       com.google.protobuf.MessageOrBuilder {
 
     /**
      * <pre>
-     * The url used for dynamic tracking.
+     * The display mode for vanity pharma URLs.
      * </pre>
      *
-     * <code>.google.protobuf.StringValue tracking_url = 1;</code>
+     * <code>.google.ads.googleads.v1.enums.VanityPharmaDisplayUrlModeEnum.VanityPharmaDisplayUrlMode vanity_pharma_display_url_mode = 1;</code>
      */
-    boolean hasTrackingUrl();
+    int getVanityPharmaDisplayUrlModeValue();
     /**
      * <pre>
-     * The url used for dynamic tracking.
+     * The display mode for vanity pharma URLs.
      * </pre>
      *
-     * <code>.google.protobuf.StringValue tracking_url = 1;</code>
+     * <code>.google.ads.googleads.v1.enums.VanityPharmaDisplayUrlModeEnum.VanityPharmaDisplayUrlMode vanity_pharma_display_url_mode = 1;</code>
      */
-    com.google.protobuf.StringValue getTrackingUrl();
+    com.google.ads.googleads.v1.enums.VanityPharmaDisplayUrlModeEnum.VanityPharmaDisplayUrlMode getVanityPharmaDisplayUrlMode();
+
     /**
      * <pre>
-     * The url used for dynamic tracking.
+     * The text that will be displayed in display URL of the text ad when
+     * website description is the selected display mode for vanity pharma URLs.
      * </pre>
      *
-     * <code>.google.protobuf.StringValue tracking_url = 1;</code>
+     * <code>.google.ads.googleads.v1.enums.VanityPharmaTextEnum.VanityPharmaText vanity_pharma_text = 2;</code>
      */
-    com.google.protobuf.StringValueOrBuilder getTrackingUrlOrBuilder();
+    int getVanityPharmaTextValue();
+    /**
+     * <pre>
+     * The text that will be displayed in display URL of the text ad when
+     * website description is the selected display mode for vanity pharma URLs.
+     * </pre>
+     *
+     * <code>.google.ads.googleads.v1.enums.VanityPharmaTextEnum.VanityPharmaText vanity_pharma_text = 2;</code>
+     */
+    com.google.ads.googleads.v1.enums.VanityPharmaTextEnum.VanityPharmaText getVanityPharmaText();
   }
   /**
    * <pre>
-   * Campaign level settings for tracking information.
+   * Describes how unbranded pharma ads will be displayed.
    * </pre>
    *
-   * Protobuf type {@code google.ads.googleads.v1.resources.Campaign.TrackingSetting}
+   * Protobuf type {@code google.ads.googleads.v1.resources.Campaign.VanityPharma}
    */
-  public  static final class TrackingSetting extends
+  public  static final class VanityPharma extends
       com.google.protobuf.GeneratedMessageV3 implements
-      // @@protoc_insertion_point(message_implements:google.ads.googleads.v1.resources.Campaign.TrackingSetting)
-      TrackingSettingOrBuilder {
+      // @@protoc_insertion_point(message_implements:google.ads.googleads.v1.resources.Campaign.VanityPharma)
+      VanityPharmaOrBuilder {
   private static final long serialVersionUID = 0L;
-    // Use TrackingSetting.newBuilder() to construct.
-    private TrackingSetting(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+    // Use VanityPharma.newBuilder() to construct.
+    private VanityPharma(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
     }
-    private TrackingSetting() {
+    private VanityPharma() {
+      vanityPharmaDisplayUrlMode_ = 0;
+      vanityPharmaText_ = 0;
     }
 
     @java.lang.Override
@@ -2827,7 +2840,7 @@ private static final long serialVersionUID = 0L;
     getUnknownFields() {
       return this.unknownFields;
     }
-    private TrackingSetting(
+    private VanityPharma(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
@@ -2846,17 +2859,16 @@ private static final long serialVersionUID = 0L;
             case 0:
               done = true;
               break;
-            case 10: {
-              com.google.protobuf.StringValue.Builder subBuilder = null;
-              if (trackingUrl_ != null) {
-                subBuilder = trackingUrl_.toBuilder();
-              }
-              trackingUrl_ = input.readMessage(com.google.protobuf.StringValue.parser(), extensionRegistry);
-              if (subBuilder != null) {
-                subBuilder.mergeFrom(trackingUrl_);
-                trackingUrl_ = subBuilder.buildPartial();
-              }
+            case 8: {
+              int rawValue = input.readEnum();
 
+              vanityPharmaDisplayUrlMode_ = rawValue;
+              break;
+            }
+            case 16: {
+              int rawValue = input.readEnum();
+
+              vanityPharmaText_ = rawValue;
               break;
             }
             default: {
@@ -2880,48 +2892,67 @@ private static final long serialVersionUID = 0L;
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.google.ads.googleads.v1.resources.CampaignProto.internal_static_google_ads_googleads_v1_resources_Campaign_TrackingSetting_descriptor;
+      return com.google.ads.googleads.v1.resources.CampaignProto.internal_static_google_ads_googleads_v1_resources_Campaign_VanityPharma_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.google.ads.googleads.v1.resources.CampaignProto.internal_static_google_ads_googleads_v1_resources_Campaign_TrackingSetting_fieldAccessorTable
+      return com.google.ads.googleads.v1.resources.CampaignProto.internal_static_google_ads_googleads_v1_resources_Campaign_VanityPharma_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              com.google.ads.googleads.v1.resources.Campaign.TrackingSetting.class, com.google.ads.googleads.v1.resources.Campaign.TrackingSetting.Builder.class);
+              com.google.ads.googleads.v1.resources.Campaign.VanityPharma.class, com.google.ads.googleads.v1.resources.Campaign.VanityPharma.Builder.class);
     }
 
-    public static final int TRACKING_URL_FIELD_NUMBER = 1;
-    private com.google.protobuf.StringValue trackingUrl_;
+    public static final int VANITY_PHARMA_DISPLAY_URL_MODE_FIELD_NUMBER = 1;
+    private int vanityPharmaDisplayUrlMode_;
     /**
      * <pre>
-     * The url used for dynamic tracking.
+     * The display mode for vanity pharma URLs.
      * </pre>
      *
-     * <code>.google.protobuf.StringValue tracking_url = 1;</code>
+     * <code>.google.ads.googleads.v1.enums.VanityPharmaDisplayUrlModeEnum.VanityPharmaDisplayUrlMode vanity_pharma_display_url_mode = 1;</code>
      */
-    public boolean hasTrackingUrl() {
-      return trackingUrl_ != null;
+    public int getVanityPharmaDisplayUrlModeValue() {
+      return vanityPharmaDisplayUrlMode_;
     }
     /**
      * <pre>
-     * The url used for dynamic tracking.
+     * The display mode for vanity pharma URLs.
      * </pre>
      *
-     * <code>.google.protobuf.StringValue tracking_url = 1;</code>
+     * <code>.google.ads.googleads.v1.enums.VanityPharmaDisplayUrlModeEnum.VanityPharmaDisplayUrlMode vanity_pharma_display_url_mode = 1;</code>
      */
-    public com.google.protobuf.StringValue getTrackingUrl() {
-      return trackingUrl_ == null ? com.google.protobuf.StringValue.getDefaultInstance() : trackingUrl_;
+    public com.google.ads.googleads.v1.enums.VanityPharmaDisplayUrlModeEnum.VanityPharmaDisplayUrlMode getVanityPharmaDisplayUrlMode() {
+      @SuppressWarnings("deprecation")
+      com.google.ads.googleads.v1.enums.VanityPharmaDisplayUrlModeEnum.VanityPharmaDisplayUrlMode result = com.google.ads.googleads.v1.enums.VanityPharmaDisplayUrlModeEnum.VanityPharmaDisplayUrlMode.valueOf(vanityPharmaDisplayUrlMode_);
+      return result == null ? com.google.ads.googleads.v1.enums.VanityPharmaDisplayUrlModeEnum.VanityPharmaDisplayUrlMode.UNRECOGNIZED : result;
+    }
+
+    public static final int VANITY_PHARMA_TEXT_FIELD_NUMBER = 2;
+    private int vanityPharmaText_;
+    /**
+     * <pre>
+     * The text that will be displayed in display URL of the text ad when
+     * website description is the selected display mode for vanity pharma URLs.
+     * </pre>
+     *
+     * <code>.google.ads.googleads.v1.enums.VanityPharmaTextEnum.VanityPharmaText vanity_pharma_text = 2;</code>
+     */
+    public int getVanityPharmaTextValue() {
+      return vanityPharmaText_;
     }
     /**
      * <pre>
-     * The url used for dynamic tracking.
+     * The text that will be displayed in display URL of the text ad when
+     * website description is the selected display mode for vanity pharma URLs.
      * </pre>
      *
-     * <code>.google.protobuf.StringValue tracking_url = 1;</code>
+     * <code>.google.ads.googleads.v1.enums.VanityPharmaTextEnum.VanityPharmaText vanity_pharma_text = 2;</code>
      */
-    public com.google.protobuf.StringValueOrBuilder getTrackingUrlOrBuilder() {
-      return getTrackingUrl();
+    public com.google.ads.googleads.v1.enums.VanityPharmaTextEnum.VanityPharmaText getVanityPharmaText() {
+      @SuppressWarnings("deprecation")
+      com.google.ads.googleads.v1.enums.VanityPharmaTextEnum.VanityPharmaText result = com.google.ads.googleads.v1.enums.VanityPharmaTextEnum.VanityPharmaText.valueOf(vanityPharmaText_);
+      return result == null ? com.google.ads.googleads.v1.enums.VanityPharmaTextEnum.VanityPharmaText.UNRECOGNIZED : result;
     }
 
     private byte memoizedIsInitialized = -1;
@@ -2938,8 +2969,11 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (trackingUrl_ != null) {
-        output.writeMessage(1, getTrackingUrl());
+      if (vanityPharmaDisplayUrlMode_ != com.google.ads.googleads.v1.enums.VanityPharmaDisplayUrlModeEnum.VanityPharmaDisplayUrlMode.UNSPECIFIED.getNumber()) {
+        output.writeEnum(1, vanityPharmaDisplayUrlMode_);
+      }
+      if (vanityPharmaText_ != com.google.ads.googleads.v1.enums.VanityPharmaTextEnum.VanityPharmaText.UNSPECIFIED.getNumber()) {
+        output.writeEnum(2, vanityPharmaText_);
       }
       unknownFields.writeTo(output);
     }
@@ -2950,9 +2984,13 @@ private static final long serialVersionUID = 0L;
       if (size != -1) return size;
 
       size = 0;
-      if (trackingUrl_ != null) {
+      if (vanityPharmaDisplayUrlMode_ != com.google.ads.googleads.v1.enums.VanityPharmaDisplayUrlModeEnum.VanityPharmaDisplayUrlMode.UNSPECIFIED.getNumber()) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(1, getTrackingUrl());
+          .computeEnumSize(1, vanityPharmaDisplayUrlMode_);
+      }
+      if (vanityPharmaText_ != com.google.ads.googleads.v1.enums.VanityPharmaTextEnum.VanityPharmaText.UNSPECIFIED.getNumber()) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeEnumSize(2, vanityPharmaText_);
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -2964,17 +3002,14 @@ private static final long serialVersionUID = 0L;
       if (obj == this) {
        return true;
       }
-      if (!(obj instanceof com.google.ads.googleads.v1.resources.Campaign.TrackingSetting)) {
+      if (!(obj instanceof com.google.ads.googleads.v1.resources.Campaign.VanityPharma)) {
         return super.equals(obj);
       }
-      com.google.ads.googleads.v1.resources.Campaign.TrackingSetting other = (com.google.ads.googleads.v1.resources.Campaign.TrackingSetting) obj;
+      com.google.ads.googleads.v1.resources.Campaign.VanityPharma other = (com.google.ads.googleads.v1.resources.Campaign.VanityPharma) obj;
 
       boolean result = true;
-      result = result && (hasTrackingUrl() == other.hasTrackingUrl());
-      if (hasTrackingUrl()) {
-        result = result && getTrackingUrl()
-            .equals(other.getTrackingUrl());
-      }
+      result = result && vanityPharmaDisplayUrlMode_ == other.vanityPharmaDisplayUrlMode_;
+      result = result && vanityPharmaText_ == other.vanityPharmaText_;
       result = result && unknownFields.equals(other.unknownFields);
       return result;
     }
@@ -2986,78 +3021,78 @@ private static final long serialVersionUID = 0L;
       }
       int hash = 41;
       hash = (19 * hash) + getDescriptor().hashCode();
-      if (hasTrackingUrl()) {
-        hash = (37 * hash) + TRACKING_URL_FIELD_NUMBER;
-        hash = (53 * hash) + getTrackingUrl().hashCode();
-      }
+      hash = (37 * hash) + VANITY_PHARMA_DISPLAY_URL_MODE_FIELD_NUMBER;
+      hash = (53 * hash) + vanityPharmaDisplayUrlMode_;
+      hash = (37 * hash) + VANITY_PHARMA_TEXT_FIELD_NUMBER;
+      hash = (53 * hash) + vanityPharmaText_;
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
       return hash;
     }
 
-    public static com.google.ads.googleads.v1.resources.Campaign.TrackingSetting parseFrom(
+    public static com.google.ads.googleads.v1.resources.Campaign.VanityPharma parseFrom(
         java.nio.ByteBuffer data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static com.google.ads.googleads.v1.resources.Campaign.TrackingSetting parseFrom(
+    public static com.google.ads.googleads.v1.resources.Campaign.VanityPharma parseFrom(
         java.nio.ByteBuffer data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static com.google.ads.googleads.v1.resources.Campaign.TrackingSetting parseFrom(
+    public static com.google.ads.googleads.v1.resources.Campaign.VanityPharma parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static com.google.ads.googleads.v1.resources.Campaign.TrackingSetting parseFrom(
+    public static com.google.ads.googleads.v1.resources.Campaign.VanityPharma parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static com.google.ads.googleads.v1.resources.Campaign.TrackingSetting parseFrom(byte[] data)
+    public static com.google.ads.googleads.v1.resources.Campaign.VanityPharma parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static com.google.ads.googleads.v1.resources.Campaign.TrackingSetting parseFrom(
+    public static com.google.ads.googleads.v1.resources.Campaign.VanityPharma parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static com.google.ads.googleads.v1.resources.Campaign.TrackingSetting parseFrom(java.io.InputStream input)
+    public static com.google.ads.googleads.v1.resources.Campaign.VanityPharma parseFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static com.google.ads.googleads.v1.resources.Campaign.TrackingSetting parseFrom(
+    public static com.google.ads.googleads.v1.resources.Campaign.VanityPharma parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
-    public static com.google.ads.googleads.v1.resources.Campaign.TrackingSetting parseDelimitedFrom(java.io.InputStream input)
+    public static com.google.ads.googleads.v1.resources.Campaign.VanityPharma parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
-    public static com.google.ads.googleads.v1.resources.Campaign.TrackingSetting parseDelimitedFrom(
+    public static com.google.ads.googleads.v1.resources.Campaign.VanityPharma parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
-    public static com.google.ads.googleads.v1.resources.Campaign.TrackingSetting parseFrom(
+    public static com.google.ads.googleads.v1.resources.Campaign.VanityPharma parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static com.google.ads.googleads.v1.resources.Campaign.TrackingSetting parseFrom(
+    public static com.google.ads.googleads.v1.resources.Campaign.VanityPharma parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
@@ -3070,7 +3105,7 @@ private static final long serialVersionUID = 0L;
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
     }
-    public static Builder newBuilder(com.google.ads.googleads.v1.resources.Campaign.TrackingSetting prototype) {
+    public static Builder newBuilder(com.google.ads.googleads.v1.resources.Campaign.VanityPharma prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
     @java.lang.Override
@@ -3087,29 +3122,29 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Campaign level settings for tracking information.
+     * Describes how unbranded pharma ads will be displayed.
      * </pre>
      *
-     * Protobuf type {@code google.ads.googleads.v1.resources.Campaign.TrackingSetting}
+     * Protobuf type {@code google.ads.googleads.v1.resources.Campaign.VanityPharma}
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:google.ads.googleads.v1.resources.Campaign.TrackingSetting)
-        com.google.ads.googleads.v1.resources.Campaign.TrackingSettingOrBuilder {
+        // @@protoc_insertion_point(builder_implements:google.ads.googleads.v1.resources.Campaign.VanityPharma)
+        com.google.ads.googleads.v1.resources.Campaign.VanityPharmaOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return com.google.ads.googleads.v1.resources.CampaignProto.internal_static_google_ads_googleads_v1_resources_Campaign_TrackingSetting_descriptor;
+        return com.google.ads.googleads.v1.resources.CampaignProto.internal_static_google_ads_googleads_v1_resources_Campaign_VanityPharma_descriptor;
       }
 
       @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return com.google.ads.googleads.v1.resources.CampaignProto.internal_static_google_ads_googleads_v1_resources_Campaign_TrackingSetting_fieldAccessorTable
+        return com.google.ads.googleads.v1.resources.CampaignProto.internal_static_google_ads_googleads_v1_resources_Campaign_VanityPharma_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
-                com.google.ads.googleads.v1.resources.Campaign.TrackingSetting.class, com.google.ads.googleads.v1.resources.Campaign.TrackingSetting.Builder.class);
+                com.google.ads.googleads.v1.resources.Campaign.VanityPharma.class, com.google.ads.googleads.v1.resources.Campaign.VanityPharma.Builder.class);
       }
 
-      // Construct using com.google.ads.googleads.v1.resources.Campaign.TrackingSetting.newBuilder()
+      // Construct using com.google.ads.googleads.v1.resources.Campaign.VanityPharma.newBuilder()
       private Builder() {
         maybeForceBuilderInitialization();
       }
@@ -3127,29 +3162,27 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public Builder clear() {
         super.clear();
-        if (trackingUrlBuilder_ == null) {
-          trackingUrl_ = null;
-        } else {
-          trackingUrl_ = null;
-          trackingUrlBuilder_ = null;
-        }
+        vanityPharmaDisplayUrlMode_ = 0;
+
+        vanityPharmaText_ = 0;
+
         return this;
       }
 
       @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return com.google.ads.googleads.v1.resources.CampaignProto.internal_static_google_ads_googleads_v1_resources_Campaign_TrackingSetting_descriptor;
+        return com.google.ads.googleads.v1.resources.CampaignProto.internal_static_google_ads_googleads_v1_resources_Campaign_VanityPharma_descriptor;
       }
 
       @java.lang.Override
-      public com.google.ads.googleads.v1.resources.Campaign.TrackingSetting getDefaultInstanceForType() {
-        return com.google.ads.googleads.v1.resources.Campaign.TrackingSetting.getDefaultInstance();
+      public com.google.ads.googleads.v1.resources.Campaign.VanityPharma getDefaultInstanceForType() {
+        return com.google.ads.googleads.v1.resources.Campaign.VanityPharma.getDefaultInstance();
       }
 
       @java.lang.Override
-      public com.google.ads.googleads.v1.resources.Campaign.TrackingSetting build() {
-        com.google.ads.googleads.v1.resources.Campaign.TrackingSetting result = buildPartial();
+      public com.google.ads.googleads.v1.resources.Campaign.VanityPharma build() {
+        com.google.ads.googleads.v1.resources.Campaign.VanityPharma result = buildPartial();
         if (!result.isInitialized()) {
           throw newUninitializedMessageException(result);
         }
@@ -3157,13 +3190,10 @@ private static final long serialVersionUID = 0L;
       }
 
       @java.lang.Override
-      public com.google.ads.googleads.v1.resources.Campaign.TrackingSetting buildPartial() {
-        com.google.ads.googleads.v1.resources.Campaign.TrackingSetting result = new com.google.ads.googleads.v1.resources.Campaign.TrackingSetting(this);
-        if (trackingUrlBuilder_ == null) {
-          result.trackingUrl_ = trackingUrl_;
-        } else {
-          result.trackingUrl_ = trackingUrlBuilder_.build();
-        }
+      public com.google.ads.googleads.v1.resources.Campaign.VanityPharma buildPartial() {
+        com.google.ads.googleads.v1.resources.Campaign.VanityPharma result = new com.google.ads.googleads.v1.resources.Campaign.VanityPharma(this);
+        result.vanityPharmaDisplayUrlMode_ = vanityPharmaDisplayUrlMode_;
+        result.vanityPharmaText_ = vanityPharmaText_;
         onBuilt();
         return result;
       }
@@ -3202,18 +3232,21 @@ private static final long serialVersionUID = 0L;
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof com.google.ads.googleads.v1.resources.Campaign.TrackingSetting) {
-          return mergeFrom((com.google.ads.googleads.v1.resources.Campaign.TrackingSetting)other);
+        if (other instanceof com.google.ads.googleads.v1.resources.Campaign.VanityPharma) {
+          return mergeFrom((com.google.ads.googleads.v1.resources.Campaign.VanityPharma)other);
         } else {
           super.mergeFrom(other);
           return this;
         }
       }
 
-      public Builder mergeFrom(com.google.ads.googleads.v1.resources.Campaign.TrackingSetting other) {
-        if (other == com.google.ads.googleads.v1.resources.Campaign.TrackingSetting.getDefaultInstance()) return this;
-        if (other.hasTrackingUrl()) {
-          mergeTrackingUrl(other.getTrackingUrl());
+      public Builder mergeFrom(com.google.ads.googleads.v1.resources.Campaign.VanityPharma other) {
+        if (other == com.google.ads.googleads.v1.resources.Campaign.VanityPharma.getDefaultInstance()) return this;
+        if (other.vanityPharmaDisplayUrlMode_ != 0) {
+          setVanityPharmaDisplayUrlModeValue(other.getVanityPharmaDisplayUrlModeValue());
+        }
+        if (other.vanityPharmaText_ != 0) {
+          setVanityPharmaTextValue(other.getVanityPharmaTextValue());
         }
         this.mergeUnknownFields(other.unknownFields);
         onChanged();
@@ -3230,11 +3263,11 @@ private static final long serialVersionUID = 0L;
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        com.google.ads.googleads.v1.resources.Campaign.TrackingSetting parsedMessage = null;
+        com.google.ads.googleads.v1.resources.Campaign.VanityPharma parsedMessage = null;
         try {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (com.google.ads.googleads.v1.resources.Campaign.TrackingSetting) e.getUnfinishedMessage();
+          parsedMessage = (com.google.ads.googleads.v1.resources.Campaign.VanityPharma) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
@@ -3244,157 +3277,139 @@ private static final long serialVersionUID = 0L;
         return this;
       }
 
-      private com.google.protobuf.StringValue trackingUrl_ = null;
-      private com.google.protobuf.SingleFieldBuilderV3<
-          com.google.protobuf.StringValue, com.google.protobuf.StringValue.Builder, com.google.protobuf.StringValueOrBuilder> trackingUrlBuilder_;
+      private int vanityPharmaDisplayUrlMode_ = 0;
       /**
        * <pre>
-       * The url used for dynamic tracking.
+       * The display mode for vanity pharma URLs.
        * </pre>
        *
-       * <code>.google.protobuf.StringValue tracking_url = 1;</code>
+       * <code>.google.ads.googleads.v1.enums.VanityPharmaDisplayUrlModeEnum.VanityPharmaDisplayUrlMode vanity_pharma_display_url_mode = 1;</code>
        */
-      public boolean hasTrackingUrl() {
-        return trackingUrlBuilder_ != null || trackingUrl_ != null;
+      public int getVanityPharmaDisplayUrlModeValue() {
+        return vanityPharmaDisplayUrlMode_;
       }
       /**
        * <pre>
-       * The url used for dynamic tracking.
+       * The display mode for vanity pharma URLs.
        * </pre>
        *
-       * <code>.google.protobuf.StringValue tracking_url = 1;</code>
+       * <code>.google.ads.googleads.v1.enums.VanityPharmaDisplayUrlModeEnum.VanityPharmaDisplayUrlMode vanity_pharma_display_url_mode = 1;</code>
        */
-      public com.google.protobuf.StringValue getTrackingUrl() {
-        if (trackingUrlBuilder_ == null) {
-          return trackingUrl_ == null ? com.google.protobuf.StringValue.getDefaultInstance() : trackingUrl_;
-        } else {
-          return trackingUrlBuilder_.getMessage();
-        }
-      }
-      /**
-       * <pre>
-       * The url used for dynamic tracking.
-       * </pre>
-       *
-       * <code>.google.protobuf.StringValue tracking_url = 1;</code>
-       */
-      public Builder setTrackingUrl(com.google.protobuf.StringValue value) {
-        if (trackingUrlBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          trackingUrl_ = value;
-          onChanged();
-        } else {
-          trackingUrlBuilder_.setMessage(value);
-        }
-
-        return this;
-      }
-      /**
-       * <pre>
-       * The url used for dynamic tracking.
-       * </pre>
-       *
-       * <code>.google.protobuf.StringValue tracking_url = 1;</code>
-       */
-      public Builder setTrackingUrl(
-          com.google.protobuf.StringValue.Builder builderForValue) {
-        if (trackingUrlBuilder_ == null) {
-          trackingUrl_ = builderForValue.build();
-          onChanged();
-        } else {
-          trackingUrlBuilder_.setMessage(builderForValue.build());
-        }
-
-        return this;
-      }
-      /**
-       * <pre>
-       * The url used for dynamic tracking.
-       * </pre>
-       *
-       * <code>.google.protobuf.StringValue tracking_url = 1;</code>
-       */
-      public Builder mergeTrackingUrl(com.google.protobuf.StringValue value) {
-        if (trackingUrlBuilder_ == null) {
-          if (trackingUrl_ != null) {
-            trackingUrl_ =
-              com.google.protobuf.StringValue.newBuilder(trackingUrl_).mergeFrom(value).buildPartial();
-          } else {
-            trackingUrl_ = value;
-          }
-          onChanged();
-        } else {
-          trackingUrlBuilder_.mergeFrom(value);
-        }
-
-        return this;
-      }
-      /**
-       * <pre>
-       * The url used for dynamic tracking.
-       * </pre>
-       *
-       * <code>.google.protobuf.StringValue tracking_url = 1;</code>
-       */
-      public Builder clearTrackingUrl() {
-        if (trackingUrlBuilder_ == null) {
-          trackingUrl_ = null;
-          onChanged();
-        } else {
-          trackingUrl_ = null;
-          trackingUrlBuilder_ = null;
-        }
-
-        return this;
-      }
-      /**
-       * <pre>
-       * The url used for dynamic tracking.
-       * </pre>
-       *
-       * <code>.google.protobuf.StringValue tracking_url = 1;</code>
-       */
-      public com.google.protobuf.StringValue.Builder getTrackingUrlBuilder() {
-        
+      public Builder setVanityPharmaDisplayUrlModeValue(int value) {
+        vanityPharmaDisplayUrlMode_ = value;
         onChanged();
-        return getTrackingUrlFieldBuilder().getBuilder();
+        return this;
       }
       /**
        * <pre>
-       * The url used for dynamic tracking.
+       * The display mode for vanity pharma URLs.
        * </pre>
        *
-       * <code>.google.protobuf.StringValue tracking_url = 1;</code>
+       * <code>.google.ads.googleads.v1.enums.VanityPharmaDisplayUrlModeEnum.VanityPharmaDisplayUrlMode vanity_pharma_display_url_mode = 1;</code>
        */
-      public com.google.protobuf.StringValueOrBuilder getTrackingUrlOrBuilder() {
-        if (trackingUrlBuilder_ != null) {
-          return trackingUrlBuilder_.getMessageOrBuilder();
-        } else {
-          return trackingUrl_ == null ?
-              com.google.protobuf.StringValue.getDefaultInstance() : trackingUrl_;
-        }
+      public com.google.ads.googleads.v1.enums.VanityPharmaDisplayUrlModeEnum.VanityPharmaDisplayUrlMode getVanityPharmaDisplayUrlMode() {
+        @SuppressWarnings("deprecation")
+        com.google.ads.googleads.v1.enums.VanityPharmaDisplayUrlModeEnum.VanityPharmaDisplayUrlMode result = com.google.ads.googleads.v1.enums.VanityPharmaDisplayUrlModeEnum.VanityPharmaDisplayUrlMode.valueOf(vanityPharmaDisplayUrlMode_);
+        return result == null ? com.google.ads.googleads.v1.enums.VanityPharmaDisplayUrlModeEnum.VanityPharmaDisplayUrlMode.UNRECOGNIZED : result;
       }
       /**
        * <pre>
-       * The url used for dynamic tracking.
+       * The display mode for vanity pharma URLs.
        * </pre>
        *
-       * <code>.google.protobuf.StringValue tracking_url = 1;</code>
+       * <code>.google.ads.googleads.v1.enums.VanityPharmaDisplayUrlModeEnum.VanityPharmaDisplayUrlMode vanity_pharma_display_url_mode = 1;</code>
        */
-      private com.google.protobuf.SingleFieldBuilderV3<
-          com.google.protobuf.StringValue, com.google.protobuf.StringValue.Builder, com.google.protobuf.StringValueOrBuilder> 
-          getTrackingUrlFieldBuilder() {
-        if (trackingUrlBuilder_ == null) {
-          trackingUrlBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-              com.google.protobuf.StringValue, com.google.protobuf.StringValue.Builder, com.google.protobuf.StringValueOrBuilder>(
-                  getTrackingUrl(),
-                  getParentForChildren(),
-                  isClean());
-          trackingUrl_ = null;
+      public Builder setVanityPharmaDisplayUrlMode(com.google.ads.googleads.v1.enums.VanityPharmaDisplayUrlModeEnum.VanityPharmaDisplayUrlMode value) {
+        if (value == null) {
+          throw new NullPointerException();
         }
-        return trackingUrlBuilder_;
+        
+        vanityPharmaDisplayUrlMode_ = value.getNumber();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * The display mode for vanity pharma URLs.
+       * </pre>
+       *
+       * <code>.google.ads.googleads.v1.enums.VanityPharmaDisplayUrlModeEnum.VanityPharmaDisplayUrlMode vanity_pharma_display_url_mode = 1;</code>
+       */
+      public Builder clearVanityPharmaDisplayUrlMode() {
+        
+        vanityPharmaDisplayUrlMode_ = 0;
+        onChanged();
+        return this;
+      }
+
+      private int vanityPharmaText_ = 0;
+      /**
+       * <pre>
+       * The text that will be displayed in display URL of the text ad when
+       * website description is the selected display mode for vanity pharma URLs.
+       * </pre>
+       *
+       * <code>.google.ads.googleads.v1.enums.VanityPharmaTextEnum.VanityPharmaText vanity_pharma_text = 2;</code>
+       */
+      public int getVanityPharmaTextValue() {
+        return vanityPharmaText_;
+      }
+      /**
+       * <pre>
+       * The text that will be displayed in display URL of the text ad when
+       * website description is the selected display mode for vanity pharma URLs.
+       * </pre>
+       *
+       * <code>.google.ads.googleads.v1.enums.VanityPharmaTextEnum.VanityPharmaText vanity_pharma_text = 2;</code>
+       */
+      public Builder setVanityPharmaTextValue(int value) {
+        vanityPharmaText_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * The text that will be displayed in display URL of the text ad when
+       * website description is the selected display mode for vanity pharma URLs.
+       * </pre>
+       *
+       * <code>.google.ads.googleads.v1.enums.VanityPharmaTextEnum.VanityPharmaText vanity_pharma_text = 2;</code>
+       */
+      public com.google.ads.googleads.v1.enums.VanityPharmaTextEnum.VanityPharmaText getVanityPharmaText() {
+        @SuppressWarnings("deprecation")
+        com.google.ads.googleads.v1.enums.VanityPharmaTextEnum.VanityPharmaText result = com.google.ads.googleads.v1.enums.VanityPharmaTextEnum.VanityPharmaText.valueOf(vanityPharmaText_);
+        return result == null ? com.google.ads.googleads.v1.enums.VanityPharmaTextEnum.VanityPharmaText.UNRECOGNIZED : result;
+      }
+      /**
+       * <pre>
+       * The text that will be displayed in display URL of the text ad when
+       * website description is the selected display mode for vanity pharma URLs.
+       * </pre>
+       *
+       * <code>.google.ads.googleads.v1.enums.VanityPharmaTextEnum.VanityPharmaText vanity_pharma_text = 2;</code>
+       */
+      public Builder setVanityPharmaText(com.google.ads.googleads.v1.enums.VanityPharmaTextEnum.VanityPharmaText value) {
+        if (value == null) {
+          throw new NullPointerException();
+        }
+        
+        vanityPharmaText_ = value.getNumber();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * The text that will be displayed in display URL of the text ad when
+       * website description is the selected display mode for vanity pharma URLs.
+       * </pre>
+       *
+       * <code>.google.ads.googleads.v1.enums.VanityPharmaTextEnum.VanityPharmaText vanity_pharma_text = 2;</code>
+       */
+      public Builder clearVanityPharmaText() {
+        
+        vanityPharmaText_ = 0;
+        onChanged();
+        return this;
       }
       @java.lang.Override
       public final Builder setUnknownFields(
@@ -3409,41 +3424,41 @@ private static final long serialVersionUID = 0L;
       }
 
 
-      // @@protoc_insertion_point(builder_scope:google.ads.googleads.v1.resources.Campaign.TrackingSetting)
+      // @@protoc_insertion_point(builder_scope:google.ads.googleads.v1.resources.Campaign.VanityPharma)
     }
 
-    // @@protoc_insertion_point(class_scope:google.ads.googleads.v1.resources.Campaign.TrackingSetting)
-    private static final com.google.ads.googleads.v1.resources.Campaign.TrackingSetting DEFAULT_INSTANCE;
+    // @@protoc_insertion_point(class_scope:google.ads.googleads.v1.resources.Campaign.VanityPharma)
+    private static final com.google.ads.googleads.v1.resources.Campaign.VanityPharma DEFAULT_INSTANCE;
     static {
-      DEFAULT_INSTANCE = new com.google.ads.googleads.v1.resources.Campaign.TrackingSetting();
+      DEFAULT_INSTANCE = new com.google.ads.googleads.v1.resources.Campaign.VanityPharma();
     }
 
-    public static com.google.ads.googleads.v1.resources.Campaign.TrackingSetting getDefaultInstance() {
+    public static com.google.ads.googleads.v1.resources.Campaign.VanityPharma getDefaultInstance() {
       return DEFAULT_INSTANCE;
     }
 
-    private static final com.google.protobuf.Parser<TrackingSetting>
-        PARSER = new com.google.protobuf.AbstractParser<TrackingSetting>() {
+    private static final com.google.protobuf.Parser<VanityPharma>
+        PARSER = new com.google.protobuf.AbstractParser<VanityPharma>() {
       @java.lang.Override
-      public TrackingSetting parsePartialFrom(
+      public VanityPharma parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new TrackingSetting(input, extensionRegistry);
+        return new VanityPharma(input, extensionRegistry);
       }
     };
 
-    public static com.google.protobuf.Parser<TrackingSetting> parser() {
+    public static com.google.protobuf.Parser<VanityPharma> parser() {
       return PARSER;
     }
 
     @java.lang.Override
-    public com.google.protobuf.Parser<TrackingSetting> getParserForType() {
+    public com.google.protobuf.Parser<VanityPharma> getParserForType() {
       return PARSER;
     }
 
     @java.lang.Override
-    public com.google.ads.googleads.v1.resources.Campaign.TrackingSetting getDefaultInstanceForType() {
+    public com.google.ads.googleads.v1.resources.Campaign.VanityPharma getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
 
@@ -6722,63 +6737,52 @@ private static final long serialVersionUID = 0L;
 
   }
 
-  public interface GeoTargetTypeSettingOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting)
+  public interface TrackingSettingOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:google.ads.googleads.v1.resources.Campaign.TrackingSetting)
       com.google.protobuf.MessageOrBuilder {
 
     /**
      * <pre>
-     * The setting used for positive geotargeting in this particular campaign.
+     * The url used for dynamic tracking.
      * </pre>
      *
-     * <code>.google.ads.googleads.v1.enums.PositiveGeoTargetTypeEnum.PositiveGeoTargetType positive_geo_target_type = 1;</code>
+     * <code>.google.protobuf.StringValue tracking_url = 1;</code>
      */
-    int getPositiveGeoTargetTypeValue();
+    boolean hasTrackingUrl();
     /**
      * <pre>
-     * The setting used for positive geotargeting in this particular campaign.
+     * The url used for dynamic tracking.
      * </pre>
      *
-     * <code>.google.ads.googleads.v1.enums.PositiveGeoTargetTypeEnum.PositiveGeoTargetType positive_geo_target_type = 1;</code>
+     * <code>.google.protobuf.StringValue tracking_url = 1;</code>
      */
-    com.google.ads.googleads.v1.enums.PositiveGeoTargetTypeEnum.PositiveGeoTargetType getPositiveGeoTargetType();
-
+    com.google.protobuf.StringValue getTrackingUrl();
     /**
      * <pre>
-     * The setting used for negative geotargeting in this particular campaign.
+     * The url used for dynamic tracking.
      * </pre>
      *
-     * <code>.google.ads.googleads.v1.enums.NegativeGeoTargetTypeEnum.NegativeGeoTargetType negative_geo_target_type = 2;</code>
+     * <code>.google.protobuf.StringValue tracking_url = 1;</code>
      */
-    int getNegativeGeoTargetTypeValue();
-    /**
-     * <pre>
-     * The setting used for negative geotargeting in this particular campaign.
-     * </pre>
-     *
-     * <code>.google.ads.googleads.v1.enums.NegativeGeoTargetTypeEnum.NegativeGeoTargetType negative_geo_target_type = 2;</code>
-     */
-    com.google.ads.googleads.v1.enums.NegativeGeoTargetTypeEnum.NegativeGeoTargetType getNegativeGeoTargetType();
+    com.google.protobuf.StringValueOrBuilder getTrackingUrlOrBuilder();
   }
   /**
    * <pre>
-   * Represents a collection of settings related to ads geotargeting.
+   * Campaign level settings for tracking information.
    * </pre>
    *
-   * Protobuf type {@code google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting}
+   * Protobuf type {@code google.ads.googleads.v1.resources.Campaign.TrackingSetting}
    */
-  public  static final class GeoTargetTypeSetting extends
+  public  static final class TrackingSetting extends
       com.google.protobuf.GeneratedMessageV3 implements
-      // @@protoc_insertion_point(message_implements:google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting)
-      GeoTargetTypeSettingOrBuilder {
+      // @@protoc_insertion_point(message_implements:google.ads.googleads.v1.resources.Campaign.TrackingSetting)
+      TrackingSettingOrBuilder {
   private static final long serialVersionUID = 0L;
-    // Use GeoTargetTypeSetting.newBuilder() to construct.
-    private GeoTargetTypeSetting(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+    // Use TrackingSetting.newBuilder() to construct.
+    private TrackingSetting(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
     }
-    private GeoTargetTypeSetting() {
-      positiveGeoTargetType_ = 0;
-      negativeGeoTargetType_ = 0;
+    private TrackingSetting() {
     }
 
     @java.lang.Override
@@ -6786,7 +6790,7 @@ private static final long serialVersionUID = 0L;
     getUnknownFields() {
       return this.unknownFields;
     }
-    private GeoTargetTypeSetting(
+    private TrackingSetting(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
@@ -6805,16 +6809,17 @@ private static final long serialVersionUID = 0L;
             case 0:
               done = true;
               break;
-            case 8: {
-              int rawValue = input.readEnum();
+            case 10: {
+              com.google.protobuf.StringValue.Builder subBuilder = null;
+              if (trackingUrl_ != null) {
+                subBuilder = trackingUrl_.toBuilder();
+              }
+              trackingUrl_ = input.readMessage(com.google.protobuf.StringValue.parser(), extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(trackingUrl_);
+                trackingUrl_ = subBuilder.buildPartial();
+              }
 
-              positiveGeoTargetType_ = rawValue;
-              break;
-            }
-            case 16: {
-              int rawValue = input.readEnum();
-
-              negativeGeoTargetType_ = rawValue;
               break;
             }
             default: {
@@ -6838,65 +6843,48 @@ private static final long serialVersionUID = 0L;
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.google.ads.googleads.v1.resources.CampaignProto.internal_static_google_ads_googleads_v1_resources_Campaign_GeoTargetTypeSetting_descriptor;
+      return com.google.ads.googleads.v1.resources.CampaignProto.internal_static_google_ads_googleads_v1_resources_Campaign_TrackingSetting_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.google.ads.googleads.v1.resources.CampaignProto.internal_static_google_ads_googleads_v1_resources_Campaign_GeoTargetTypeSetting_fieldAccessorTable
+      return com.google.ads.googleads.v1.resources.CampaignProto.internal_static_google_ads_googleads_v1_resources_Campaign_TrackingSetting_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting.class, com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting.Builder.class);
+              com.google.ads.googleads.v1.resources.Campaign.TrackingSetting.class, com.google.ads.googleads.v1.resources.Campaign.TrackingSetting.Builder.class);
     }
 
-    public static final int POSITIVE_GEO_TARGET_TYPE_FIELD_NUMBER = 1;
-    private int positiveGeoTargetType_;
+    public static final int TRACKING_URL_FIELD_NUMBER = 1;
+    private com.google.protobuf.StringValue trackingUrl_;
     /**
      * <pre>
-     * The setting used for positive geotargeting in this particular campaign.
+     * The url used for dynamic tracking.
      * </pre>
      *
-     * <code>.google.ads.googleads.v1.enums.PositiveGeoTargetTypeEnum.PositiveGeoTargetType positive_geo_target_type = 1;</code>
+     * <code>.google.protobuf.StringValue tracking_url = 1;</code>
      */
-    public int getPositiveGeoTargetTypeValue() {
-      return positiveGeoTargetType_;
+    public boolean hasTrackingUrl() {
+      return trackingUrl_ != null;
     }
     /**
      * <pre>
-     * The setting used for positive geotargeting in this particular campaign.
+     * The url used for dynamic tracking.
      * </pre>
      *
-     * <code>.google.ads.googleads.v1.enums.PositiveGeoTargetTypeEnum.PositiveGeoTargetType positive_geo_target_type = 1;</code>
+     * <code>.google.protobuf.StringValue tracking_url = 1;</code>
      */
-    public com.google.ads.googleads.v1.enums.PositiveGeoTargetTypeEnum.PositiveGeoTargetType getPositiveGeoTargetType() {
-      @SuppressWarnings("deprecation")
-      com.google.ads.googleads.v1.enums.PositiveGeoTargetTypeEnum.PositiveGeoTargetType result = com.google.ads.googleads.v1.enums.PositiveGeoTargetTypeEnum.PositiveGeoTargetType.valueOf(positiveGeoTargetType_);
-      return result == null ? com.google.ads.googleads.v1.enums.PositiveGeoTargetTypeEnum.PositiveGeoTargetType.UNRECOGNIZED : result;
-    }
-
-    public static final int NEGATIVE_GEO_TARGET_TYPE_FIELD_NUMBER = 2;
-    private int negativeGeoTargetType_;
-    /**
-     * <pre>
-     * The setting used for negative geotargeting in this particular campaign.
-     * </pre>
-     *
-     * <code>.google.ads.googleads.v1.enums.NegativeGeoTargetTypeEnum.NegativeGeoTargetType negative_geo_target_type = 2;</code>
-     */
-    public int getNegativeGeoTargetTypeValue() {
-      return negativeGeoTargetType_;
+    public com.google.protobuf.StringValue getTrackingUrl() {
+      return trackingUrl_ == null ? com.google.protobuf.StringValue.getDefaultInstance() : trackingUrl_;
     }
     /**
      * <pre>
-     * The setting used for negative geotargeting in this particular campaign.
+     * The url used for dynamic tracking.
      * </pre>
      *
-     * <code>.google.ads.googleads.v1.enums.NegativeGeoTargetTypeEnum.NegativeGeoTargetType negative_geo_target_type = 2;</code>
+     * <code>.google.protobuf.StringValue tracking_url = 1;</code>
      */
-    public com.google.ads.googleads.v1.enums.NegativeGeoTargetTypeEnum.NegativeGeoTargetType getNegativeGeoTargetType() {
-      @SuppressWarnings("deprecation")
-      com.google.ads.googleads.v1.enums.NegativeGeoTargetTypeEnum.NegativeGeoTargetType result = com.google.ads.googleads.v1.enums.NegativeGeoTargetTypeEnum.NegativeGeoTargetType.valueOf(negativeGeoTargetType_);
-      return result == null ? com.google.ads.googleads.v1.enums.NegativeGeoTargetTypeEnum.NegativeGeoTargetType.UNRECOGNIZED : result;
+    public com.google.protobuf.StringValueOrBuilder getTrackingUrlOrBuilder() {
+      return getTrackingUrl();
     }
 
     private byte memoizedIsInitialized = -1;
@@ -6913,11 +6901,8 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (positiveGeoTargetType_ != com.google.ads.googleads.v1.enums.PositiveGeoTargetTypeEnum.PositiveGeoTargetType.UNSPECIFIED.getNumber()) {
-        output.writeEnum(1, positiveGeoTargetType_);
-      }
-      if (negativeGeoTargetType_ != com.google.ads.googleads.v1.enums.NegativeGeoTargetTypeEnum.NegativeGeoTargetType.UNSPECIFIED.getNumber()) {
-        output.writeEnum(2, negativeGeoTargetType_);
+      if (trackingUrl_ != null) {
+        output.writeMessage(1, getTrackingUrl());
       }
       unknownFields.writeTo(output);
     }
@@ -6928,13 +6913,9 @@ private static final long serialVersionUID = 0L;
       if (size != -1) return size;
 
       size = 0;
-      if (positiveGeoTargetType_ != com.google.ads.googleads.v1.enums.PositiveGeoTargetTypeEnum.PositiveGeoTargetType.UNSPECIFIED.getNumber()) {
+      if (trackingUrl_ != null) {
         size += com.google.protobuf.CodedOutputStream
-          .computeEnumSize(1, positiveGeoTargetType_);
-      }
-      if (negativeGeoTargetType_ != com.google.ads.googleads.v1.enums.NegativeGeoTargetTypeEnum.NegativeGeoTargetType.UNSPECIFIED.getNumber()) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeEnumSize(2, negativeGeoTargetType_);
+          .computeMessageSize(1, getTrackingUrl());
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -6946,14 +6927,17 @@ private static final long serialVersionUID = 0L;
       if (obj == this) {
        return true;
       }
-      if (!(obj instanceof com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting)) {
+      if (!(obj instanceof com.google.ads.googleads.v1.resources.Campaign.TrackingSetting)) {
         return super.equals(obj);
       }
-      com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting other = (com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting) obj;
+      com.google.ads.googleads.v1.resources.Campaign.TrackingSetting other = (com.google.ads.googleads.v1.resources.Campaign.TrackingSetting) obj;
 
       boolean result = true;
-      result = result && positiveGeoTargetType_ == other.positiveGeoTargetType_;
-      result = result && negativeGeoTargetType_ == other.negativeGeoTargetType_;
+      result = result && (hasTrackingUrl() == other.hasTrackingUrl());
+      if (hasTrackingUrl()) {
+        result = result && getTrackingUrl()
+            .equals(other.getTrackingUrl());
+      }
       result = result && unknownFields.equals(other.unknownFields);
       return result;
     }
@@ -6965,78 +6949,78 @@ private static final long serialVersionUID = 0L;
       }
       int hash = 41;
       hash = (19 * hash) + getDescriptor().hashCode();
-      hash = (37 * hash) + POSITIVE_GEO_TARGET_TYPE_FIELD_NUMBER;
-      hash = (53 * hash) + positiveGeoTargetType_;
-      hash = (37 * hash) + NEGATIVE_GEO_TARGET_TYPE_FIELD_NUMBER;
-      hash = (53 * hash) + negativeGeoTargetType_;
+      if (hasTrackingUrl()) {
+        hash = (37 * hash) + TRACKING_URL_FIELD_NUMBER;
+        hash = (53 * hash) + getTrackingUrl().hashCode();
+      }
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
       return hash;
     }
 
-    public static com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting parseFrom(
+    public static com.google.ads.googleads.v1.resources.Campaign.TrackingSetting parseFrom(
         java.nio.ByteBuffer data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting parseFrom(
+    public static com.google.ads.googleads.v1.resources.Campaign.TrackingSetting parseFrom(
         java.nio.ByteBuffer data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting parseFrom(
+    public static com.google.ads.googleads.v1.resources.Campaign.TrackingSetting parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting parseFrom(
+    public static com.google.ads.googleads.v1.resources.Campaign.TrackingSetting parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting parseFrom(byte[] data)
+    public static com.google.ads.googleads.v1.resources.Campaign.TrackingSetting parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting parseFrom(
+    public static com.google.ads.googleads.v1.resources.Campaign.TrackingSetting parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting parseFrom(java.io.InputStream input)
+    public static com.google.ads.googleads.v1.resources.Campaign.TrackingSetting parseFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting parseFrom(
+    public static com.google.ads.googleads.v1.resources.Campaign.TrackingSetting parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
-    public static com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting parseDelimitedFrom(java.io.InputStream input)
+    public static com.google.ads.googleads.v1.resources.Campaign.TrackingSetting parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
-    public static com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting parseDelimitedFrom(
+    public static com.google.ads.googleads.v1.resources.Campaign.TrackingSetting parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
-    public static com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting parseFrom(
+    public static com.google.ads.googleads.v1.resources.Campaign.TrackingSetting parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting parseFrom(
+    public static com.google.ads.googleads.v1.resources.Campaign.TrackingSetting parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
@@ -7049,7 +7033,7 @@ private static final long serialVersionUID = 0L;
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
     }
-    public static Builder newBuilder(com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting prototype) {
+    public static Builder newBuilder(com.google.ads.googleads.v1.resources.Campaign.TrackingSetting prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
     @java.lang.Override
@@ -7066,29 +7050,29 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Represents a collection of settings related to ads geotargeting.
+     * Campaign level settings for tracking information.
      * </pre>
      *
-     * Protobuf type {@code google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting}
+     * Protobuf type {@code google.ads.googleads.v1.resources.Campaign.TrackingSetting}
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting)
-        com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSettingOrBuilder {
+        // @@protoc_insertion_point(builder_implements:google.ads.googleads.v1.resources.Campaign.TrackingSetting)
+        com.google.ads.googleads.v1.resources.Campaign.TrackingSettingOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return com.google.ads.googleads.v1.resources.CampaignProto.internal_static_google_ads_googleads_v1_resources_Campaign_GeoTargetTypeSetting_descriptor;
+        return com.google.ads.googleads.v1.resources.CampaignProto.internal_static_google_ads_googleads_v1_resources_Campaign_TrackingSetting_descriptor;
       }
 
       @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return com.google.ads.googleads.v1.resources.CampaignProto.internal_static_google_ads_googleads_v1_resources_Campaign_GeoTargetTypeSetting_fieldAccessorTable
+        return com.google.ads.googleads.v1.resources.CampaignProto.internal_static_google_ads_googleads_v1_resources_Campaign_TrackingSetting_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
-                com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting.class, com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting.Builder.class);
+                com.google.ads.googleads.v1.resources.Campaign.TrackingSetting.class, com.google.ads.googleads.v1.resources.Campaign.TrackingSetting.Builder.class);
       }
 
-      // Construct using com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting.newBuilder()
+      // Construct using com.google.ads.googleads.v1.resources.Campaign.TrackingSetting.newBuilder()
       private Builder() {
         maybeForceBuilderInitialization();
       }
@@ -7106,27 +7090,29 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public Builder clear() {
         super.clear();
-        positiveGeoTargetType_ = 0;
-
-        negativeGeoTargetType_ = 0;
-
+        if (trackingUrlBuilder_ == null) {
+          trackingUrl_ = null;
+        } else {
+          trackingUrl_ = null;
+          trackingUrlBuilder_ = null;
+        }
         return this;
       }
 
       @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return com.google.ads.googleads.v1.resources.CampaignProto.internal_static_google_ads_googleads_v1_resources_Campaign_GeoTargetTypeSetting_descriptor;
+        return com.google.ads.googleads.v1.resources.CampaignProto.internal_static_google_ads_googleads_v1_resources_Campaign_TrackingSetting_descriptor;
       }
 
       @java.lang.Override
-      public com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting getDefaultInstanceForType() {
-        return com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting.getDefaultInstance();
+      public com.google.ads.googleads.v1.resources.Campaign.TrackingSetting getDefaultInstanceForType() {
+        return com.google.ads.googleads.v1.resources.Campaign.TrackingSetting.getDefaultInstance();
       }
 
       @java.lang.Override
-      public com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting build() {
-        com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting result = buildPartial();
+      public com.google.ads.googleads.v1.resources.Campaign.TrackingSetting build() {
+        com.google.ads.googleads.v1.resources.Campaign.TrackingSetting result = buildPartial();
         if (!result.isInitialized()) {
           throw newUninitializedMessageException(result);
         }
@@ -7134,10 +7120,13 @@ private static final long serialVersionUID = 0L;
       }
 
       @java.lang.Override
-      public com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting buildPartial() {
-        com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting result = new com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting(this);
-        result.positiveGeoTargetType_ = positiveGeoTargetType_;
-        result.negativeGeoTargetType_ = negativeGeoTargetType_;
+      public com.google.ads.googleads.v1.resources.Campaign.TrackingSetting buildPartial() {
+        com.google.ads.googleads.v1.resources.Campaign.TrackingSetting result = new com.google.ads.googleads.v1.resources.Campaign.TrackingSetting(this);
+        if (trackingUrlBuilder_ == null) {
+          result.trackingUrl_ = trackingUrl_;
+        } else {
+          result.trackingUrl_ = trackingUrlBuilder_.build();
+        }
         onBuilt();
         return result;
       }
@@ -7176,21 +7165,18 @@ private static final long serialVersionUID = 0L;
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting) {
-          return mergeFrom((com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting)other);
+        if (other instanceof com.google.ads.googleads.v1.resources.Campaign.TrackingSetting) {
+          return mergeFrom((com.google.ads.googleads.v1.resources.Campaign.TrackingSetting)other);
         } else {
           super.mergeFrom(other);
           return this;
         }
       }
 
-      public Builder mergeFrom(com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting other) {
-        if (other == com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting.getDefaultInstance()) return this;
-        if (other.positiveGeoTargetType_ != 0) {
-          setPositiveGeoTargetTypeValue(other.getPositiveGeoTargetTypeValue());
-        }
-        if (other.negativeGeoTargetType_ != 0) {
-          setNegativeGeoTargetTypeValue(other.getNegativeGeoTargetTypeValue());
+      public Builder mergeFrom(com.google.ads.googleads.v1.resources.Campaign.TrackingSetting other) {
+        if (other == com.google.ads.googleads.v1.resources.Campaign.TrackingSetting.getDefaultInstance()) return this;
+        if (other.hasTrackingUrl()) {
+          mergeTrackingUrl(other.getTrackingUrl());
         }
         this.mergeUnknownFields(other.unknownFields);
         onChanged();
@@ -7207,11 +7193,11 @@ private static final long serialVersionUID = 0L;
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting parsedMessage = null;
+        com.google.ads.googleads.v1.resources.Campaign.TrackingSetting parsedMessage = null;
         try {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting) e.getUnfinishedMessage();
+          parsedMessage = (com.google.ads.googleads.v1.resources.Campaign.TrackingSetting) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
@@ -7221,134 +7207,157 @@ private static final long serialVersionUID = 0L;
         return this;
       }
 
-      private int positiveGeoTargetType_ = 0;
+      private com.google.protobuf.StringValue trackingUrl_ = null;
+      private com.google.protobuf.SingleFieldBuilderV3<
+          com.google.protobuf.StringValue, com.google.protobuf.StringValue.Builder, com.google.protobuf.StringValueOrBuilder> trackingUrlBuilder_;
       /**
        * <pre>
-       * The setting used for positive geotargeting in this particular campaign.
+       * The url used for dynamic tracking.
        * </pre>
        *
-       * <code>.google.ads.googleads.v1.enums.PositiveGeoTargetTypeEnum.PositiveGeoTargetType positive_geo_target_type = 1;</code>
+       * <code>.google.protobuf.StringValue tracking_url = 1;</code>
        */
-      public int getPositiveGeoTargetTypeValue() {
-        return positiveGeoTargetType_;
+      public boolean hasTrackingUrl() {
+        return trackingUrlBuilder_ != null || trackingUrl_ != null;
       }
       /**
        * <pre>
-       * The setting used for positive geotargeting in this particular campaign.
+       * The url used for dynamic tracking.
        * </pre>
        *
-       * <code>.google.ads.googleads.v1.enums.PositiveGeoTargetTypeEnum.PositiveGeoTargetType positive_geo_target_type = 1;</code>
+       * <code>.google.protobuf.StringValue tracking_url = 1;</code>
        */
-      public Builder setPositiveGeoTargetTypeValue(int value) {
-        positiveGeoTargetType_ = value;
-        onChanged();
-        return this;
-      }
-      /**
-       * <pre>
-       * The setting used for positive geotargeting in this particular campaign.
-       * </pre>
-       *
-       * <code>.google.ads.googleads.v1.enums.PositiveGeoTargetTypeEnum.PositiveGeoTargetType positive_geo_target_type = 1;</code>
-       */
-      public com.google.ads.googleads.v1.enums.PositiveGeoTargetTypeEnum.PositiveGeoTargetType getPositiveGeoTargetType() {
-        @SuppressWarnings("deprecation")
-        com.google.ads.googleads.v1.enums.PositiveGeoTargetTypeEnum.PositiveGeoTargetType result = com.google.ads.googleads.v1.enums.PositiveGeoTargetTypeEnum.PositiveGeoTargetType.valueOf(positiveGeoTargetType_);
-        return result == null ? com.google.ads.googleads.v1.enums.PositiveGeoTargetTypeEnum.PositiveGeoTargetType.UNRECOGNIZED : result;
-      }
-      /**
-       * <pre>
-       * The setting used for positive geotargeting in this particular campaign.
-       * </pre>
-       *
-       * <code>.google.ads.googleads.v1.enums.PositiveGeoTargetTypeEnum.PositiveGeoTargetType positive_geo_target_type = 1;</code>
-       */
-      public Builder setPositiveGeoTargetType(com.google.ads.googleads.v1.enums.PositiveGeoTargetTypeEnum.PositiveGeoTargetType value) {
-        if (value == null) {
-          throw new NullPointerException();
+      public com.google.protobuf.StringValue getTrackingUrl() {
+        if (trackingUrlBuilder_ == null) {
+          return trackingUrl_ == null ? com.google.protobuf.StringValue.getDefaultInstance() : trackingUrl_;
+        } else {
+          return trackingUrlBuilder_.getMessage();
         }
-        
-        positiveGeoTargetType_ = value.getNumber();
-        onChanged();
-        return this;
       }
       /**
        * <pre>
-       * The setting used for positive geotargeting in this particular campaign.
+       * The url used for dynamic tracking.
        * </pre>
        *
-       * <code>.google.ads.googleads.v1.enums.PositiveGeoTargetTypeEnum.PositiveGeoTargetType positive_geo_target_type = 1;</code>
+       * <code>.google.protobuf.StringValue tracking_url = 1;</code>
        */
-      public Builder clearPositiveGeoTargetType() {
-        
-        positiveGeoTargetType_ = 0;
-        onChanged();
-        return this;
-      }
+      public Builder setTrackingUrl(com.google.protobuf.StringValue value) {
+        if (trackingUrlBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          trackingUrl_ = value;
+          onChanged();
+        } else {
+          trackingUrlBuilder_.setMessage(value);
+        }
 
-      private int negativeGeoTargetType_ = 0;
-      /**
-       * <pre>
-       * The setting used for negative geotargeting in this particular campaign.
-       * </pre>
-       *
-       * <code>.google.ads.googleads.v1.enums.NegativeGeoTargetTypeEnum.NegativeGeoTargetType negative_geo_target_type = 2;</code>
-       */
-      public int getNegativeGeoTargetTypeValue() {
-        return negativeGeoTargetType_;
-      }
-      /**
-       * <pre>
-       * The setting used for negative geotargeting in this particular campaign.
-       * </pre>
-       *
-       * <code>.google.ads.googleads.v1.enums.NegativeGeoTargetTypeEnum.NegativeGeoTargetType negative_geo_target_type = 2;</code>
-       */
-      public Builder setNegativeGeoTargetTypeValue(int value) {
-        negativeGeoTargetType_ = value;
-        onChanged();
         return this;
       }
       /**
        * <pre>
-       * The setting used for negative geotargeting in this particular campaign.
+       * The url used for dynamic tracking.
        * </pre>
        *
-       * <code>.google.ads.googleads.v1.enums.NegativeGeoTargetTypeEnum.NegativeGeoTargetType negative_geo_target_type = 2;</code>
+       * <code>.google.protobuf.StringValue tracking_url = 1;</code>
        */
-      public com.google.ads.googleads.v1.enums.NegativeGeoTargetTypeEnum.NegativeGeoTargetType getNegativeGeoTargetType() {
-        @SuppressWarnings("deprecation")
-        com.google.ads.googleads.v1.enums.NegativeGeoTargetTypeEnum.NegativeGeoTargetType result = com.google.ads.googleads.v1.enums.NegativeGeoTargetTypeEnum.NegativeGeoTargetType.valueOf(negativeGeoTargetType_);
-        return result == null ? com.google.ads.googleads.v1.enums.NegativeGeoTargetTypeEnum.NegativeGeoTargetType.UNRECOGNIZED : result;
-      }
-      /**
-       * <pre>
-       * The setting used for negative geotargeting in this particular campaign.
-       * </pre>
-       *
-       * <code>.google.ads.googleads.v1.enums.NegativeGeoTargetTypeEnum.NegativeGeoTargetType negative_geo_target_type = 2;</code>
-       */
-      public Builder setNegativeGeoTargetType(com.google.ads.googleads.v1.enums.NegativeGeoTargetTypeEnum.NegativeGeoTargetType value) {
-        if (value == null) {
-          throw new NullPointerException();
+      public Builder setTrackingUrl(
+          com.google.protobuf.StringValue.Builder builderForValue) {
+        if (trackingUrlBuilder_ == null) {
+          trackingUrl_ = builderForValue.build();
+          onChanged();
+        } else {
+          trackingUrlBuilder_.setMessage(builderForValue.build());
         }
-        
-        negativeGeoTargetType_ = value.getNumber();
-        onChanged();
+
         return this;
       }
       /**
        * <pre>
-       * The setting used for negative geotargeting in this particular campaign.
+       * The url used for dynamic tracking.
        * </pre>
        *
-       * <code>.google.ads.googleads.v1.enums.NegativeGeoTargetTypeEnum.NegativeGeoTargetType negative_geo_target_type = 2;</code>
+       * <code>.google.protobuf.StringValue tracking_url = 1;</code>
        */
-      public Builder clearNegativeGeoTargetType() {
-        
-        negativeGeoTargetType_ = 0;
-        onChanged();
+      public Builder mergeTrackingUrl(com.google.protobuf.StringValue value) {
+        if (trackingUrlBuilder_ == null) {
+          if (trackingUrl_ != null) {
+            trackingUrl_ =
+              com.google.protobuf.StringValue.newBuilder(trackingUrl_).mergeFrom(value).buildPartial();
+          } else {
+            trackingUrl_ = value;
+          }
+          onChanged();
+        } else {
+          trackingUrlBuilder_.mergeFrom(value);
+        }
+
         return this;
+      }
+      /**
+       * <pre>
+       * The url used for dynamic tracking.
+       * </pre>
+       *
+       * <code>.google.protobuf.StringValue tracking_url = 1;</code>
+       */
+      public Builder clearTrackingUrl() {
+        if (trackingUrlBuilder_ == null) {
+          trackingUrl_ = null;
+          onChanged();
+        } else {
+          trackingUrl_ = null;
+          trackingUrlBuilder_ = null;
+        }
+
+        return this;
+      }
+      /**
+       * <pre>
+       * The url used for dynamic tracking.
+       * </pre>
+       *
+       * <code>.google.protobuf.StringValue tracking_url = 1;</code>
+       */
+      public com.google.protobuf.StringValue.Builder getTrackingUrlBuilder() {
+        
+        onChanged();
+        return getTrackingUrlFieldBuilder().getBuilder();
+      }
+      /**
+       * <pre>
+       * The url used for dynamic tracking.
+       * </pre>
+       *
+       * <code>.google.protobuf.StringValue tracking_url = 1;</code>
+       */
+      public com.google.protobuf.StringValueOrBuilder getTrackingUrlOrBuilder() {
+        if (trackingUrlBuilder_ != null) {
+          return trackingUrlBuilder_.getMessageOrBuilder();
+        } else {
+          return trackingUrl_ == null ?
+              com.google.protobuf.StringValue.getDefaultInstance() : trackingUrl_;
+        }
+      }
+      /**
+       * <pre>
+       * The url used for dynamic tracking.
+       * </pre>
+       *
+       * <code>.google.protobuf.StringValue tracking_url = 1;</code>
+       */
+      private com.google.protobuf.SingleFieldBuilderV3<
+          com.google.protobuf.StringValue, com.google.protobuf.StringValue.Builder, com.google.protobuf.StringValueOrBuilder> 
+          getTrackingUrlFieldBuilder() {
+        if (trackingUrlBuilder_ == null) {
+          trackingUrlBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
+              com.google.protobuf.StringValue, com.google.protobuf.StringValue.Builder, com.google.protobuf.StringValueOrBuilder>(
+                  getTrackingUrl(),
+                  getParentForChildren(),
+                  isClean());
+          trackingUrl_ = null;
+        }
+        return trackingUrlBuilder_;
       }
       @java.lang.Override
       public final Builder setUnknownFields(
@@ -7363,41 +7372,945 @@ private static final long serialVersionUID = 0L;
       }
 
 
-      // @@protoc_insertion_point(builder_scope:google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting)
+      // @@protoc_insertion_point(builder_scope:google.ads.googleads.v1.resources.Campaign.TrackingSetting)
     }
 
-    // @@protoc_insertion_point(class_scope:google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting)
-    private static final com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting DEFAULT_INSTANCE;
+    // @@protoc_insertion_point(class_scope:google.ads.googleads.v1.resources.Campaign.TrackingSetting)
+    private static final com.google.ads.googleads.v1.resources.Campaign.TrackingSetting DEFAULT_INSTANCE;
     static {
-      DEFAULT_INSTANCE = new com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting();
+      DEFAULT_INSTANCE = new com.google.ads.googleads.v1.resources.Campaign.TrackingSetting();
     }
 
-    public static com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting getDefaultInstance() {
+    public static com.google.ads.googleads.v1.resources.Campaign.TrackingSetting getDefaultInstance() {
       return DEFAULT_INSTANCE;
     }
 
-    private static final com.google.protobuf.Parser<GeoTargetTypeSetting>
-        PARSER = new com.google.protobuf.AbstractParser<GeoTargetTypeSetting>() {
+    private static final com.google.protobuf.Parser<TrackingSetting>
+        PARSER = new com.google.protobuf.AbstractParser<TrackingSetting>() {
       @java.lang.Override
-      public GeoTargetTypeSetting parsePartialFrom(
+      public TrackingSetting parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new GeoTargetTypeSetting(input, extensionRegistry);
+        return new TrackingSetting(input, extensionRegistry);
       }
     };
 
-    public static com.google.protobuf.Parser<GeoTargetTypeSetting> parser() {
+    public static com.google.protobuf.Parser<TrackingSetting> parser() {
       return PARSER;
     }
 
     @java.lang.Override
-    public com.google.protobuf.Parser<GeoTargetTypeSetting> getParserForType() {
+    public com.google.protobuf.Parser<TrackingSetting> getParserForType() {
       return PARSER;
     }
 
     @java.lang.Override
-    public com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting getDefaultInstanceForType() {
+    public com.google.ads.googleads.v1.resources.Campaign.TrackingSetting getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
+  public interface SelectiveOptimizationOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:google.ads.googleads.v1.resources.Campaign.SelectiveOptimization)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <pre>
+     * The selected set of conversion actions for optimizing this campaign.
+     * </pre>
+     *
+     * <code>repeated .google.protobuf.StringValue conversion_actions = 1;</code>
+     */
+    java.util.List<com.google.protobuf.StringValue> 
+        getConversionActionsList();
+    /**
+     * <pre>
+     * The selected set of conversion actions for optimizing this campaign.
+     * </pre>
+     *
+     * <code>repeated .google.protobuf.StringValue conversion_actions = 1;</code>
+     */
+    com.google.protobuf.StringValue getConversionActions(int index);
+    /**
+     * <pre>
+     * The selected set of conversion actions for optimizing this campaign.
+     * </pre>
+     *
+     * <code>repeated .google.protobuf.StringValue conversion_actions = 1;</code>
+     */
+    int getConversionActionsCount();
+    /**
+     * <pre>
+     * The selected set of conversion actions for optimizing this campaign.
+     * </pre>
+     *
+     * <code>repeated .google.protobuf.StringValue conversion_actions = 1;</code>
+     */
+    java.util.List<? extends com.google.protobuf.StringValueOrBuilder> 
+        getConversionActionsOrBuilderList();
+    /**
+     * <pre>
+     * The selected set of conversion actions for optimizing this campaign.
+     * </pre>
+     *
+     * <code>repeated .google.protobuf.StringValue conversion_actions = 1;</code>
+     */
+    com.google.protobuf.StringValueOrBuilder getConversionActionsOrBuilder(
+        int index);
+  }
+  /**
+   * <pre>
+   * Selective optimization setting for this campaign, which includes a set of
+   * conversion actions to optimize this campaign towards.
+   * </pre>
+   *
+   * Protobuf type {@code google.ads.googleads.v1.resources.Campaign.SelectiveOptimization}
+   */
+  public  static final class SelectiveOptimization extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:google.ads.googleads.v1.resources.Campaign.SelectiveOptimization)
+      SelectiveOptimizationOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use SelectiveOptimization.newBuilder() to construct.
+    private SelectiveOptimization(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private SelectiveOptimization() {
+      conversionActions_ = java.util.Collections.emptyList();
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private SelectiveOptimization(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            case 10: {
+              if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+                conversionActions_ = new java.util.ArrayList<com.google.protobuf.StringValue>();
+                mutable_bitField0_ |= 0x00000001;
+              }
+              conversionActions_.add(
+                  input.readMessage(com.google.protobuf.StringValue.parser(), extensionRegistry));
+              break;
+            }
+            default: {
+              if (!parseUnknownFieldProto3(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+          conversionActions_ = java.util.Collections.unmodifiableList(conversionActions_);
+        }
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return com.google.ads.googleads.v1.resources.CampaignProto.internal_static_google_ads_googleads_v1_resources_Campaign_SelectiveOptimization_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return com.google.ads.googleads.v1.resources.CampaignProto.internal_static_google_ads_googleads_v1_resources_Campaign_SelectiveOptimization_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization.class, com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization.Builder.class);
+    }
+
+    public static final int CONVERSION_ACTIONS_FIELD_NUMBER = 1;
+    private java.util.List<com.google.protobuf.StringValue> conversionActions_;
+    /**
+     * <pre>
+     * The selected set of conversion actions for optimizing this campaign.
+     * </pre>
+     *
+     * <code>repeated .google.protobuf.StringValue conversion_actions = 1;</code>
+     */
+    public java.util.List<com.google.protobuf.StringValue> getConversionActionsList() {
+      return conversionActions_;
+    }
+    /**
+     * <pre>
+     * The selected set of conversion actions for optimizing this campaign.
+     * </pre>
+     *
+     * <code>repeated .google.protobuf.StringValue conversion_actions = 1;</code>
+     */
+    public java.util.List<? extends com.google.protobuf.StringValueOrBuilder> 
+        getConversionActionsOrBuilderList() {
+      return conversionActions_;
+    }
+    /**
+     * <pre>
+     * The selected set of conversion actions for optimizing this campaign.
+     * </pre>
+     *
+     * <code>repeated .google.protobuf.StringValue conversion_actions = 1;</code>
+     */
+    public int getConversionActionsCount() {
+      return conversionActions_.size();
+    }
+    /**
+     * <pre>
+     * The selected set of conversion actions for optimizing this campaign.
+     * </pre>
+     *
+     * <code>repeated .google.protobuf.StringValue conversion_actions = 1;</code>
+     */
+    public com.google.protobuf.StringValue getConversionActions(int index) {
+      return conversionActions_.get(index);
+    }
+    /**
+     * <pre>
+     * The selected set of conversion actions for optimizing this campaign.
+     * </pre>
+     *
+     * <code>repeated .google.protobuf.StringValue conversion_actions = 1;</code>
+     */
+    public com.google.protobuf.StringValueOrBuilder getConversionActionsOrBuilder(
+        int index) {
+      return conversionActions_.get(index);
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      for (int i = 0; i < conversionActions_.size(); i++) {
+        output.writeMessage(1, conversionActions_.get(i));
+      }
+      unknownFields.writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      for (int i = 0; i < conversionActions_.size(); i++) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(1, conversionActions_.get(i));
+      }
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization)) {
+        return super.equals(obj);
+      }
+      com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization other = (com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization) obj;
+
+      boolean result = true;
+      result = result && getConversionActionsList()
+          .equals(other.getConversionActionsList());
+      result = result && unknownFields.equals(other.unknownFields);
+      return result;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (getConversionActionsCount() > 0) {
+        hash = (37 * hash) + CONVERSION_ACTIONS_FIELD_NUMBER;
+        hash = (53 * hash) + getConversionActionsList().hashCode();
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * <pre>
+     * Selective optimization setting for this campaign, which includes a set of
+     * conversion actions to optimize this campaign towards.
+     * </pre>
+     *
+     * Protobuf type {@code google.ads.googleads.v1.resources.Campaign.SelectiveOptimization}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:google.ads.googleads.v1.resources.Campaign.SelectiveOptimization)
+        com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimizationOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return com.google.ads.googleads.v1.resources.CampaignProto.internal_static_google_ads_googleads_v1_resources_Campaign_SelectiveOptimization_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return com.google.ads.googleads.v1.resources.CampaignProto.internal_static_google_ads_googleads_v1_resources_Campaign_SelectiveOptimization_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization.class, com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization.Builder.class);
+      }
+
+      // Construct using com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+          getConversionActionsFieldBuilder();
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        if (conversionActionsBuilder_ == null) {
+          conversionActions_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000001);
+        } else {
+          conversionActionsBuilder_.clear();
+        }
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return com.google.ads.googleads.v1.resources.CampaignProto.internal_static_google_ads_googleads_v1_resources_Campaign_SelectiveOptimization_descriptor;
+      }
+
+      @java.lang.Override
+      public com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization getDefaultInstanceForType() {
+        return com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization build() {
+        com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization buildPartial() {
+        com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization result = new com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization(this);
+        int from_bitField0_ = bitField0_;
+        if (conversionActionsBuilder_ == null) {
+          if (((bitField0_ & 0x00000001) == 0x00000001)) {
+            conversionActions_ = java.util.Collections.unmodifiableList(conversionActions_);
+            bitField0_ = (bitField0_ & ~0x00000001);
+          }
+          result.conversionActions_ = conversionActions_;
+        } else {
+          result.conversionActions_ = conversionActionsBuilder_.build();
+        }
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return (Builder) super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return (Builder) super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return (Builder) super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return (Builder) super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return (Builder) super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return (Builder) super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization) {
+          return mergeFrom((com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization other) {
+        if (other == com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization.getDefaultInstance()) return this;
+        if (conversionActionsBuilder_ == null) {
+          if (!other.conversionActions_.isEmpty()) {
+            if (conversionActions_.isEmpty()) {
+              conversionActions_ = other.conversionActions_;
+              bitField0_ = (bitField0_ & ~0x00000001);
+            } else {
+              ensureConversionActionsIsMutable();
+              conversionActions_.addAll(other.conversionActions_);
+            }
+            onChanged();
+          }
+        } else {
+          if (!other.conversionActions_.isEmpty()) {
+            if (conversionActionsBuilder_.isEmpty()) {
+              conversionActionsBuilder_.dispose();
+              conversionActionsBuilder_ = null;
+              conversionActions_ = other.conversionActions_;
+              bitField0_ = (bitField0_ & ~0x00000001);
+              conversionActionsBuilder_ = 
+                com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
+                   getConversionActionsFieldBuilder() : null;
+            } else {
+              conversionActionsBuilder_.addAllMessages(other.conversionActions_);
+            }
+          }
+        }
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      private java.util.List<com.google.protobuf.StringValue> conversionActions_ =
+        java.util.Collections.emptyList();
+      private void ensureConversionActionsIsMutable() {
+        if (!((bitField0_ & 0x00000001) == 0x00000001)) {
+          conversionActions_ = new java.util.ArrayList<com.google.protobuf.StringValue>(conversionActions_);
+          bitField0_ |= 0x00000001;
+         }
+      }
+
+      private com.google.protobuf.RepeatedFieldBuilderV3<
+          com.google.protobuf.StringValue, com.google.protobuf.StringValue.Builder, com.google.protobuf.StringValueOrBuilder> conversionActionsBuilder_;
+
+      /**
+       * <pre>
+       * The selected set of conversion actions for optimizing this campaign.
+       * </pre>
+       *
+       * <code>repeated .google.protobuf.StringValue conversion_actions = 1;</code>
+       */
+      public java.util.List<com.google.protobuf.StringValue> getConversionActionsList() {
+        if (conversionActionsBuilder_ == null) {
+          return java.util.Collections.unmodifiableList(conversionActions_);
+        } else {
+          return conversionActionsBuilder_.getMessageList();
+        }
+      }
+      /**
+       * <pre>
+       * The selected set of conversion actions for optimizing this campaign.
+       * </pre>
+       *
+       * <code>repeated .google.protobuf.StringValue conversion_actions = 1;</code>
+       */
+      public int getConversionActionsCount() {
+        if (conversionActionsBuilder_ == null) {
+          return conversionActions_.size();
+        } else {
+          return conversionActionsBuilder_.getCount();
+        }
+      }
+      /**
+       * <pre>
+       * The selected set of conversion actions for optimizing this campaign.
+       * </pre>
+       *
+       * <code>repeated .google.protobuf.StringValue conversion_actions = 1;</code>
+       */
+      public com.google.protobuf.StringValue getConversionActions(int index) {
+        if (conversionActionsBuilder_ == null) {
+          return conversionActions_.get(index);
+        } else {
+          return conversionActionsBuilder_.getMessage(index);
+        }
+      }
+      /**
+       * <pre>
+       * The selected set of conversion actions for optimizing this campaign.
+       * </pre>
+       *
+       * <code>repeated .google.protobuf.StringValue conversion_actions = 1;</code>
+       */
+      public Builder setConversionActions(
+          int index, com.google.protobuf.StringValue value) {
+        if (conversionActionsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureConversionActionsIsMutable();
+          conversionActions_.set(index, value);
+          onChanged();
+        } else {
+          conversionActionsBuilder_.setMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <pre>
+       * The selected set of conversion actions for optimizing this campaign.
+       * </pre>
+       *
+       * <code>repeated .google.protobuf.StringValue conversion_actions = 1;</code>
+       */
+      public Builder setConversionActions(
+          int index, com.google.protobuf.StringValue.Builder builderForValue) {
+        if (conversionActionsBuilder_ == null) {
+          ensureConversionActionsIsMutable();
+          conversionActions_.set(index, builderForValue.build());
+          onChanged();
+        } else {
+          conversionActionsBuilder_.setMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <pre>
+       * The selected set of conversion actions for optimizing this campaign.
+       * </pre>
+       *
+       * <code>repeated .google.protobuf.StringValue conversion_actions = 1;</code>
+       */
+      public Builder addConversionActions(com.google.protobuf.StringValue value) {
+        if (conversionActionsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureConversionActionsIsMutable();
+          conversionActions_.add(value);
+          onChanged();
+        } else {
+          conversionActionsBuilder_.addMessage(value);
+        }
+        return this;
+      }
+      /**
+       * <pre>
+       * The selected set of conversion actions for optimizing this campaign.
+       * </pre>
+       *
+       * <code>repeated .google.protobuf.StringValue conversion_actions = 1;</code>
+       */
+      public Builder addConversionActions(
+          int index, com.google.protobuf.StringValue value) {
+        if (conversionActionsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureConversionActionsIsMutable();
+          conversionActions_.add(index, value);
+          onChanged();
+        } else {
+          conversionActionsBuilder_.addMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <pre>
+       * The selected set of conversion actions for optimizing this campaign.
+       * </pre>
+       *
+       * <code>repeated .google.protobuf.StringValue conversion_actions = 1;</code>
+       */
+      public Builder addConversionActions(
+          com.google.protobuf.StringValue.Builder builderForValue) {
+        if (conversionActionsBuilder_ == null) {
+          ensureConversionActionsIsMutable();
+          conversionActions_.add(builderForValue.build());
+          onChanged();
+        } else {
+          conversionActionsBuilder_.addMessage(builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <pre>
+       * The selected set of conversion actions for optimizing this campaign.
+       * </pre>
+       *
+       * <code>repeated .google.protobuf.StringValue conversion_actions = 1;</code>
+       */
+      public Builder addConversionActions(
+          int index, com.google.protobuf.StringValue.Builder builderForValue) {
+        if (conversionActionsBuilder_ == null) {
+          ensureConversionActionsIsMutable();
+          conversionActions_.add(index, builderForValue.build());
+          onChanged();
+        } else {
+          conversionActionsBuilder_.addMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <pre>
+       * The selected set of conversion actions for optimizing this campaign.
+       * </pre>
+       *
+       * <code>repeated .google.protobuf.StringValue conversion_actions = 1;</code>
+       */
+      public Builder addAllConversionActions(
+          java.lang.Iterable<? extends com.google.protobuf.StringValue> values) {
+        if (conversionActionsBuilder_ == null) {
+          ensureConversionActionsIsMutable();
+          com.google.protobuf.AbstractMessageLite.Builder.addAll(
+              values, conversionActions_);
+          onChanged();
+        } else {
+          conversionActionsBuilder_.addAllMessages(values);
+        }
+        return this;
+      }
+      /**
+       * <pre>
+       * The selected set of conversion actions for optimizing this campaign.
+       * </pre>
+       *
+       * <code>repeated .google.protobuf.StringValue conversion_actions = 1;</code>
+       */
+      public Builder clearConversionActions() {
+        if (conversionActionsBuilder_ == null) {
+          conversionActions_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000001);
+          onChanged();
+        } else {
+          conversionActionsBuilder_.clear();
+        }
+        return this;
+      }
+      /**
+       * <pre>
+       * The selected set of conversion actions for optimizing this campaign.
+       * </pre>
+       *
+       * <code>repeated .google.protobuf.StringValue conversion_actions = 1;</code>
+       */
+      public Builder removeConversionActions(int index) {
+        if (conversionActionsBuilder_ == null) {
+          ensureConversionActionsIsMutable();
+          conversionActions_.remove(index);
+          onChanged();
+        } else {
+          conversionActionsBuilder_.remove(index);
+        }
+        return this;
+      }
+      /**
+       * <pre>
+       * The selected set of conversion actions for optimizing this campaign.
+       * </pre>
+       *
+       * <code>repeated .google.protobuf.StringValue conversion_actions = 1;</code>
+       */
+      public com.google.protobuf.StringValue.Builder getConversionActionsBuilder(
+          int index) {
+        return getConversionActionsFieldBuilder().getBuilder(index);
+      }
+      /**
+       * <pre>
+       * The selected set of conversion actions for optimizing this campaign.
+       * </pre>
+       *
+       * <code>repeated .google.protobuf.StringValue conversion_actions = 1;</code>
+       */
+      public com.google.protobuf.StringValueOrBuilder getConversionActionsOrBuilder(
+          int index) {
+        if (conversionActionsBuilder_ == null) {
+          return conversionActions_.get(index);  } else {
+          return conversionActionsBuilder_.getMessageOrBuilder(index);
+        }
+      }
+      /**
+       * <pre>
+       * The selected set of conversion actions for optimizing this campaign.
+       * </pre>
+       *
+       * <code>repeated .google.protobuf.StringValue conversion_actions = 1;</code>
+       */
+      public java.util.List<? extends com.google.protobuf.StringValueOrBuilder> 
+           getConversionActionsOrBuilderList() {
+        if (conversionActionsBuilder_ != null) {
+          return conversionActionsBuilder_.getMessageOrBuilderList();
+        } else {
+          return java.util.Collections.unmodifiableList(conversionActions_);
+        }
+      }
+      /**
+       * <pre>
+       * The selected set of conversion actions for optimizing this campaign.
+       * </pre>
+       *
+       * <code>repeated .google.protobuf.StringValue conversion_actions = 1;</code>
+       */
+      public com.google.protobuf.StringValue.Builder addConversionActionsBuilder() {
+        return getConversionActionsFieldBuilder().addBuilder(
+            com.google.protobuf.StringValue.getDefaultInstance());
+      }
+      /**
+       * <pre>
+       * The selected set of conversion actions for optimizing this campaign.
+       * </pre>
+       *
+       * <code>repeated .google.protobuf.StringValue conversion_actions = 1;</code>
+       */
+      public com.google.protobuf.StringValue.Builder addConversionActionsBuilder(
+          int index) {
+        return getConversionActionsFieldBuilder().addBuilder(
+            index, com.google.protobuf.StringValue.getDefaultInstance());
+      }
+      /**
+       * <pre>
+       * The selected set of conversion actions for optimizing this campaign.
+       * </pre>
+       *
+       * <code>repeated .google.protobuf.StringValue conversion_actions = 1;</code>
+       */
+      public java.util.List<com.google.protobuf.StringValue.Builder> 
+           getConversionActionsBuilderList() {
+        return getConversionActionsFieldBuilder().getBuilderList();
+      }
+      private com.google.protobuf.RepeatedFieldBuilderV3<
+          com.google.protobuf.StringValue, com.google.protobuf.StringValue.Builder, com.google.protobuf.StringValueOrBuilder> 
+          getConversionActionsFieldBuilder() {
+        if (conversionActionsBuilder_ == null) {
+          conversionActionsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
+              com.google.protobuf.StringValue, com.google.protobuf.StringValue.Builder, com.google.protobuf.StringValueOrBuilder>(
+                  conversionActions_,
+                  ((bitField0_ & 0x00000001) == 0x00000001),
+                  getParentForChildren(),
+                  isClean());
+          conversionActions_ = null;
+        }
+        return conversionActionsBuilder_;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFieldsProto3(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:google.ads.googleads.v1.resources.Campaign.SelectiveOptimization)
+    }
+
+    // @@protoc_insertion_point(class_scope:google.ads.googleads.v1.resources.Campaign.SelectiveOptimization)
+    private static final com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization();
+    }
+
+    public static com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static final com.google.protobuf.Parser<SelectiveOptimization>
+        PARSER = new com.google.protobuf.AbstractParser<SelectiveOptimization>() {
+      @java.lang.Override
+      public SelectiveOptimization parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new SelectiveOptimization(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<SelectiveOptimization> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<SelectiveOptimization> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
 
@@ -8347,65 +9260,63 @@ private static final long serialVersionUID = 0L;
 
   }
 
-  public interface VanityPharmaOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:google.ads.googleads.v1.resources.Campaign.VanityPharma)
+  public interface GeoTargetTypeSettingOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting)
       com.google.protobuf.MessageOrBuilder {
 
     /**
      * <pre>
-     * The display mode for vanity pharma URLs.
+     * The setting used for positive geotargeting in this particular campaign.
      * </pre>
      *
-     * <code>.google.ads.googleads.v1.enums.VanityPharmaDisplayUrlModeEnum.VanityPharmaDisplayUrlMode vanity_pharma_display_url_mode = 1;</code>
+     * <code>.google.ads.googleads.v1.enums.PositiveGeoTargetTypeEnum.PositiveGeoTargetType positive_geo_target_type = 1;</code>
      */
-    int getVanityPharmaDisplayUrlModeValue();
+    int getPositiveGeoTargetTypeValue();
     /**
      * <pre>
-     * The display mode for vanity pharma URLs.
+     * The setting used for positive geotargeting in this particular campaign.
      * </pre>
      *
-     * <code>.google.ads.googleads.v1.enums.VanityPharmaDisplayUrlModeEnum.VanityPharmaDisplayUrlMode vanity_pharma_display_url_mode = 1;</code>
+     * <code>.google.ads.googleads.v1.enums.PositiveGeoTargetTypeEnum.PositiveGeoTargetType positive_geo_target_type = 1;</code>
      */
-    com.google.ads.googleads.v1.enums.VanityPharmaDisplayUrlModeEnum.VanityPharmaDisplayUrlMode getVanityPharmaDisplayUrlMode();
+    com.google.ads.googleads.v1.enums.PositiveGeoTargetTypeEnum.PositiveGeoTargetType getPositiveGeoTargetType();
 
     /**
      * <pre>
-     * The text that will be displayed in display URL of the text ad when
-     * website description is the selected display mode for vanity pharma URLs.
+     * The setting used for negative geotargeting in this particular campaign.
      * </pre>
      *
-     * <code>.google.ads.googleads.v1.enums.VanityPharmaTextEnum.VanityPharmaText vanity_pharma_text = 2;</code>
+     * <code>.google.ads.googleads.v1.enums.NegativeGeoTargetTypeEnum.NegativeGeoTargetType negative_geo_target_type = 2;</code>
      */
-    int getVanityPharmaTextValue();
+    int getNegativeGeoTargetTypeValue();
     /**
      * <pre>
-     * The text that will be displayed in display URL of the text ad when
-     * website description is the selected display mode for vanity pharma URLs.
+     * The setting used for negative geotargeting in this particular campaign.
      * </pre>
      *
-     * <code>.google.ads.googleads.v1.enums.VanityPharmaTextEnum.VanityPharmaText vanity_pharma_text = 2;</code>
+     * <code>.google.ads.googleads.v1.enums.NegativeGeoTargetTypeEnum.NegativeGeoTargetType negative_geo_target_type = 2;</code>
      */
-    com.google.ads.googleads.v1.enums.VanityPharmaTextEnum.VanityPharmaText getVanityPharmaText();
+    com.google.ads.googleads.v1.enums.NegativeGeoTargetTypeEnum.NegativeGeoTargetType getNegativeGeoTargetType();
   }
   /**
    * <pre>
-   * Describes how unbranded pharma ads will be displayed.
+   * Represents a collection of settings related to ads geotargeting.
    * </pre>
    *
-   * Protobuf type {@code google.ads.googleads.v1.resources.Campaign.VanityPharma}
+   * Protobuf type {@code google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting}
    */
-  public  static final class VanityPharma extends
+  public  static final class GeoTargetTypeSetting extends
       com.google.protobuf.GeneratedMessageV3 implements
-      // @@protoc_insertion_point(message_implements:google.ads.googleads.v1.resources.Campaign.VanityPharma)
-      VanityPharmaOrBuilder {
+      // @@protoc_insertion_point(message_implements:google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting)
+      GeoTargetTypeSettingOrBuilder {
   private static final long serialVersionUID = 0L;
-    // Use VanityPharma.newBuilder() to construct.
-    private VanityPharma(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+    // Use GeoTargetTypeSetting.newBuilder() to construct.
+    private GeoTargetTypeSetting(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
     }
-    private VanityPharma() {
-      vanityPharmaDisplayUrlMode_ = 0;
-      vanityPharmaText_ = 0;
+    private GeoTargetTypeSetting() {
+      positiveGeoTargetType_ = 0;
+      negativeGeoTargetType_ = 0;
     }
 
     @java.lang.Override
@@ -8413,7 +9324,7 @@ private static final long serialVersionUID = 0L;
     getUnknownFields() {
       return this.unknownFields;
     }
-    private VanityPharma(
+    private GeoTargetTypeSetting(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
@@ -8435,13 +9346,13 @@ private static final long serialVersionUID = 0L;
             case 8: {
               int rawValue = input.readEnum();
 
-              vanityPharmaDisplayUrlMode_ = rawValue;
+              positiveGeoTargetType_ = rawValue;
               break;
             }
             case 16: {
               int rawValue = input.readEnum();
 
-              vanityPharmaText_ = rawValue;
+              negativeGeoTargetType_ = rawValue;
               break;
             }
             default: {
@@ -8465,67 +9376,65 @@ private static final long serialVersionUID = 0L;
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.google.ads.googleads.v1.resources.CampaignProto.internal_static_google_ads_googleads_v1_resources_Campaign_VanityPharma_descriptor;
+      return com.google.ads.googleads.v1.resources.CampaignProto.internal_static_google_ads_googleads_v1_resources_Campaign_GeoTargetTypeSetting_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.google.ads.googleads.v1.resources.CampaignProto.internal_static_google_ads_googleads_v1_resources_Campaign_VanityPharma_fieldAccessorTable
+      return com.google.ads.googleads.v1.resources.CampaignProto.internal_static_google_ads_googleads_v1_resources_Campaign_GeoTargetTypeSetting_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              com.google.ads.googleads.v1.resources.Campaign.VanityPharma.class, com.google.ads.googleads.v1.resources.Campaign.VanityPharma.Builder.class);
+              com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting.class, com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting.Builder.class);
     }
 
-    public static final int VANITY_PHARMA_DISPLAY_URL_MODE_FIELD_NUMBER = 1;
-    private int vanityPharmaDisplayUrlMode_;
+    public static final int POSITIVE_GEO_TARGET_TYPE_FIELD_NUMBER = 1;
+    private int positiveGeoTargetType_;
     /**
      * <pre>
-     * The display mode for vanity pharma URLs.
+     * The setting used for positive geotargeting in this particular campaign.
      * </pre>
      *
-     * <code>.google.ads.googleads.v1.enums.VanityPharmaDisplayUrlModeEnum.VanityPharmaDisplayUrlMode vanity_pharma_display_url_mode = 1;</code>
+     * <code>.google.ads.googleads.v1.enums.PositiveGeoTargetTypeEnum.PositiveGeoTargetType positive_geo_target_type = 1;</code>
      */
-    public int getVanityPharmaDisplayUrlModeValue() {
-      return vanityPharmaDisplayUrlMode_;
+    public int getPositiveGeoTargetTypeValue() {
+      return positiveGeoTargetType_;
     }
     /**
      * <pre>
-     * The display mode for vanity pharma URLs.
+     * The setting used for positive geotargeting in this particular campaign.
      * </pre>
      *
-     * <code>.google.ads.googleads.v1.enums.VanityPharmaDisplayUrlModeEnum.VanityPharmaDisplayUrlMode vanity_pharma_display_url_mode = 1;</code>
+     * <code>.google.ads.googleads.v1.enums.PositiveGeoTargetTypeEnum.PositiveGeoTargetType positive_geo_target_type = 1;</code>
      */
-    public com.google.ads.googleads.v1.enums.VanityPharmaDisplayUrlModeEnum.VanityPharmaDisplayUrlMode getVanityPharmaDisplayUrlMode() {
+    public com.google.ads.googleads.v1.enums.PositiveGeoTargetTypeEnum.PositiveGeoTargetType getPositiveGeoTargetType() {
       @SuppressWarnings("deprecation")
-      com.google.ads.googleads.v1.enums.VanityPharmaDisplayUrlModeEnum.VanityPharmaDisplayUrlMode result = com.google.ads.googleads.v1.enums.VanityPharmaDisplayUrlModeEnum.VanityPharmaDisplayUrlMode.valueOf(vanityPharmaDisplayUrlMode_);
-      return result == null ? com.google.ads.googleads.v1.enums.VanityPharmaDisplayUrlModeEnum.VanityPharmaDisplayUrlMode.UNRECOGNIZED : result;
+      com.google.ads.googleads.v1.enums.PositiveGeoTargetTypeEnum.PositiveGeoTargetType result = com.google.ads.googleads.v1.enums.PositiveGeoTargetTypeEnum.PositiveGeoTargetType.valueOf(positiveGeoTargetType_);
+      return result == null ? com.google.ads.googleads.v1.enums.PositiveGeoTargetTypeEnum.PositiveGeoTargetType.UNRECOGNIZED : result;
     }
 
-    public static final int VANITY_PHARMA_TEXT_FIELD_NUMBER = 2;
-    private int vanityPharmaText_;
+    public static final int NEGATIVE_GEO_TARGET_TYPE_FIELD_NUMBER = 2;
+    private int negativeGeoTargetType_;
     /**
      * <pre>
-     * The text that will be displayed in display URL of the text ad when
-     * website description is the selected display mode for vanity pharma URLs.
+     * The setting used for negative geotargeting in this particular campaign.
      * </pre>
      *
-     * <code>.google.ads.googleads.v1.enums.VanityPharmaTextEnum.VanityPharmaText vanity_pharma_text = 2;</code>
+     * <code>.google.ads.googleads.v1.enums.NegativeGeoTargetTypeEnum.NegativeGeoTargetType negative_geo_target_type = 2;</code>
      */
-    public int getVanityPharmaTextValue() {
-      return vanityPharmaText_;
+    public int getNegativeGeoTargetTypeValue() {
+      return negativeGeoTargetType_;
     }
     /**
      * <pre>
-     * The text that will be displayed in display URL of the text ad when
-     * website description is the selected display mode for vanity pharma URLs.
+     * The setting used for negative geotargeting in this particular campaign.
      * </pre>
      *
-     * <code>.google.ads.googleads.v1.enums.VanityPharmaTextEnum.VanityPharmaText vanity_pharma_text = 2;</code>
+     * <code>.google.ads.googleads.v1.enums.NegativeGeoTargetTypeEnum.NegativeGeoTargetType negative_geo_target_type = 2;</code>
      */
-    public com.google.ads.googleads.v1.enums.VanityPharmaTextEnum.VanityPharmaText getVanityPharmaText() {
+    public com.google.ads.googleads.v1.enums.NegativeGeoTargetTypeEnum.NegativeGeoTargetType getNegativeGeoTargetType() {
       @SuppressWarnings("deprecation")
-      com.google.ads.googleads.v1.enums.VanityPharmaTextEnum.VanityPharmaText result = com.google.ads.googleads.v1.enums.VanityPharmaTextEnum.VanityPharmaText.valueOf(vanityPharmaText_);
-      return result == null ? com.google.ads.googleads.v1.enums.VanityPharmaTextEnum.VanityPharmaText.UNRECOGNIZED : result;
+      com.google.ads.googleads.v1.enums.NegativeGeoTargetTypeEnum.NegativeGeoTargetType result = com.google.ads.googleads.v1.enums.NegativeGeoTargetTypeEnum.NegativeGeoTargetType.valueOf(negativeGeoTargetType_);
+      return result == null ? com.google.ads.googleads.v1.enums.NegativeGeoTargetTypeEnum.NegativeGeoTargetType.UNRECOGNIZED : result;
     }
 
     private byte memoizedIsInitialized = -1;
@@ -8542,11 +9451,11 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (vanityPharmaDisplayUrlMode_ != com.google.ads.googleads.v1.enums.VanityPharmaDisplayUrlModeEnum.VanityPharmaDisplayUrlMode.UNSPECIFIED.getNumber()) {
-        output.writeEnum(1, vanityPharmaDisplayUrlMode_);
+      if (positiveGeoTargetType_ != com.google.ads.googleads.v1.enums.PositiveGeoTargetTypeEnum.PositiveGeoTargetType.UNSPECIFIED.getNumber()) {
+        output.writeEnum(1, positiveGeoTargetType_);
       }
-      if (vanityPharmaText_ != com.google.ads.googleads.v1.enums.VanityPharmaTextEnum.VanityPharmaText.UNSPECIFIED.getNumber()) {
-        output.writeEnum(2, vanityPharmaText_);
+      if (negativeGeoTargetType_ != com.google.ads.googleads.v1.enums.NegativeGeoTargetTypeEnum.NegativeGeoTargetType.UNSPECIFIED.getNumber()) {
+        output.writeEnum(2, negativeGeoTargetType_);
       }
       unknownFields.writeTo(output);
     }
@@ -8557,13 +9466,13 @@ private static final long serialVersionUID = 0L;
       if (size != -1) return size;
 
       size = 0;
-      if (vanityPharmaDisplayUrlMode_ != com.google.ads.googleads.v1.enums.VanityPharmaDisplayUrlModeEnum.VanityPharmaDisplayUrlMode.UNSPECIFIED.getNumber()) {
+      if (positiveGeoTargetType_ != com.google.ads.googleads.v1.enums.PositiveGeoTargetTypeEnum.PositiveGeoTargetType.UNSPECIFIED.getNumber()) {
         size += com.google.protobuf.CodedOutputStream
-          .computeEnumSize(1, vanityPharmaDisplayUrlMode_);
+          .computeEnumSize(1, positiveGeoTargetType_);
       }
-      if (vanityPharmaText_ != com.google.ads.googleads.v1.enums.VanityPharmaTextEnum.VanityPharmaText.UNSPECIFIED.getNumber()) {
+      if (negativeGeoTargetType_ != com.google.ads.googleads.v1.enums.NegativeGeoTargetTypeEnum.NegativeGeoTargetType.UNSPECIFIED.getNumber()) {
         size += com.google.protobuf.CodedOutputStream
-          .computeEnumSize(2, vanityPharmaText_);
+          .computeEnumSize(2, negativeGeoTargetType_);
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -8575,14 +9484,14 @@ private static final long serialVersionUID = 0L;
       if (obj == this) {
        return true;
       }
-      if (!(obj instanceof com.google.ads.googleads.v1.resources.Campaign.VanityPharma)) {
+      if (!(obj instanceof com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting)) {
         return super.equals(obj);
       }
-      com.google.ads.googleads.v1.resources.Campaign.VanityPharma other = (com.google.ads.googleads.v1.resources.Campaign.VanityPharma) obj;
+      com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting other = (com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting) obj;
 
       boolean result = true;
-      result = result && vanityPharmaDisplayUrlMode_ == other.vanityPharmaDisplayUrlMode_;
-      result = result && vanityPharmaText_ == other.vanityPharmaText_;
+      result = result && positiveGeoTargetType_ == other.positiveGeoTargetType_;
+      result = result && negativeGeoTargetType_ == other.negativeGeoTargetType_;
       result = result && unknownFields.equals(other.unknownFields);
       return result;
     }
@@ -8594,78 +9503,78 @@ private static final long serialVersionUID = 0L;
       }
       int hash = 41;
       hash = (19 * hash) + getDescriptor().hashCode();
-      hash = (37 * hash) + VANITY_PHARMA_DISPLAY_URL_MODE_FIELD_NUMBER;
-      hash = (53 * hash) + vanityPharmaDisplayUrlMode_;
-      hash = (37 * hash) + VANITY_PHARMA_TEXT_FIELD_NUMBER;
-      hash = (53 * hash) + vanityPharmaText_;
+      hash = (37 * hash) + POSITIVE_GEO_TARGET_TYPE_FIELD_NUMBER;
+      hash = (53 * hash) + positiveGeoTargetType_;
+      hash = (37 * hash) + NEGATIVE_GEO_TARGET_TYPE_FIELD_NUMBER;
+      hash = (53 * hash) + negativeGeoTargetType_;
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
       return hash;
     }
 
-    public static com.google.ads.googleads.v1.resources.Campaign.VanityPharma parseFrom(
+    public static com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting parseFrom(
         java.nio.ByteBuffer data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static com.google.ads.googleads.v1.resources.Campaign.VanityPharma parseFrom(
+    public static com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting parseFrom(
         java.nio.ByteBuffer data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static com.google.ads.googleads.v1.resources.Campaign.VanityPharma parseFrom(
+    public static com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static com.google.ads.googleads.v1.resources.Campaign.VanityPharma parseFrom(
+    public static com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static com.google.ads.googleads.v1.resources.Campaign.VanityPharma parseFrom(byte[] data)
+    public static com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static com.google.ads.googleads.v1.resources.Campaign.VanityPharma parseFrom(
+    public static com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static com.google.ads.googleads.v1.resources.Campaign.VanityPharma parseFrom(java.io.InputStream input)
+    public static com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting parseFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static com.google.ads.googleads.v1.resources.Campaign.VanityPharma parseFrom(
+    public static com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
-    public static com.google.ads.googleads.v1.resources.Campaign.VanityPharma parseDelimitedFrom(java.io.InputStream input)
+    public static com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
-    public static com.google.ads.googleads.v1.resources.Campaign.VanityPharma parseDelimitedFrom(
+    public static com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
-    public static com.google.ads.googleads.v1.resources.Campaign.VanityPharma parseFrom(
+    public static com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static com.google.ads.googleads.v1.resources.Campaign.VanityPharma parseFrom(
+    public static com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
@@ -8678,7 +9587,7 @@ private static final long serialVersionUID = 0L;
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
     }
-    public static Builder newBuilder(com.google.ads.googleads.v1.resources.Campaign.VanityPharma prototype) {
+    public static Builder newBuilder(com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
     @java.lang.Override
@@ -8695,29 +9604,29 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * Describes how unbranded pharma ads will be displayed.
+     * Represents a collection of settings related to ads geotargeting.
      * </pre>
      *
-     * Protobuf type {@code google.ads.googleads.v1.resources.Campaign.VanityPharma}
+     * Protobuf type {@code google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting}
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:google.ads.googleads.v1.resources.Campaign.VanityPharma)
-        com.google.ads.googleads.v1.resources.Campaign.VanityPharmaOrBuilder {
+        // @@protoc_insertion_point(builder_implements:google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting)
+        com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSettingOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return com.google.ads.googleads.v1.resources.CampaignProto.internal_static_google_ads_googleads_v1_resources_Campaign_VanityPharma_descriptor;
+        return com.google.ads.googleads.v1.resources.CampaignProto.internal_static_google_ads_googleads_v1_resources_Campaign_GeoTargetTypeSetting_descriptor;
       }
 
       @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return com.google.ads.googleads.v1.resources.CampaignProto.internal_static_google_ads_googleads_v1_resources_Campaign_VanityPharma_fieldAccessorTable
+        return com.google.ads.googleads.v1.resources.CampaignProto.internal_static_google_ads_googleads_v1_resources_Campaign_GeoTargetTypeSetting_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
-                com.google.ads.googleads.v1.resources.Campaign.VanityPharma.class, com.google.ads.googleads.v1.resources.Campaign.VanityPharma.Builder.class);
+                com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting.class, com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting.Builder.class);
       }
 
-      // Construct using com.google.ads.googleads.v1.resources.Campaign.VanityPharma.newBuilder()
+      // Construct using com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting.newBuilder()
       private Builder() {
         maybeForceBuilderInitialization();
       }
@@ -8735,9 +9644,9 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public Builder clear() {
         super.clear();
-        vanityPharmaDisplayUrlMode_ = 0;
+        positiveGeoTargetType_ = 0;
 
-        vanityPharmaText_ = 0;
+        negativeGeoTargetType_ = 0;
 
         return this;
       }
@@ -8745,17 +9654,17 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return com.google.ads.googleads.v1.resources.CampaignProto.internal_static_google_ads_googleads_v1_resources_Campaign_VanityPharma_descriptor;
+        return com.google.ads.googleads.v1.resources.CampaignProto.internal_static_google_ads_googleads_v1_resources_Campaign_GeoTargetTypeSetting_descriptor;
       }
 
       @java.lang.Override
-      public com.google.ads.googleads.v1.resources.Campaign.VanityPharma getDefaultInstanceForType() {
-        return com.google.ads.googleads.v1.resources.Campaign.VanityPharma.getDefaultInstance();
+      public com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting getDefaultInstanceForType() {
+        return com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting.getDefaultInstance();
       }
 
       @java.lang.Override
-      public com.google.ads.googleads.v1.resources.Campaign.VanityPharma build() {
-        com.google.ads.googleads.v1.resources.Campaign.VanityPharma result = buildPartial();
+      public com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting build() {
+        com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting result = buildPartial();
         if (!result.isInitialized()) {
           throw newUninitializedMessageException(result);
         }
@@ -8763,10 +9672,10 @@ private static final long serialVersionUID = 0L;
       }
 
       @java.lang.Override
-      public com.google.ads.googleads.v1.resources.Campaign.VanityPharma buildPartial() {
-        com.google.ads.googleads.v1.resources.Campaign.VanityPharma result = new com.google.ads.googleads.v1.resources.Campaign.VanityPharma(this);
-        result.vanityPharmaDisplayUrlMode_ = vanityPharmaDisplayUrlMode_;
-        result.vanityPharmaText_ = vanityPharmaText_;
+      public com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting buildPartial() {
+        com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting result = new com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting(this);
+        result.positiveGeoTargetType_ = positiveGeoTargetType_;
+        result.negativeGeoTargetType_ = negativeGeoTargetType_;
         onBuilt();
         return result;
       }
@@ -8805,21 +9714,21 @@ private static final long serialVersionUID = 0L;
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof com.google.ads.googleads.v1.resources.Campaign.VanityPharma) {
-          return mergeFrom((com.google.ads.googleads.v1.resources.Campaign.VanityPharma)other);
+        if (other instanceof com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting) {
+          return mergeFrom((com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting)other);
         } else {
           super.mergeFrom(other);
           return this;
         }
       }
 
-      public Builder mergeFrom(com.google.ads.googleads.v1.resources.Campaign.VanityPharma other) {
-        if (other == com.google.ads.googleads.v1.resources.Campaign.VanityPharma.getDefaultInstance()) return this;
-        if (other.vanityPharmaDisplayUrlMode_ != 0) {
-          setVanityPharmaDisplayUrlModeValue(other.getVanityPharmaDisplayUrlModeValue());
+      public Builder mergeFrom(com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting other) {
+        if (other == com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting.getDefaultInstance()) return this;
+        if (other.positiveGeoTargetType_ != 0) {
+          setPositiveGeoTargetTypeValue(other.getPositiveGeoTargetTypeValue());
         }
-        if (other.vanityPharmaText_ != 0) {
-          setVanityPharmaTextValue(other.getVanityPharmaTextValue());
+        if (other.negativeGeoTargetType_ != 0) {
+          setNegativeGeoTargetTypeValue(other.getNegativeGeoTargetTypeValue());
         }
         this.mergeUnknownFields(other.unknownFields);
         onChanged();
@@ -8836,11 +9745,11 @@ private static final long serialVersionUID = 0L;
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        com.google.ads.googleads.v1.resources.Campaign.VanityPharma parsedMessage = null;
+        com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting parsedMessage = null;
         try {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (com.google.ads.googleads.v1.resources.Campaign.VanityPharma) e.getUnfinishedMessage();
+          parsedMessage = (com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
@@ -8850,137 +9759,132 @@ private static final long serialVersionUID = 0L;
         return this;
       }
 
-      private int vanityPharmaDisplayUrlMode_ = 0;
+      private int positiveGeoTargetType_ = 0;
       /**
        * <pre>
-       * The display mode for vanity pharma URLs.
+       * The setting used for positive geotargeting in this particular campaign.
        * </pre>
        *
-       * <code>.google.ads.googleads.v1.enums.VanityPharmaDisplayUrlModeEnum.VanityPharmaDisplayUrlMode vanity_pharma_display_url_mode = 1;</code>
+       * <code>.google.ads.googleads.v1.enums.PositiveGeoTargetTypeEnum.PositiveGeoTargetType positive_geo_target_type = 1;</code>
        */
-      public int getVanityPharmaDisplayUrlModeValue() {
-        return vanityPharmaDisplayUrlMode_;
+      public int getPositiveGeoTargetTypeValue() {
+        return positiveGeoTargetType_;
       }
       /**
        * <pre>
-       * The display mode for vanity pharma URLs.
+       * The setting used for positive geotargeting in this particular campaign.
        * </pre>
        *
-       * <code>.google.ads.googleads.v1.enums.VanityPharmaDisplayUrlModeEnum.VanityPharmaDisplayUrlMode vanity_pharma_display_url_mode = 1;</code>
+       * <code>.google.ads.googleads.v1.enums.PositiveGeoTargetTypeEnum.PositiveGeoTargetType positive_geo_target_type = 1;</code>
        */
-      public Builder setVanityPharmaDisplayUrlModeValue(int value) {
-        vanityPharmaDisplayUrlMode_ = value;
+      public Builder setPositiveGeoTargetTypeValue(int value) {
+        positiveGeoTargetType_ = value;
         onChanged();
         return this;
       }
       /**
        * <pre>
-       * The display mode for vanity pharma URLs.
+       * The setting used for positive geotargeting in this particular campaign.
        * </pre>
        *
-       * <code>.google.ads.googleads.v1.enums.VanityPharmaDisplayUrlModeEnum.VanityPharmaDisplayUrlMode vanity_pharma_display_url_mode = 1;</code>
+       * <code>.google.ads.googleads.v1.enums.PositiveGeoTargetTypeEnum.PositiveGeoTargetType positive_geo_target_type = 1;</code>
        */
-      public com.google.ads.googleads.v1.enums.VanityPharmaDisplayUrlModeEnum.VanityPharmaDisplayUrlMode getVanityPharmaDisplayUrlMode() {
+      public com.google.ads.googleads.v1.enums.PositiveGeoTargetTypeEnum.PositiveGeoTargetType getPositiveGeoTargetType() {
         @SuppressWarnings("deprecation")
-        com.google.ads.googleads.v1.enums.VanityPharmaDisplayUrlModeEnum.VanityPharmaDisplayUrlMode result = com.google.ads.googleads.v1.enums.VanityPharmaDisplayUrlModeEnum.VanityPharmaDisplayUrlMode.valueOf(vanityPharmaDisplayUrlMode_);
-        return result == null ? com.google.ads.googleads.v1.enums.VanityPharmaDisplayUrlModeEnum.VanityPharmaDisplayUrlMode.UNRECOGNIZED : result;
+        com.google.ads.googleads.v1.enums.PositiveGeoTargetTypeEnum.PositiveGeoTargetType result = com.google.ads.googleads.v1.enums.PositiveGeoTargetTypeEnum.PositiveGeoTargetType.valueOf(positiveGeoTargetType_);
+        return result == null ? com.google.ads.googleads.v1.enums.PositiveGeoTargetTypeEnum.PositiveGeoTargetType.UNRECOGNIZED : result;
       }
       /**
        * <pre>
-       * The display mode for vanity pharma URLs.
+       * The setting used for positive geotargeting in this particular campaign.
        * </pre>
        *
-       * <code>.google.ads.googleads.v1.enums.VanityPharmaDisplayUrlModeEnum.VanityPharmaDisplayUrlMode vanity_pharma_display_url_mode = 1;</code>
+       * <code>.google.ads.googleads.v1.enums.PositiveGeoTargetTypeEnum.PositiveGeoTargetType positive_geo_target_type = 1;</code>
        */
-      public Builder setVanityPharmaDisplayUrlMode(com.google.ads.googleads.v1.enums.VanityPharmaDisplayUrlModeEnum.VanityPharmaDisplayUrlMode value) {
+      public Builder setPositiveGeoTargetType(com.google.ads.googleads.v1.enums.PositiveGeoTargetTypeEnum.PositiveGeoTargetType value) {
         if (value == null) {
           throw new NullPointerException();
         }
         
-        vanityPharmaDisplayUrlMode_ = value.getNumber();
+        positiveGeoTargetType_ = value.getNumber();
         onChanged();
         return this;
       }
       /**
        * <pre>
-       * The display mode for vanity pharma URLs.
+       * The setting used for positive geotargeting in this particular campaign.
        * </pre>
        *
-       * <code>.google.ads.googleads.v1.enums.VanityPharmaDisplayUrlModeEnum.VanityPharmaDisplayUrlMode vanity_pharma_display_url_mode = 1;</code>
+       * <code>.google.ads.googleads.v1.enums.PositiveGeoTargetTypeEnum.PositiveGeoTargetType positive_geo_target_type = 1;</code>
        */
-      public Builder clearVanityPharmaDisplayUrlMode() {
+      public Builder clearPositiveGeoTargetType() {
         
-        vanityPharmaDisplayUrlMode_ = 0;
+        positiveGeoTargetType_ = 0;
         onChanged();
         return this;
       }
 
-      private int vanityPharmaText_ = 0;
+      private int negativeGeoTargetType_ = 0;
       /**
        * <pre>
-       * The text that will be displayed in display URL of the text ad when
-       * website description is the selected display mode for vanity pharma URLs.
+       * The setting used for negative geotargeting in this particular campaign.
        * </pre>
        *
-       * <code>.google.ads.googleads.v1.enums.VanityPharmaTextEnum.VanityPharmaText vanity_pharma_text = 2;</code>
+       * <code>.google.ads.googleads.v1.enums.NegativeGeoTargetTypeEnum.NegativeGeoTargetType negative_geo_target_type = 2;</code>
        */
-      public int getVanityPharmaTextValue() {
-        return vanityPharmaText_;
+      public int getNegativeGeoTargetTypeValue() {
+        return negativeGeoTargetType_;
       }
       /**
        * <pre>
-       * The text that will be displayed in display URL of the text ad when
-       * website description is the selected display mode for vanity pharma URLs.
+       * The setting used for negative geotargeting in this particular campaign.
        * </pre>
        *
-       * <code>.google.ads.googleads.v1.enums.VanityPharmaTextEnum.VanityPharmaText vanity_pharma_text = 2;</code>
+       * <code>.google.ads.googleads.v1.enums.NegativeGeoTargetTypeEnum.NegativeGeoTargetType negative_geo_target_type = 2;</code>
        */
-      public Builder setVanityPharmaTextValue(int value) {
-        vanityPharmaText_ = value;
+      public Builder setNegativeGeoTargetTypeValue(int value) {
+        negativeGeoTargetType_ = value;
         onChanged();
         return this;
       }
       /**
        * <pre>
-       * The text that will be displayed in display URL of the text ad when
-       * website description is the selected display mode for vanity pharma URLs.
+       * The setting used for negative geotargeting in this particular campaign.
        * </pre>
        *
-       * <code>.google.ads.googleads.v1.enums.VanityPharmaTextEnum.VanityPharmaText vanity_pharma_text = 2;</code>
+       * <code>.google.ads.googleads.v1.enums.NegativeGeoTargetTypeEnum.NegativeGeoTargetType negative_geo_target_type = 2;</code>
        */
-      public com.google.ads.googleads.v1.enums.VanityPharmaTextEnum.VanityPharmaText getVanityPharmaText() {
+      public com.google.ads.googleads.v1.enums.NegativeGeoTargetTypeEnum.NegativeGeoTargetType getNegativeGeoTargetType() {
         @SuppressWarnings("deprecation")
-        com.google.ads.googleads.v1.enums.VanityPharmaTextEnum.VanityPharmaText result = com.google.ads.googleads.v1.enums.VanityPharmaTextEnum.VanityPharmaText.valueOf(vanityPharmaText_);
-        return result == null ? com.google.ads.googleads.v1.enums.VanityPharmaTextEnum.VanityPharmaText.UNRECOGNIZED : result;
+        com.google.ads.googleads.v1.enums.NegativeGeoTargetTypeEnum.NegativeGeoTargetType result = com.google.ads.googleads.v1.enums.NegativeGeoTargetTypeEnum.NegativeGeoTargetType.valueOf(negativeGeoTargetType_);
+        return result == null ? com.google.ads.googleads.v1.enums.NegativeGeoTargetTypeEnum.NegativeGeoTargetType.UNRECOGNIZED : result;
       }
       /**
        * <pre>
-       * The text that will be displayed in display URL of the text ad when
-       * website description is the selected display mode for vanity pharma URLs.
+       * The setting used for negative geotargeting in this particular campaign.
        * </pre>
        *
-       * <code>.google.ads.googleads.v1.enums.VanityPharmaTextEnum.VanityPharmaText vanity_pharma_text = 2;</code>
+       * <code>.google.ads.googleads.v1.enums.NegativeGeoTargetTypeEnum.NegativeGeoTargetType negative_geo_target_type = 2;</code>
        */
-      public Builder setVanityPharmaText(com.google.ads.googleads.v1.enums.VanityPharmaTextEnum.VanityPharmaText value) {
+      public Builder setNegativeGeoTargetType(com.google.ads.googleads.v1.enums.NegativeGeoTargetTypeEnum.NegativeGeoTargetType value) {
         if (value == null) {
           throw new NullPointerException();
         }
         
-        vanityPharmaText_ = value.getNumber();
+        negativeGeoTargetType_ = value.getNumber();
         onChanged();
         return this;
       }
       /**
        * <pre>
-       * The text that will be displayed in display URL of the text ad when
-       * website description is the selected display mode for vanity pharma URLs.
+       * The setting used for negative geotargeting in this particular campaign.
        * </pre>
        *
-       * <code>.google.ads.googleads.v1.enums.VanityPharmaTextEnum.VanityPharmaText vanity_pharma_text = 2;</code>
+       * <code>.google.ads.googleads.v1.enums.NegativeGeoTargetTypeEnum.NegativeGeoTargetType negative_geo_target_type = 2;</code>
        */
-      public Builder clearVanityPharmaText() {
+      public Builder clearNegativeGeoTargetType() {
         
-        vanityPharmaText_ = 0;
+        negativeGeoTargetType_ = 0;
         onChanged();
         return this;
       }
@@ -8997,945 +9901,41 @@ private static final long serialVersionUID = 0L;
       }
 
 
-      // @@protoc_insertion_point(builder_scope:google.ads.googleads.v1.resources.Campaign.VanityPharma)
+      // @@protoc_insertion_point(builder_scope:google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting)
     }
 
-    // @@protoc_insertion_point(class_scope:google.ads.googleads.v1.resources.Campaign.VanityPharma)
-    private static final com.google.ads.googleads.v1.resources.Campaign.VanityPharma DEFAULT_INSTANCE;
+    // @@protoc_insertion_point(class_scope:google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting)
+    private static final com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting DEFAULT_INSTANCE;
     static {
-      DEFAULT_INSTANCE = new com.google.ads.googleads.v1.resources.Campaign.VanityPharma();
+      DEFAULT_INSTANCE = new com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting();
     }
 
-    public static com.google.ads.googleads.v1.resources.Campaign.VanityPharma getDefaultInstance() {
+    public static com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting getDefaultInstance() {
       return DEFAULT_INSTANCE;
     }
 
-    private static final com.google.protobuf.Parser<VanityPharma>
-        PARSER = new com.google.protobuf.AbstractParser<VanityPharma>() {
+    private static final com.google.protobuf.Parser<GeoTargetTypeSetting>
+        PARSER = new com.google.protobuf.AbstractParser<GeoTargetTypeSetting>() {
       @java.lang.Override
-      public VanityPharma parsePartialFrom(
+      public GeoTargetTypeSetting parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new VanityPharma(input, extensionRegistry);
+        return new GeoTargetTypeSetting(input, extensionRegistry);
       }
     };
 
-    public static com.google.protobuf.Parser<VanityPharma> parser() {
+    public static com.google.protobuf.Parser<GeoTargetTypeSetting> parser() {
       return PARSER;
     }
 
     @java.lang.Override
-    public com.google.protobuf.Parser<VanityPharma> getParserForType() {
+    public com.google.protobuf.Parser<GeoTargetTypeSetting> getParserForType() {
       return PARSER;
     }
 
     @java.lang.Override
-    public com.google.ads.googleads.v1.resources.Campaign.VanityPharma getDefaultInstanceForType() {
-      return DEFAULT_INSTANCE;
-    }
-
-  }
-
-  public interface SelectiveOptimizationOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:google.ads.googleads.v1.resources.Campaign.SelectiveOptimization)
-      com.google.protobuf.MessageOrBuilder {
-
-    /**
-     * <pre>
-     * The selected set of conversion actions for optimizing this campaign.
-     * </pre>
-     *
-     * <code>repeated .google.protobuf.StringValue conversion_actions = 1;</code>
-     */
-    java.util.List<com.google.protobuf.StringValue> 
-        getConversionActionsList();
-    /**
-     * <pre>
-     * The selected set of conversion actions for optimizing this campaign.
-     * </pre>
-     *
-     * <code>repeated .google.protobuf.StringValue conversion_actions = 1;</code>
-     */
-    com.google.protobuf.StringValue getConversionActions(int index);
-    /**
-     * <pre>
-     * The selected set of conversion actions for optimizing this campaign.
-     * </pre>
-     *
-     * <code>repeated .google.protobuf.StringValue conversion_actions = 1;</code>
-     */
-    int getConversionActionsCount();
-    /**
-     * <pre>
-     * The selected set of conversion actions for optimizing this campaign.
-     * </pre>
-     *
-     * <code>repeated .google.protobuf.StringValue conversion_actions = 1;</code>
-     */
-    java.util.List<? extends com.google.protobuf.StringValueOrBuilder> 
-        getConversionActionsOrBuilderList();
-    /**
-     * <pre>
-     * The selected set of conversion actions for optimizing this campaign.
-     * </pre>
-     *
-     * <code>repeated .google.protobuf.StringValue conversion_actions = 1;</code>
-     */
-    com.google.protobuf.StringValueOrBuilder getConversionActionsOrBuilder(
-        int index);
-  }
-  /**
-   * <pre>
-   * Selective optimization setting for this campaign, which includes a set of
-   * conversion actions to optimize this campaign towards.
-   * </pre>
-   *
-   * Protobuf type {@code google.ads.googleads.v1.resources.Campaign.SelectiveOptimization}
-   */
-  public  static final class SelectiveOptimization extends
-      com.google.protobuf.GeneratedMessageV3 implements
-      // @@protoc_insertion_point(message_implements:google.ads.googleads.v1.resources.Campaign.SelectiveOptimization)
-      SelectiveOptimizationOrBuilder {
-  private static final long serialVersionUID = 0L;
-    // Use SelectiveOptimization.newBuilder() to construct.
-    private SelectiveOptimization(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
-      super(builder);
-    }
-    private SelectiveOptimization() {
-      conversionActions_ = java.util.Collections.emptyList();
-    }
-
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
-    private SelectiveOptimization(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            case 10: {
-              if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
-                conversionActions_ = new java.util.ArrayList<com.google.protobuf.StringValue>();
-                mutable_bitField0_ |= 0x00000001;
-              }
-              conversionActions_.add(
-                  input.readMessage(com.google.protobuf.StringValue.parser(), extensionRegistry));
-              break;
-            }
-            default: {
-              if (!parseUnknownFieldProto3(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e).setUnfinishedMessage(this);
-      } finally {
-        if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
-          conversionActions_ = java.util.Collections.unmodifiableList(conversionActions_);
-        }
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return com.google.ads.googleads.v1.resources.CampaignProto.internal_static_google_ads_googleads_v1_resources_Campaign_SelectiveOptimization_descriptor;
-    }
-
-    @java.lang.Override
-    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-        internalGetFieldAccessorTable() {
-      return com.google.ads.googleads.v1.resources.CampaignProto.internal_static_google_ads_googleads_v1_resources_Campaign_SelectiveOptimization_fieldAccessorTable
-          .ensureFieldAccessorsInitialized(
-              com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization.class, com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization.Builder.class);
-    }
-
-    public static final int CONVERSION_ACTIONS_FIELD_NUMBER = 1;
-    private java.util.List<com.google.protobuf.StringValue> conversionActions_;
-    /**
-     * <pre>
-     * The selected set of conversion actions for optimizing this campaign.
-     * </pre>
-     *
-     * <code>repeated .google.protobuf.StringValue conversion_actions = 1;</code>
-     */
-    public java.util.List<com.google.protobuf.StringValue> getConversionActionsList() {
-      return conversionActions_;
-    }
-    /**
-     * <pre>
-     * The selected set of conversion actions for optimizing this campaign.
-     * </pre>
-     *
-     * <code>repeated .google.protobuf.StringValue conversion_actions = 1;</code>
-     */
-    public java.util.List<? extends com.google.protobuf.StringValueOrBuilder> 
-        getConversionActionsOrBuilderList() {
-      return conversionActions_;
-    }
-    /**
-     * <pre>
-     * The selected set of conversion actions for optimizing this campaign.
-     * </pre>
-     *
-     * <code>repeated .google.protobuf.StringValue conversion_actions = 1;</code>
-     */
-    public int getConversionActionsCount() {
-      return conversionActions_.size();
-    }
-    /**
-     * <pre>
-     * The selected set of conversion actions for optimizing this campaign.
-     * </pre>
-     *
-     * <code>repeated .google.protobuf.StringValue conversion_actions = 1;</code>
-     */
-    public com.google.protobuf.StringValue getConversionActions(int index) {
-      return conversionActions_.get(index);
-    }
-    /**
-     * <pre>
-     * The selected set of conversion actions for optimizing this campaign.
-     * </pre>
-     *
-     * <code>repeated .google.protobuf.StringValue conversion_actions = 1;</code>
-     */
-    public com.google.protobuf.StringValueOrBuilder getConversionActionsOrBuilder(
-        int index) {
-      return conversionActions_.get(index);
-    }
-
-    private byte memoizedIsInitialized = -1;
-    @java.lang.Override
-    public final boolean isInitialized() {
-      byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
-
-      memoizedIsInitialized = 1;
-      return true;
-    }
-
-    @java.lang.Override
-    public void writeTo(com.google.protobuf.CodedOutputStream output)
-                        throws java.io.IOException {
-      for (int i = 0; i < conversionActions_.size(); i++) {
-        output.writeMessage(1, conversionActions_.get(i));
-      }
-      unknownFields.writeTo(output);
-    }
-
-    @java.lang.Override
-    public int getSerializedSize() {
-      int size = memoizedSize;
-      if (size != -1) return size;
-
-      size = 0;
-      for (int i = 0; i < conversionActions_.size(); i++) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(1, conversionActions_.get(i));
-      }
-      size += unknownFields.getSerializedSize();
-      memoizedSize = size;
-      return size;
-    }
-
-    @java.lang.Override
-    public boolean equals(final java.lang.Object obj) {
-      if (obj == this) {
-       return true;
-      }
-      if (!(obj instanceof com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization)) {
-        return super.equals(obj);
-      }
-      com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization other = (com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization) obj;
-
-      boolean result = true;
-      result = result && getConversionActionsList()
-          .equals(other.getConversionActionsList());
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
-    }
-
-    @java.lang.Override
-    public int hashCode() {
-      if (memoizedHashCode != 0) {
-        return memoizedHashCode;
-      }
-      int hash = 41;
-      hash = (19 * hash) + getDescriptor().hashCode();
-      if (getConversionActionsCount() > 0) {
-        hash = (37 * hash) + CONVERSION_ACTIONS_FIELD_NUMBER;
-        hash = (53 * hash) + getConversionActionsList().hashCode();
-      }
-      hash = (29 * hash) + unknownFields.hashCode();
-      memoizedHashCode = hash;
-      return hash;
-    }
-
-    public static com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization parseFrom(
-        java.nio.ByteBuffer data)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
-    }
-    public static com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization parseFrom(
-        java.nio.ByteBuffer data,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
-    }
-    public static com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization parseFrom(
-        com.google.protobuf.ByteString data)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
-    }
-    public static com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization parseFrom(
-        com.google.protobuf.ByteString data,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
-    }
-    public static com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization parseFrom(byte[] data)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
-    }
-    public static com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization parseFrom(
-        byte[] data,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
-    }
-    public static com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization parseFrom(java.io.InputStream input)
-        throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
-          .parseWithIOException(PARSER, input);
-    }
-    public static com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization parseFrom(
-        java.io.InputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
-          .parseWithIOException(PARSER, input, extensionRegistry);
-    }
-    public static com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization parseDelimitedFrom(java.io.InputStream input)
-        throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
-          .parseDelimitedWithIOException(PARSER, input);
-    }
-    public static com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization parseDelimitedFrom(
-        java.io.InputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
-          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
-    }
-    public static com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization parseFrom(
-        com.google.protobuf.CodedInputStream input)
-        throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
-          .parseWithIOException(PARSER, input);
-    }
-    public static com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization parseFrom(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
-          .parseWithIOException(PARSER, input, extensionRegistry);
-    }
-
-    @java.lang.Override
-    public Builder newBuilderForType() { return newBuilder(); }
-    public static Builder newBuilder() {
-      return DEFAULT_INSTANCE.toBuilder();
-    }
-    public static Builder newBuilder(com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization prototype) {
-      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
-    }
-    @java.lang.Override
-    public Builder toBuilder() {
-      return this == DEFAULT_INSTANCE
-          ? new Builder() : new Builder().mergeFrom(this);
-    }
-
-    @java.lang.Override
-    protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
-      Builder builder = new Builder(parent);
-      return builder;
-    }
-    /**
-     * <pre>
-     * Selective optimization setting for this campaign, which includes a set of
-     * conversion actions to optimize this campaign towards.
-     * </pre>
-     *
-     * Protobuf type {@code google.ads.googleads.v1.resources.Campaign.SelectiveOptimization}
-     */
-    public static final class Builder extends
-        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:google.ads.googleads.v1.resources.Campaign.SelectiveOptimization)
-        com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimizationOrBuilder {
-      public static final com.google.protobuf.Descriptors.Descriptor
-          getDescriptor() {
-        return com.google.ads.googleads.v1.resources.CampaignProto.internal_static_google_ads_googleads_v1_resources_Campaign_SelectiveOptimization_descriptor;
-      }
-
-      @java.lang.Override
-      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-          internalGetFieldAccessorTable() {
-        return com.google.ads.googleads.v1.resources.CampaignProto.internal_static_google_ads_googleads_v1_resources_Campaign_SelectiveOptimization_fieldAccessorTable
-            .ensureFieldAccessorsInitialized(
-                com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization.class, com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization.Builder.class);
-      }
-
-      // Construct using com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization.newBuilder()
-      private Builder() {
-        maybeForceBuilderInitialization();
-      }
-
-      private Builder(
-          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
-        super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessageV3
-                .alwaysUseFieldBuilders) {
-          getConversionActionsFieldBuilder();
-        }
-      }
-      @java.lang.Override
-      public Builder clear() {
-        super.clear();
-        if (conversionActionsBuilder_ == null) {
-          conversionActions_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000001);
-        } else {
-          conversionActionsBuilder_.clear();
-        }
-        return this;
-      }
-
-      @java.lang.Override
-      public com.google.protobuf.Descriptors.Descriptor
-          getDescriptorForType() {
-        return com.google.ads.googleads.v1.resources.CampaignProto.internal_static_google_ads_googleads_v1_resources_Campaign_SelectiveOptimization_descriptor;
-      }
-
-      @java.lang.Override
-      public com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization getDefaultInstanceForType() {
-        return com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization.getDefaultInstance();
-      }
-
-      @java.lang.Override
-      public com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization build() {
-        com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization result = buildPartial();
-        if (!result.isInitialized()) {
-          throw newUninitializedMessageException(result);
-        }
-        return result;
-      }
-
-      @java.lang.Override
-      public com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization buildPartial() {
-        com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization result = new com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization(this);
-        int from_bitField0_ = bitField0_;
-        if (conversionActionsBuilder_ == null) {
-          if (((bitField0_ & 0x00000001) == 0x00000001)) {
-            conversionActions_ = java.util.Collections.unmodifiableList(conversionActions_);
-            bitField0_ = (bitField0_ & ~0x00000001);
-          }
-          result.conversionActions_ = conversionActions_;
-        } else {
-          result.conversionActions_ = conversionActionsBuilder_.build();
-        }
-        onBuilt();
-        return result;
-      }
-
-      @java.lang.Override
-      public Builder clone() {
-        return (Builder) super.clone();
-      }
-      @java.lang.Override
-      public Builder setField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return (Builder) super.setField(field, value);
-      }
-      @java.lang.Override
-      public Builder clearField(
-          com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
-      }
-      @java.lang.Override
-      public Builder clearOneof(
-          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
-      }
-      @java.lang.Override
-      public Builder setRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
-      }
-      @java.lang.Override
-      public Builder addRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
-      }
-      @java.lang.Override
-      public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization) {
-          return mergeFrom((com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization)other);
-        } else {
-          super.mergeFrom(other);
-          return this;
-        }
-      }
-
-      public Builder mergeFrom(com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization other) {
-        if (other == com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization.getDefaultInstance()) return this;
-        if (conversionActionsBuilder_ == null) {
-          if (!other.conversionActions_.isEmpty()) {
-            if (conversionActions_.isEmpty()) {
-              conversionActions_ = other.conversionActions_;
-              bitField0_ = (bitField0_ & ~0x00000001);
-            } else {
-              ensureConversionActionsIsMutable();
-              conversionActions_.addAll(other.conversionActions_);
-            }
-            onChanged();
-          }
-        } else {
-          if (!other.conversionActions_.isEmpty()) {
-            if (conversionActionsBuilder_.isEmpty()) {
-              conversionActionsBuilder_.dispose();
-              conversionActionsBuilder_ = null;
-              conversionActions_ = other.conversionActions_;
-              bitField0_ = (bitField0_ & ~0x00000001);
-              conversionActionsBuilder_ = 
-                com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
-                   getConversionActionsFieldBuilder() : null;
-            } else {
-              conversionActionsBuilder_.addAllMessages(other.conversionActions_);
-            }
-          }
-        }
-        this.mergeUnknownFields(other.unknownFields);
-        onChanged();
-        return this;
-      }
-
-      @java.lang.Override
-      public final boolean isInitialized() {
-        return true;
-      }
-
-      @java.lang.Override
-      public Builder mergeFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws java.io.IOException {
-        com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization parsedMessage = null;
-        try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization) e.getUnfinishedMessage();
-          throw e.unwrapIOException();
-        } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
-        return this;
-      }
-      private int bitField0_;
-
-      private java.util.List<com.google.protobuf.StringValue> conversionActions_ =
-        java.util.Collections.emptyList();
-      private void ensureConversionActionsIsMutable() {
-        if (!((bitField0_ & 0x00000001) == 0x00000001)) {
-          conversionActions_ = new java.util.ArrayList<com.google.protobuf.StringValue>(conversionActions_);
-          bitField0_ |= 0x00000001;
-         }
-      }
-
-      private com.google.protobuf.RepeatedFieldBuilderV3<
-          com.google.protobuf.StringValue, com.google.protobuf.StringValue.Builder, com.google.protobuf.StringValueOrBuilder> conversionActionsBuilder_;
-
-      /**
-       * <pre>
-       * The selected set of conversion actions for optimizing this campaign.
-       * </pre>
-       *
-       * <code>repeated .google.protobuf.StringValue conversion_actions = 1;</code>
-       */
-      public java.util.List<com.google.protobuf.StringValue> getConversionActionsList() {
-        if (conversionActionsBuilder_ == null) {
-          return java.util.Collections.unmodifiableList(conversionActions_);
-        } else {
-          return conversionActionsBuilder_.getMessageList();
-        }
-      }
-      /**
-       * <pre>
-       * The selected set of conversion actions for optimizing this campaign.
-       * </pre>
-       *
-       * <code>repeated .google.protobuf.StringValue conversion_actions = 1;</code>
-       */
-      public int getConversionActionsCount() {
-        if (conversionActionsBuilder_ == null) {
-          return conversionActions_.size();
-        } else {
-          return conversionActionsBuilder_.getCount();
-        }
-      }
-      /**
-       * <pre>
-       * The selected set of conversion actions for optimizing this campaign.
-       * </pre>
-       *
-       * <code>repeated .google.protobuf.StringValue conversion_actions = 1;</code>
-       */
-      public com.google.protobuf.StringValue getConversionActions(int index) {
-        if (conversionActionsBuilder_ == null) {
-          return conversionActions_.get(index);
-        } else {
-          return conversionActionsBuilder_.getMessage(index);
-        }
-      }
-      /**
-       * <pre>
-       * The selected set of conversion actions for optimizing this campaign.
-       * </pre>
-       *
-       * <code>repeated .google.protobuf.StringValue conversion_actions = 1;</code>
-       */
-      public Builder setConversionActions(
-          int index, com.google.protobuf.StringValue value) {
-        if (conversionActionsBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          ensureConversionActionsIsMutable();
-          conversionActions_.set(index, value);
-          onChanged();
-        } else {
-          conversionActionsBuilder_.setMessage(index, value);
-        }
-        return this;
-      }
-      /**
-       * <pre>
-       * The selected set of conversion actions for optimizing this campaign.
-       * </pre>
-       *
-       * <code>repeated .google.protobuf.StringValue conversion_actions = 1;</code>
-       */
-      public Builder setConversionActions(
-          int index, com.google.protobuf.StringValue.Builder builderForValue) {
-        if (conversionActionsBuilder_ == null) {
-          ensureConversionActionsIsMutable();
-          conversionActions_.set(index, builderForValue.build());
-          onChanged();
-        } else {
-          conversionActionsBuilder_.setMessage(index, builderForValue.build());
-        }
-        return this;
-      }
-      /**
-       * <pre>
-       * The selected set of conversion actions for optimizing this campaign.
-       * </pre>
-       *
-       * <code>repeated .google.protobuf.StringValue conversion_actions = 1;</code>
-       */
-      public Builder addConversionActions(com.google.protobuf.StringValue value) {
-        if (conversionActionsBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          ensureConversionActionsIsMutable();
-          conversionActions_.add(value);
-          onChanged();
-        } else {
-          conversionActionsBuilder_.addMessage(value);
-        }
-        return this;
-      }
-      /**
-       * <pre>
-       * The selected set of conversion actions for optimizing this campaign.
-       * </pre>
-       *
-       * <code>repeated .google.protobuf.StringValue conversion_actions = 1;</code>
-       */
-      public Builder addConversionActions(
-          int index, com.google.protobuf.StringValue value) {
-        if (conversionActionsBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          ensureConversionActionsIsMutable();
-          conversionActions_.add(index, value);
-          onChanged();
-        } else {
-          conversionActionsBuilder_.addMessage(index, value);
-        }
-        return this;
-      }
-      /**
-       * <pre>
-       * The selected set of conversion actions for optimizing this campaign.
-       * </pre>
-       *
-       * <code>repeated .google.protobuf.StringValue conversion_actions = 1;</code>
-       */
-      public Builder addConversionActions(
-          com.google.protobuf.StringValue.Builder builderForValue) {
-        if (conversionActionsBuilder_ == null) {
-          ensureConversionActionsIsMutable();
-          conversionActions_.add(builderForValue.build());
-          onChanged();
-        } else {
-          conversionActionsBuilder_.addMessage(builderForValue.build());
-        }
-        return this;
-      }
-      /**
-       * <pre>
-       * The selected set of conversion actions for optimizing this campaign.
-       * </pre>
-       *
-       * <code>repeated .google.protobuf.StringValue conversion_actions = 1;</code>
-       */
-      public Builder addConversionActions(
-          int index, com.google.protobuf.StringValue.Builder builderForValue) {
-        if (conversionActionsBuilder_ == null) {
-          ensureConversionActionsIsMutable();
-          conversionActions_.add(index, builderForValue.build());
-          onChanged();
-        } else {
-          conversionActionsBuilder_.addMessage(index, builderForValue.build());
-        }
-        return this;
-      }
-      /**
-       * <pre>
-       * The selected set of conversion actions for optimizing this campaign.
-       * </pre>
-       *
-       * <code>repeated .google.protobuf.StringValue conversion_actions = 1;</code>
-       */
-      public Builder addAllConversionActions(
-          java.lang.Iterable<? extends com.google.protobuf.StringValue> values) {
-        if (conversionActionsBuilder_ == null) {
-          ensureConversionActionsIsMutable();
-          com.google.protobuf.AbstractMessageLite.Builder.addAll(
-              values, conversionActions_);
-          onChanged();
-        } else {
-          conversionActionsBuilder_.addAllMessages(values);
-        }
-        return this;
-      }
-      /**
-       * <pre>
-       * The selected set of conversion actions for optimizing this campaign.
-       * </pre>
-       *
-       * <code>repeated .google.protobuf.StringValue conversion_actions = 1;</code>
-       */
-      public Builder clearConversionActions() {
-        if (conversionActionsBuilder_ == null) {
-          conversionActions_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000001);
-          onChanged();
-        } else {
-          conversionActionsBuilder_.clear();
-        }
-        return this;
-      }
-      /**
-       * <pre>
-       * The selected set of conversion actions for optimizing this campaign.
-       * </pre>
-       *
-       * <code>repeated .google.protobuf.StringValue conversion_actions = 1;</code>
-       */
-      public Builder removeConversionActions(int index) {
-        if (conversionActionsBuilder_ == null) {
-          ensureConversionActionsIsMutable();
-          conversionActions_.remove(index);
-          onChanged();
-        } else {
-          conversionActionsBuilder_.remove(index);
-        }
-        return this;
-      }
-      /**
-       * <pre>
-       * The selected set of conversion actions for optimizing this campaign.
-       * </pre>
-       *
-       * <code>repeated .google.protobuf.StringValue conversion_actions = 1;</code>
-       */
-      public com.google.protobuf.StringValue.Builder getConversionActionsBuilder(
-          int index) {
-        return getConversionActionsFieldBuilder().getBuilder(index);
-      }
-      /**
-       * <pre>
-       * The selected set of conversion actions for optimizing this campaign.
-       * </pre>
-       *
-       * <code>repeated .google.protobuf.StringValue conversion_actions = 1;</code>
-       */
-      public com.google.protobuf.StringValueOrBuilder getConversionActionsOrBuilder(
-          int index) {
-        if (conversionActionsBuilder_ == null) {
-          return conversionActions_.get(index);  } else {
-          return conversionActionsBuilder_.getMessageOrBuilder(index);
-        }
-      }
-      /**
-       * <pre>
-       * The selected set of conversion actions for optimizing this campaign.
-       * </pre>
-       *
-       * <code>repeated .google.protobuf.StringValue conversion_actions = 1;</code>
-       */
-      public java.util.List<? extends com.google.protobuf.StringValueOrBuilder> 
-           getConversionActionsOrBuilderList() {
-        if (conversionActionsBuilder_ != null) {
-          return conversionActionsBuilder_.getMessageOrBuilderList();
-        } else {
-          return java.util.Collections.unmodifiableList(conversionActions_);
-        }
-      }
-      /**
-       * <pre>
-       * The selected set of conversion actions for optimizing this campaign.
-       * </pre>
-       *
-       * <code>repeated .google.protobuf.StringValue conversion_actions = 1;</code>
-       */
-      public com.google.protobuf.StringValue.Builder addConversionActionsBuilder() {
-        return getConversionActionsFieldBuilder().addBuilder(
-            com.google.protobuf.StringValue.getDefaultInstance());
-      }
-      /**
-       * <pre>
-       * The selected set of conversion actions for optimizing this campaign.
-       * </pre>
-       *
-       * <code>repeated .google.protobuf.StringValue conversion_actions = 1;</code>
-       */
-      public com.google.protobuf.StringValue.Builder addConversionActionsBuilder(
-          int index) {
-        return getConversionActionsFieldBuilder().addBuilder(
-            index, com.google.protobuf.StringValue.getDefaultInstance());
-      }
-      /**
-       * <pre>
-       * The selected set of conversion actions for optimizing this campaign.
-       * </pre>
-       *
-       * <code>repeated .google.protobuf.StringValue conversion_actions = 1;</code>
-       */
-      public java.util.List<com.google.protobuf.StringValue.Builder> 
-           getConversionActionsBuilderList() {
-        return getConversionActionsFieldBuilder().getBuilderList();
-      }
-      private com.google.protobuf.RepeatedFieldBuilderV3<
-          com.google.protobuf.StringValue, com.google.protobuf.StringValue.Builder, com.google.protobuf.StringValueOrBuilder> 
-          getConversionActionsFieldBuilder() {
-        if (conversionActionsBuilder_ == null) {
-          conversionActionsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-              com.google.protobuf.StringValue, com.google.protobuf.StringValue.Builder, com.google.protobuf.StringValueOrBuilder>(
-                  conversionActions_,
-                  ((bitField0_ & 0x00000001) == 0x00000001),
-                  getParentForChildren(),
-                  isClean());
-          conversionActions_ = null;
-        }
-        return conversionActionsBuilder_;
-      }
-      @java.lang.Override
-      public final Builder setUnknownFields(
-          final com.google.protobuf.UnknownFieldSet unknownFields) {
-        return super.setUnknownFieldsProto3(unknownFields);
-      }
-
-      @java.lang.Override
-      public final Builder mergeUnknownFields(
-          final com.google.protobuf.UnknownFieldSet unknownFields) {
-        return super.mergeUnknownFields(unknownFields);
-      }
-
-
-      // @@protoc_insertion_point(builder_scope:google.ads.googleads.v1.resources.Campaign.SelectiveOptimization)
-    }
-
-    // @@protoc_insertion_point(class_scope:google.ads.googleads.v1.resources.Campaign.SelectiveOptimization)
-    private static final com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization DEFAULT_INSTANCE;
-    static {
-      DEFAULT_INSTANCE = new com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization();
-    }
-
-    public static com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization getDefaultInstance() {
-      return DEFAULT_INSTANCE;
-    }
-
-    private static final com.google.protobuf.Parser<SelectiveOptimization>
-        PARSER = new com.google.protobuf.AbstractParser<SelectiveOptimization>() {
-      @java.lang.Override
-      public SelectiveOptimization parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new SelectiveOptimization(input, extensionRegistry);
-      }
-    };
-
-    public static com.google.protobuf.Parser<SelectiveOptimization> parser() {
-      return PARSER;
-    }
-
-    @java.lang.Override
-    public com.google.protobuf.Parser<SelectiveOptimization> getParserForType() {
-      return PARSER;
-    }
-
-    @java.lang.Override
-    public com.google.ads.googleads.v1.resources.Campaign.SelectiveOptimization getDefaultInstanceForType() {
+    public com.google.ads.googleads.v1.resources.Campaign.GeoTargetTypeSetting getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
 

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/resources/CampaignProto.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/resources/CampaignProto.java
@@ -30,10 +30,10 @@ public final class CampaignProto {
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_ads_googleads_v1_resources_Campaign_HotelSettingInfo_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_google_ads_googleads_v1_resources_Campaign_TrackingSetting_descriptor;
+    internal_static_google_ads_googleads_v1_resources_Campaign_VanityPharma_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_google_ads_googleads_v1_resources_Campaign_TrackingSetting_fieldAccessorTable;
+      internal_static_google_ads_googleads_v1_resources_Campaign_VanityPharma_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_ads_googleads_v1_resources_Campaign_DynamicSearchAdsSetting_descriptor;
   static final 
@@ -45,25 +45,25 @@ public final class CampaignProto {
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_ads_googleads_v1_resources_Campaign_ShoppingSetting_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_google_ads_googleads_v1_resources_Campaign_GeoTargetTypeSetting_descriptor;
+    internal_static_google_ads_googleads_v1_resources_Campaign_TrackingSetting_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_google_ads_googleads_v1_resources_Campaign_GeoTargetTypeSetting_fieldAccessorTable;
+      internal_static_google_ads_googleads_v1_resources_Campaign_TrackingSetting_fieldAccessorTable;
+  static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_google_ads_googleads_v1_resources_Campaign_SelectiveOptimization_descriptor;
+  static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_google_ads_googleads_v1_resources_Campaign_SelectiveOptimization_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_ads_googleads_v1_resources_Campaign_AppCampaignSetting_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_ads_googleads_v1_resources_Campaign_AppCampaignSetting_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_google_ads_googleads_v1_resources_Campaign_VanityPharma_descriptor;
+    internal_static_google_ads_googleads_v1_resources_Campaign_GeoTargetTypeSetting_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_google_ads_googleads_v1_resources_Campaign_VanityPharma_fieldAccessorTable;
-  static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_google_ads_googleads_v1_resources_Campaign_SelectiveOptimization_descriptor;
-  static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_google_ads_googleads_v1_resources_Campaign_SelectiveOptimization_fieldAccessorTable;
+      internal_static_google_ads_googleads_v1_resources_Campaign_GeoTargetTypeSetting_fieldAccessorTable;
 
   public static com.google.protobuf.Descriptors.FileDescriptor
       getDescriptor() {
@@ -203,43 +203,43 @@ public final class CampaignProto {
       "ue\022A\n\035target_partner_search_network\030\004 \001(" +
       "\0132\032.google.protobuf.BoolValue\032H\n\020HotelSe" +
       "ttingInfo\0224\n\017hotel_center_id\030\001 \001(\0132\033.goo" +
-      "gle.protobuf.Int64Value\032E\n\017TrackingSetti" +
-      "ng\0222\n\014tracking_url\030\001 \001(\0132\034.google.protob" +
-      "uf.StringValue\032\352\001\n\027DynamicSearchAdsSetti" +
-      "ng\0221\n\013domain_name\030\001 \001(\0132\034.google.protobu" +
-      "f.StringValue\0223\n\rlanguage_code\030\002 \001(\0132\034.g" +
-      "oogle.protobuf.StringValue\022:\n\026use_suppli" +
-      "ed_urls_only\030\003 \001(\0132\032.google.protobuf.Boo" +
-      "lValue\022+\n\005feeds\030\005 \003(\0132\034.google.protobuf." +
-      "StringValue\032\342\001\n\017ShoppingSetting\0220\n\013merch" +
-      "ant_id\030\001 \001(\0132\033.google.protobuf.Int64Valu" +
-      "e\0223\n\rsales_country\030\002 \001(\0132\034.google.protob" +
-      "uf.StringValue\0226\n\021campaign_priority\030\003 \001(" +
-      "\0132\033.google.protobuf.Int32Value\0220\n\014enable" +
-      "_local\030\004 \001(\0132\032.google.protobuf.BoolValue" +
-      "\032\372\001\n\024GeoTargetTypeSetting\022p\n\030positive_ge" +
-      "o_target_type\030\001 \001(\0162N.google.ads.googlea" +
-      "ds.v1.enums.PositiveGeoTargetTypeEnum.Po" +
-      "sitiveGeoTargetType\022p\n\030negative_geo_targ" +
-      "et_type\030\002 \001(\0162N.google.ads.googleads.v1." +
-      "enums.NegativeGeoTargetTypeEnum.Negative" +
-      "GeoTargetType\032\260\002\n\022AppCampaignSetting\022\214\001\n" +
-      "\032bidding_strategy_goal_type\030\001 \001(\0162h.goog" +
-      "le.ads.googleads.v1.enums.AppCampaignBid" +
-      "dingStrategyGoalTypeEnum.AppCampaignBidd" +
-      "ingStrategyGoalType\022,\n\006app_id\030\002 \001(\0132\034.go" +
-      "ogle.protobuf.StringValue\022]\n\tapp_store\030\003" +
-      " \001(\0162J.google.ads.googleads.v1.enums.App" +
-      "CampaignAppStoreEnum.AppCampaignAppStore" +
-      "\032\363\001\n\014VanityPharma\022\200\001\n\036vanity_pharma_disp" +
-      "lay_url_mode\030\001 \001(\0162X.google.ads.googlead" +
-      "s.v1.enums.VanityPharmaDisplayUrlModeEnu" +
-      "m.VanityPharmaDisplayUrlMode\022`\n\022vanity_p" +
-      "harma_text\030\002 \001(\0162D.google.ads.googleads." +
-      "v1.enums.VanityPharmaTextEnum.VanityPhar" +
-      "maText\032Q\n\025SelectiveOptimization\0228\n\022conve" +
+      "gle.protobuf.Int64Value\032\363\001\n\014VanityPharma" +
+      "\022\200\001\n\036vanity_pharma_display_url_mode\030\001 \001(" +
+      "\0162X.google.ads.googleads.v1.enums.Vanity" +
+      "PharmaDisplayUrlModeEnum.VanityPharmaDis" +
+      "playUrlMode\022`\n\022vanity_pharma_text\030\002 \001(\0162" +
+      "D.google.ads.googleads.v1.enums.VanityPh" +
+      "armaTextEnum.VanityPharmaText\032\352\001\n\027Dynami" +
+      "cSearchAdsSetting\0221\n\013domain_name\030\001 \001(\0132\034" +
+      ".google.protobuf.StringValue\0223\n\rlanguage" +
+      "_code\030\002 \001(\0132\034.google.protobuf.StringValu" +
+      "e\022:\n\026use_supplied_urls_only\030\003 \001(\0132\032.goog" +
+      "le.protobuf.BoolValue\022+\n\005feeds\030\005 \003(\0132\034.g" +
+      "oogle.protobuf.StringValue\032\342\001\n\017ShoppingS" +
+      "etting\0220\n\013merchant_id\030\001 \001(\0132\033.google.pro" +
+      "tobuf.Int64Value\0223\n\rsales_country\030\002 \001(\0132" +
+      "\034.google.protobuf.StringValue\0226\n\021campaig" +
+      "n_priority\030\003 \001(\0132\033.google.protobuf.Int32" +
+      "Value\0220\n\014enable_local\030\004 \001(\0132\032.google.pro" +
+      "tobuf.BoolValue\032E\n\017TrackingSetting\0222\n\014tr" +
+      "acking_url\030\001 \001(\0132\034.google.protobuf.Strin" +
+      "gValue\032Q\n\025SelectiveOptimization\0228\n\022conve" +
       "rsion_actions\030\001 \003(\0132\034.google.protobuf.St" +
-      "ringValueB\033\n\031campaign_bidding_strategyB\372" +
+      "ringValue\032\260\002\n\022AppCampaignSetting\022\214\001\n\032bid" +
+      "ding_strategy_goal_type\030\001 \001(\0162h.google.a" +
+      "ds.googleads.v1.enums.AppCampaignBidding" +
+      "StrategyGoalTypeEnum.AppCampaignBiddingS" +
+      "trategyGoalType\022,\n\006app_id\030\002 \001(\0132\034.google" +
+      ".protobuf.StringValue\022]\n\tapp_store\030\003 \001(\016" +
+      "2J.google.ads.googleads.v1.enums.AppCamp" +
+      "aignAppStoreEnum.AppCampaignAppStore\032\372\001\n" +
+      "\024GeoTargetTypeSetting\022p\n\030positive_geo_ta" +
+      "rget_type\030\001 \001(\0162N.google.ads.googleads.v" +
+      "1.enums.PositiveGeoTargetTypeEnum.Positi" +
+      "veGeoTargetType\022p\n\030negative_geo_target_t" +
+      "ype\030\002 \001(\0162N.google.ads.googleads.v1.enum" +
+      "s.NegativeGeoTargetTypeEnum.NegativeGeoT" +
+      "argetTypeB\033\n\031campaign_bidding_strategyB\372" +
       "\001\n%com.google.ads.googleads.v1.resources" +
       "B\rCampaignProtoP\001ZJgoogle.golang.org/gen" +
       "proto/googleapis/ads/googleads/v1/resour" +
@@ -300,12 +300,12 @@ public final class CampaignProto {
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_ads_googleads_v1_resources_Campaign_HotelSettingInfo_descriptor,
         new java.lang.String[] { "HotelCenterId", });
-    internal_static_google_ads_googleads_v1_resources_Campaign_TrackingSetting_descriptor =
+    internal_static_google_ads_googleads_v1_resources_Campaign_VanityPharma_descriptor =
       internal_static_google_ads_googleads_v1_resources_Campaign_descriptor.getNestedTypes().get(2);
-    internal_static_google_ads_googleads_v1_resources_Campaign_TrackingSetting_fieldAccessorTable = new
+    internal_static_google_ads_googleads_v1_resources_Campaign_VanityPharma_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_google_ads_googleads_v1_resources_Campaign_TrackingSetting_descriptor,
-        new java.lang.String[] { "TrackingUrl", });
+        internal_static_google_ads_googleads_v1_resources_Campaign_VanityPharma_descriptor,
+        new java.lang.String[] { "VanityPharmaDisplayUrlMode", "VanityPharmaText", });
     internal_static_google_ads_googleads_v1_resources_Campaign_DynamicSearchAdsSetting_descriptor =
       internal_static_google_ads_googleads_v1_resources_Campaign_descriptor.getNestedTypes().get(3);
     internal_static_google_ads_googleads_v1_resources_Campaign_DynamicSearchAdsSetting_fieldAccessorTable = new
@@ -318,30 +318,30 @@ public final class CampaignProto {
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_ads_googleads_v1_resources_Campaign_ShoppingSetting_descriptor,
         new java.lang.String[] { "MerchantId", "SalesCountry", "CampaignPriority", "EnableLocal", });
-    internal_static_google_ads_googleads_v1_resources_Campaign_GeoTargetTypeSetting_descriptor =
+    internal_static_google_ads_googleads_v1_resources_Campaign_TrackingSetting_descriptor =
       internal_static_google_ads_googleads_v1_resources_Campaign_descriptor.getNestedTypes().get(5);
-    internal_static_google_ads_googleads_v1_resources_Campaign_GeoTargetTypeSetting_fieldAccessorTable = new
+    internal_static_google_ads_googleads_v1_resources_Campaign_TrackingSetting_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_google_ads_googleads_v1_resources_Campaign_GeoTargetTypeSetting_descriptor,
-        new java.lang.String[] { "PositiveGeoTargetType", "NegativeGeoTargetType", });
-    internal_static_google_ads_googleads_v1_resources_Campaign_AppCampaignSetting_descriptor =
-      internal_static_google_ads_googleads_v1_resources_Campaign_descriptor.getNestedTypes().get(6);
-    internal_static_google_ads_googleads_v1_resources_Campaign_AppCampaignSetting_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_google_ads_googleads_v1_resources_Campaign_AppCampaignSetting_descriptor,
-        new java.lang.String[] { "BiddingStrategyGoalType", "AppId", "AppStore", });
-    internal_static_google_ads_googleads_v1_resources_Campaign_VanityPharma_descriptor =
-      internal_static_google_ads_googleads_v1_resources_Campaign_descriptor.getNestedTypes().get(7);
-    internal_static_google_ads_googleads_v1_resources_Campaign_VanityPharma_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_google_ads_googleads_v1_resources_Campaign_VanityPharma_descriptor,
-        new java.lang.String[] { "VanityPharmaDisplayUrlMode", "VanityPharmaText", });
+        internal_static_google_ads_googleads_v1_resources_Campaign_TrackingSetting_descriptor,
+        new java.lang.String[] { "TrackingUrl", });
     internal_static_google_ads_googleads_v1_resources_Campaign_SelectiveOptimization_descriptor =
-      internal_static_google_ads_googleads_v1_resources_Campaign_descriptor.getNestedTypes().get(8);
+      internal_static_google_ads_googleads_v1_resources_Campaign_descriptor.getNestedTypes().get(6);
     internal_static_google_ads_googleads_v1_resources_Campaign_SelectiveOptimization_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_ads_googleads_v1_resources_Campaign_SelectiveOptimization_descriptor,
         new java.lang.String[] { "ConversionActions", });
+    internal_static_google_ads_googleads_v1_resources_Campaign_AppCampaignSetting_descriptor =
+      internal_static_google_ads_googleads_v1_resources_Campaign_descriptor.getNestedTypes().get(7);
+    internal_static_google_ads_googleads_v1_resources_Campaign_AppCampaignSetting_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_google_ads_googleads_v1_resources_Campaign_AppCampaignSetting_descriptor,
+        new java.lang.String[] { "BiddingStrategyGoalType", "AppId", "AppStore", });
+    internal_static_google_ads_googleads_v1_resources_Campaign_GeoTargetTypeSetting_descriptor =
+      internal_static_google_ads_googleads_v1_resources_Campaign_descriptor.getNestedTypes().get(8);
+    internal_static_google_ads_googleads_v1_resources_Campaign_GeoTargetTypeSetting_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_google_ads_googleads_v1_resources_Campaign_GeoTargetTypeSetting_descriptor,
+        new java.lang.String[] { "PositiveGeoTargetType", "NegativeGeoTargetType", });
     com.google.ads.googleads.v1.common.BiddingProto.getDescriptor();
     com.google.ads.googleads.v1.common.CustomParameterProto.getDescriptor();
     com.google.ads.googleads.v1.common.FrequencyCapProto.getDescriptor();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/resources/Recommendation.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/resources/Recommendation.java
@@ -6291,55 +6291,70 @@ private static final long serialVersionUID = 0L;
 
   }
 
-  public interface MaximizeClicksOptInRecommendationOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation)
+  public interface KeywordMatchTypeRecommendationOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation)
       com.google.protobuf.MessageOrBuilder {
 
     /**
      * <pre>
-     * The recommended new budget amount.
-     * Only set if the current budget is too high.
+     * The existing keyword where the match type should be more broad.
      * </pre>
      *
-     * <code>.google.protobuf.Int64Value recommended_budget_amount_micros = 1;</code>
+     * <code>.google.ads.googleads.v1.common.KeywordInfo keyword = 1;</code>
      */
-    boolean hasRecommendedBudgetAmountMicros();
+    boolean hasKeyword();
     /**
      * <pre>
-     * The recommended new budget amount.
-     * Only set if the current budget is too high.
+     * The existing keyword where the match type should be more broad.
      * </pre>
      *
-     * <code>.google.protobuf.Int64Value recommended_budget_amount_micros = 1;</code>
+     * <code>.google.ads.googleads.v1.common.KeywordInfo keyword = 1;</code>
      */
-    com.google.protobuf.Int64Value getRecommendedBudgetAmountMicros();
+    com.google.ads.googleads.v1.common.KeywordInfo getKeyword();
     /**
      * <pre>
-     * The recommended new budget amount.
-     * Only set if the current budget is too high.
+     * The existing keyword where the match type should be more broad.
      * </pre>
      *
-     * <code>.google.protobuf.Int64Value recommended_budget_amount_micros = 1;</code>
+     * <code>.google.ads.googleads.v1.common.KeywordInfo keyword = 1;</code>
      */
-    com.google.protobuf.Int64ValueOrBuilder getRecommendedBudgetAmountMicrosOrBuilder();
+    com.google.ads.googleads.v1.common.KeywordInfoOrBuilder getKeywordOrBuilder();
+
+    /**
+     * <pre>
+     * The recommended new match type.
+     * </pre>
+     *
+     * <code>.google.ads.googleads.v1.enums.KeywordMatchTypeEnum.KeywordMatchType recommended_match_type = 2;</code>
+     */
+    int getRecommendedMatchTypeValue();
+    /**
+     * <pre>
+     * The recommended new match type.
+     * </pre>
+     *
+     * <code>.google.ads.googleads.v1.enums.KeywordMatchTypeEnum.KeywordMatchType recommended_match_type = 2;</code>
+     */
+    com.google.ads.googleads.v1.enums.KeywordMatchTypeEnum.KeywordMatchType getRecommendedMatchType();
   }
   /**
    * <pre>
-   * The Maximize Clicks opt-in recommendation.
+   * The keyword match type recommendation.
    * </pre>
    *
-   * Protobuf type {@code google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation}
+   * Protobuf type {@code google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation}
    */
-  public  static final class MaximizeClicksOptInRecommendation extends
+  public  static final class KeywordMatchTypeRecommendation extends
       com.google.protobuf.GeneratedMessageV3 implements
-      // @@protoc_insertion_point(message_implements:google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation)
-      MaximizeClicksOptInRecommendationOrBuilder {
+      // @@protoc_insertion_point(message_implements:google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation)
+      KeywordMatchTypeRecommendationOrBuilder {
   private static final long serialVersionUID = 0L;
-    // Use MaximizeClicksOptInRecommendation.newBuilder() to construct.
-    private MaximizeClicksOptInRecommendation(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+    // Use KeywordMatchTypeRecommendation.newBuilder() to construct.
+    private KeywordMatchTypeRecommendation(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
     }
-    private MaximizeClicksOptInRecommendation() {
+    private KeywordMatchTypeRecommendation() {
+      recommendedMatchType_ = 0;
     }
 
     @java.lang.Override
@@ -6347,7 +6362,7 @@ private static final long serialVersionUID = 0L;
     getUnknownFields() {
       return this.unknownFields;
     }
-    private MaximizeClicksOptInRecommendation(
+    private KeywordMatchTypeRecommendation(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
@@ -6367,16 +6382,22 @@ private static final long serialVersionUID = 0L;
               done = true;
               break;
             case 10: {
-              com.google.protobuf.Int64Value.Builder subBuilder = null;
-              if (recommendedBudgetAmountMicros_ != null) {
-                subBuilder = recommendedBudgetAmountMicros_.toBuilder();
+              com.google.ads.googleads.v1.common.KeywordInfo.Builder subBuilder = null;
+              if (keyword_ != null) {
+                subBuilder = keyword_.toBuilder();
               }
-              recommendedBudgetAmountMicros_ = input.readMessage(com.google.protobuf.Int64Value.parser(), extensionRegistry);
+              keyword_ = input.readMessage(com.google.ads.googleads.v1.common.KeywordInfo.parser(), extensionRegistry);
               if (subBuilder != null) {
-                subBuilder.mergeFrom(recommendedBudgetAmountMicros_);
-                recommendedBudgetAmountMicros_ = subBuilder.buildPartial();
+                subBuilder.mergeFrom(keyword_);
+                keyword_ = subBuilder.buildPartial();
               }
 
+              break;
+            }
+            case 16: {
+              int rawValue = input.readEnum();
+
+              recommendedMatchType_ = rawValue;
               break;
             }
             default: {
@@ -6400,51 +6421,73 @@ private static final long serialVersionUID = 0L;
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.google.ads.googleads.v1.resources.RecommendationProto.internal_static_google_ads_googleads_v1_resources_Recommendation_MaximizeClicksOptInRecommendation_descriptor;
+      return com.google.ads.googleads.v1.resources.RecommendationProto.internal_static_google_ads_googleads_v1_resources_Recommendation_KeywordMatchTypeRecommendation_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.google.ads.googleads.v1.resources.RecommendationProto.internal_static_google_ads_googleads_v1_resources_Recommendation_MaximizeClicksOptInRecommendation_fieldAccessorTable
+      return com.google.ads.googleads.v1.resources.RecommendationProto.internal_static_google_ads_googleads_v1_resources_Recommendation_KeywordMatchTypeRecommendation_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation.class, com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation.Builder.class);
+              com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation.class, com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation.Builder.class);
     }
 
-    public static final int RECOMMENDED_BUDGET_AMOUNT_MICROS_FIELD_NUMBER = 1;
-    private com.google.protobuf.Int64Value recommendedBudgetAmountMicros_;
+    public static final int KEYWORD_FIELD_NUMBER = 1;
+    private com.google.ads.googleads.v1.common.KeywordInfo keyword_;
     /**
      * <pre>
-     * The recommended new budget amount.
-     * Only set if the current budget is too high.
+     * The existing keyword where the match type should be more broad.
      * </pre>
      *
-     * <code>.google.protobuf.Int64Value recommended_budget_amount_micros = 1;</code>
+     * <code>.google.ads.googleads.v1.common.KeywordInfo keyword = 1;</code>
      */
-    public boolean hasRecommendedBudgetAmountMicros() {
-      return recommendedBudgetAmountMicros_ != null;
+    public boolean hasKeyword() {
+      return keyword_ != null;
     }
     /**
      * <pre>
-     * The recommended new budget amount.
-     * Only set if the current budget is too high.
+     * The existing keyword where the match type should be more broad.
      * </pre>
      *
-     * <code>.google.protobuf.Int64Value recommended_budget_amount_micros = 1;</code>
+     * <code>.google.ads.googleads.v1.common.KeywordInfo keyword = 1;</code>
      */
-    public com.google.protobuf.Int64Value getRecommendedBudgetAmountMicros() {
-      return recommendedBudgetAmountMicros_ == null ? com.google.protobuf.Int64Value.getDefaultInstance() : recommendedBudgetAmountMicros_;
+    public com.google.ads.googleads.v1.common.KeywordInfo getKeyword() {
+      return keyword_ == null ? com.google.ads.googleads.v1.common.KeywordInfo.getDefaultInstance() : keyword_;
     }
     /**
      * <pre>
-     * The recommended new budget amount.
-     * Only set if the current budget is too high.
+     * The existing keyword where the match type should be more broad.
      * </pre>
      *
-     * <code>.google.protobuf.Int64Value recommended_budget_amount_micros = 1;</code>
+     * <code>.google.ads.googleads.v1.common.KeywordInfo keyword = 1;</code>
      */
-    public com.google.protobuf.Int64ValueOrBuilder getRecommendedBudgetAmountMicrosOrBuilder() {
-      return getRecommendedBudgetAmountMicros();
+    public com.google.ads.googleads.v1.common.KeywordInfoOrBuilder getKeywordOrBuilder() {
+      return getKeyword();
+    }
+
+    public static final int RECOMMENDED_MATCH_TYPE_FIELD_NUMBER = 2;
+    private int recommendedMatchType_;
+    /**
+     * <pre>
+     * The recommended new match type.
+     * </pre>
+     *
+     * <code>.google.ads.googleads.v1.enums.KeywordMatchTypeEnum.KeywordMatchType recommended_match_type = 2;</code>
+     */
+    public int getRecommendedMatchTypeValue() {
+      return recommendedMatchType_;
+    }
+    /**
+     * <pre>
+     * The recommended new match type.
+     * </pre>
+     *
+     * <code>.google.ads.googleads.v1.enums.KeywordMatchTypeEnum.KeywordMatchType recommended_match_type = 2;</code>
+     */
+    public com.google.ads.googleads.v1.enums.KeywordMatchTypeEnum.KeywordMatchType getRecommendedMatchType() {
+      @SuppressWarnings("deprecation")
+      com.google.ads.googleads.v1.enums.KeywordMatchTypeEnum.KeywordMatchType result = com.google.ads.googleads.v1.enums.KeywordMatchTypeEnum.KeywordMatchType.valueOf(recommendedMatchType_);
+      return result == null ? com.google.ads.googleads.v1.enums.KeywordMatchTypeEnum.KeywordMatchType.UNRECOGNIZED : result;
     }
 
     private byte memoizedIsInitialized = -1;
@@ -6461,8 +6504,11 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (recommendedBudgetAmountMicros_ != null) {
-        output.writeMessage(1, getRecommendedBudgetAmountMicros());
+      if (keyword_ != null) {
+        output.writeMessage(1, getKeyword());
+      }
+      if (recommendedMatchType_ != com.google.ads.googleads.v1.enums.KeywordMatchTypeEnum.KeywordMatchType.UNSPECIFIED.getNumber()) {
+        output.writeEnum(2, recommendedMatchType_);
       }
       unknownFields.writeTo(output);
     }
@@ -6473,9 +6519,13 @@ private static final long serialVersionUID = 0L;
       if (size != -1) return size;
 
       size = 0;
-      if (recommendedBudgetAmountMicros_ != null) {
+      if (keyword_ != null) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(1, getRecommendedBudgetAmountMicros());
+          .computeMessageSize(1, getKeyword());
+      }
+      if (recommendedMatchType_ != com.google.ads.googleads.v1.enums.KeywordMatchTypeEnum.KeywordMatchType.UNSPECIFIED.getNumber()) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeEnumSize(2, recommendedMatchType_);
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -6487,17 +6537,18 @@ private static final long serialVersionUID = 0L;
       if (obj == this) {
        return true;
       }
-      if (!(obj instanceof com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation)) {
+      if (!(obj instanceof com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation)) {
         return super.equals(obj);
       }
-      com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation other = (com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation) obj;
+      com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation other = (com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation) obj;
 
       boolean result = true;
-      result = result && (hasRecommendedBudgetAmountMicros() == other.hasRecommendedBudgetAmountMicros());
-      if (hasRecommendedBudgetAmountMicros()) {
-        result = result && getRecommendedBudgetAmountMicros()
-            .equals(other.getRecommendedBudgetAmountMicros());
+      result = result && (hasKeyword() == other.hasKeyword());
+      if (hasKeyword()) {
+        result = result && getKeyword()
+            .equals(other.getKeyword());
       }
+      result = result && recommendedMatchType_ == other.recommendedMatchType_;
       result = result && unknownFields.equals(other.unknownFields);
       return result;
     }
@@ -6509,78 +6560,80 @@ private static final long serialVersionUID = 0L;
       }
       int hash = 41;
       hash = (19 * hash) + getDescriptor().hashCode();
-      if (hasRecommendedBudgetAmountMicros()) {
-        hash = (37 * hash) + RECOMMENDED_BUDGET_AMOUNT_MICROS_FIELD_NUMBER;
-        hash = (53 * hash) + getRecommendedBudgetAmountMicros().hashCode();
+      if (hasKeyword()) {
+        hash = (37 * hash) + KEYWORD_FIELD_NUMBER;
+        hash = (53 * hash) + getKeyword().hashCode();
       }
+      hash = (37 * hash) + RECOMMENDED_MATCH_TYPE_FIELD_NUMBER;
+      hash = (53 * hash) + recommendedMatchType_;
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
       return hash;
     }
 
-    public static com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation parseFrom(
+    public static com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation parseFrom(
         java.nio.ByteBuffer data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation parseFrom(
+    public static com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation parseFrom(
         java.nio.ByteBuffer data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation parseFrom(
+    public static com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation parseFrom(
+    public static com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation parseFrom(byte[] data)
+    public static com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation parseFrom(
+    public static com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation parseFrom(java.io.InputStream input)
+    public static com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation parseFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation parseFrom(
+    public static com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
-    public static com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation parseDelimitedFrom(java.io.InputStream input)
+    public static com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
-    public static com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation parseDelimitedFrom(
+    public static com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
-    public static com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation parseFrom(
+    public static com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation parseFrom(
+    public static com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
@@ -6593,7 +6646,7 @@ private static final long serialVersionUID = 0L;
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
     }
-    public static Builder newBuilder(com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation prototype) {
+    public static Builder newBuilder(com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
     @java.lang.Override
@@ -6610,29 +6663,29 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The Maximize Clicks opt-in recommendation.
+     * The keyword match type recommendation.
      * </pre>
      *
-     * Protobuf type {@code google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation}
+     * Protobuf type {@code google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation}
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation)
-        com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendationOrBuilder {
+        // @@protoc_insertion_point(builder_implements:google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation)
+        com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendationOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return com.google.ads.googleads.v1.resources.RecommendationProto.internal_static_google_ads_googleads_v1_resources_Recommendation_MaximizeClicksOptInRecommendation_descriptor;
+        return com.google.ads.googleads.v1.resources.RecommendationProto.internal_static_google_ads_googleads_v1_resources_Recommendation_KeywordMatchTypeRecommendation_descriptor;
       }
 
       @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return com.google.ads.googleads.v1.resources.RecommendationProto.internal_static_google_ads_googleads_v1_resources_Recommendation_MaximizeClicksOptInRecommendation_fieldAccessorTable
+        return com.google.ads.googleads.v1.resources.RecommendationProto.internal_static_google_ads_googleads_v1_resources_Recommendation_KeywordMatchTypeRecommendation_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
-                com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation.class, com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation.Builder.class);
+                com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation.class, com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation.Builder.class);
       }
 
-      // Construct using com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation.newBuilder()
+      // Construct using com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation.newBuilder()
       private Builder() {
         maybeForceBuilderInitialization();
       }
@@ -6650,29 +6703,31 @@ private static final long serialVersionUID = 0L;
       @java.lang.Override
       public Builder clear() {
         super.clear();
-        if (recommendedBudgetAmountMicrosBuilder_ == null) {
-          recommendedBudgetAmountMicros_ = null;
+        if (keywordBuilder_ == null) {
+          keyword_ = null;
         } else {
-          recommendedBudgetAmountMicros_ = null;
-          recommendedBudgetAmountMicrosBuilder_ = null;
+          keyword_ = null;
+          keywordBuilder_ = null;
         }
+        recommendedMatchType_ = 0;
+
         return this;
       }
 
       @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return com.google.ads.googleads.v1.resources.RecommendationProto.internal_static_google_ads_googleads_v1_resources_Recommendation_MaximizeClicksOptInRecommendation_descriptor;
+        return com.google.ads.googleads.v1.resources.RecommendationProto.internal_static_google_ads_googleads_v1_resources_Recommendation_KeywordMatchTypeRecommendation_descriptor;
       }
 
       @java.lang.Override
-      public com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation getDefaultInstanceForType() {
-        return com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation.getDefaultInstance();
+      public com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation getDefaultInstanceForType() {
+        return com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation.getDefaultInstance();
       }
 
       @java.lang.Override
-      public com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation build() {
-        com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation result = buildPartial();
+      public com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation build() {
+        com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation result = buildPartial();
         if (!result.isInitialized()) {
           throw newUninitializedMessageException(result);
         }
@@ -6680,13 +6735,14 @@ private static final long serialVersionUID = 0L;
       }
 
       @java.lang.Override
-      public com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation buildPartial() {
-        com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation result = new com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation(this);
-        if (recommendedBudgetAmountMicrosBuilder_ == null) {
-          result.recommendedBudgetAmountMicros_ = recommendedBudgetAmountMicros_;
+      public com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation buildPartial() {
+        com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation result = new com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation(this);
+        if (keywordBuilder_ == null) {
+          result.keyword_ = keyword_;
         } else {
-          result.recommendedBudgetAmountMicros_ = recommendedBudgetAmountMicrosBuilder_.build();
+          result.keyword_ = keywordBuilder_.build();
         }
+        result.recommendedMatchType_ = recommendedMatchType_;
         onBuilt();
         return result;
       }
@@ -6725,18 +6781,21 @@ private static final long serialVersionUID = 0L;
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation) {
-          return mergeFrom((com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation)other);
+        if (other instanceof com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation) {
+          return mergeFrom((com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation)other);
         } else {
           super.mergeFrom(other);
           return this;
         }
       }
 
-      public Builder mergeFrom(com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation other) {
-        if (other == com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation.getDefaultInstance()) return this;
-        if (other.hasRecommendedBudgetAmountMicros()) {
-          mergeRecommendedBudgetAmountMicros(other.getRecommendedBudgetAmountMicros());
+      public Builder mergeFrom(com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation other) {
+        if (other == com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation.getDefaultInstance()) return this;
+        if (other.hasKeyword()) {
+          mergeKeyword(other.getKeyword());
+        }
+        if (other.recommendedMatchType_ != 0) {
+          setRecommendedMatchTypeValue(other.getRecommendedMatchTypeValue());
         }
         this.mergeUnknownFields(other.unknownFields);
         onChanged();
@@ -6753,11 +6812,11 @@ private static final long serialVersionUID = 0L;
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation parsedMessage = null;
+        com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation parsedMessage = null;
         try {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation) e.getUnfinishedMessage();
+          parsedMessage = (com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
@@ -6767,166 +6826,222 @@ private static final long serialVersionUID = 0L;
         return this;
       }
 
-      private com.google.protobuf.Int64Value recommendedBudgetAmountMicros_ = null;
+      private com.google.ads.googleads.v1.common.KeywordInfo keyword_ = null;
       private com.google.protobuf.SingleFieldBuilderV3<
-          com.google.protobuf.Int64Value, com.google.protobuf.Int64Value.Builder, com.google.protobuf.Int64ValueOrBuilder> recommendedBudgetAmountMicrosBuilder_;
+          com.google.ads.googleads.v1.common.KeywordInfo, com.google.ads.googleads.v1.common.KeywordInfo.Builder, com.google.ads.googleads.v1.common.KeywordInfoOrBuilder> keywordBuilder_;
       /**
        * <pre>
-       * The recommended new budget amount.
-       * Only set if the current budget is too high.
+       * The existing keyword where the match type should be more broad.
        * </pre>
        *
-       * <code>.google.protobuf.Int64Value recommended_budget_amount_micros = 1;</code>
+       * <code>.google.ads.googleads.v1.common.KeywordInfo keyword = 1;</code>
        */
-      public boolean hasRecommendedBudgetAmountMicros() {
-        return recommendedBudgetAmountMicrosBuilder_ != null || recommendedBudgetAmountMicros_ != null;
+      public boolean hasKeyword() {
+        return keywordBuilder_ != null || keyword_ != null;
       }
       /**
        * <pre>
-       * The recommended new budget amount.
-       * Only set if the current budget is too high.
+       * The existing keyword where the match type should be more broad.
        * </pre>
        *
-       * <code>.google.protobuf.Int64Value recommended_budget_amount_micros = 1;</code>
+       * <code>.google.ads.googleads.v1.common.KeywordInfo keyword = 1;</code>
        */
-      public com.google.protobuf.Int64Value getRecommendedBudgetAmountMicros() {
-        if (recommendedBudgetAmountMicrosBuilder_ == null) {
-          return recommendedBudgetAmountMicros_ == null ? com.google.protobuf.Int64Value.getDefaultInstance() : recommendedBudgetAmountMicros_;
+      public com.google.ads.googleads.v1.common.KeywordInfo getKeyword() {
+        if (keywordBuilder_ == null) {
+          return keyword_ == null ? com.google.ads.googleads.v1.common.KeywordInfo.getDefaultInstance() : keyword_;
         } else {
-          return recommendedBudgetAmountMicrosBuilder_.getMessage();
+          return keywordBuilder_.getMessage();
         }
       }
       /**
        * <pre>
-       * The recommended new budget amount.
-       * Only set if the current budget is too high.
+       * The existing keyword where the match type should be more broad.
        * </pre>
        *
-       * <code>.google.protobuf.Int64Value recommended_budget_amount_micros = 1;</code>
+       * <code>.google.ads.googleads.v1.common.KeywordInfo keyword = 1;</code>
        */
-      public Builder setRecommendedBudgetAmountMicros(com.google.protobuf.Int64Value value) {
-        if (recommendedBudgetAmountMicrosBuilder_ == null) {
+      public Builder setKeyword(com.google.ads.googleads.v1.common.KeywordInfo value) {
+        if (keywordBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
           }
-          recommendedBudgetAmountMicros_ = value;
+          keyword_ = value;
           onChanged();
         } else {
-          recommendedBudgetAmountMicrosBuilder_.setMessage(value);
+          keywordBuilder_.setMessage(value);
         }
 
         return this;
       }
       /**
        * <pre>
-       * The recommended new budget amount.
-       * Only set if the current budget is too high.
+       * The existing keyword where the match type should be more broad.
        * </pre>
        *
-       * <code>.google.protobuf.Int64Value recommended_budget_amount_micros = 1;</code>
+       * <code>.google.ads.googleads.v1.common.KeywordInfo keyword = 1;</code>
        */
-      public Builder setRecommendedBudgetAmountMicros(
-          com.google.protobuf.Int64Value.Builder builderForValue) {
-        if (recommendedBudgetAmountMicrosBuilder_ == null) {
-          recommendedBudgetAmountMicros_ = builderForValue.build();
+      public Builder setKeyword(
+          com.google.ads.googleads.v1.common.KeywordInfo.Builder builderForValue) {
+        if (keywordBuilder_ == null) {
+          keyword_ = builderForValue.build();
           onChanged();
         } else {
-          recommendedBudgetAmountMicrosBuilder_.setMessage(builderForValue.build());
+          keywordBuilder_.setMessage(builderForValue.build());
         }
 
         return this;
       }
       /**
        * <pre>
-       * The recommended new budget amount.
-       * Only set if the current budget is too high.
+       * The existing keyword where the match type should be more broad.
        * </pre>
        *
-       * <code>.google.protobuf.Int64Value recommended_budget_amount_micros = 1;</code>
+       * <code>.google.ads.googleads.v1.common.KeywordInfo keyword = 1;</code>
        */
-      public Builder mergeRecommendedBudgetAmountMicros(com.google.protobuf.Int64Value value) {
-        if (recommendedBudgetAmountMicrosBuilder_ == null) {
-          if (recommendedBudgetAmountMicros_ != null) {
-            recommendedBudgetAmountMicros_ =
-              com.google.protobuf.Int64Value.newBuilder(recommendedBudgetAmountMicros_).mergeFrom(value).buildPartial();
+      public Builder mergeKeyword(com.google.ads.googleads.v1.common.KeywordInfo value) {
+        if (keywordBuilder_ == null) {
+          if (keyword_ != null) {
+            keyword_ =
+              com.google.ads.googleads.v1.common.KeywordInfo.newBuilder(keyword_).mergeFrom(value).buildPartial();
           } else {
-            recommendedBudgetAmountMicros_ = value;
+            keyword_ = value;
           }
           onChanged();
         } else {
-          recommendedBudgetAmountMicrosBuilder_.mergeFrom(value);
+          keywordBuilder_.mergeFrom(value);
         }
 
         return this;
       }
       /**
        * <pre>
-       * The recommended new budget amount.
-       * Only set if the current budget is too high.
+       * The existing keyword where the match type should be more broad.
        * </pre>
        *
-       * <code>.google.protobuf.Int64Value recommended_budget_amount_micros = 1;</code>
+       * <code>.google.ads.googleads.v1.common.KeywordInfo keyword = 1;</code>
        */
-      public Builder clearRecommendedBudgetAmountMicros() {
-        if (recommendedBudgetAmountMicrosBuilder_ == null) {
-          recommendedBudgetAmountMicros_ = null;
+      public Builder clearKeyword() {
+        if (keywordBuilder_ == null) {
+          keyword_ = null;
           onChanged();
         } else {
-          recommendedBudgetAmountMicros_ = null;
-          recommendedBudgetAmountMicrosBuilder_ = null;
+          keyword_ = null;
+          keywordBuilder_ = null;
         }
 
         return this;
       }
       /**
        * <pre>
-       * The recommended new budget amount.
-       * Only set if the current budget is too high.
+       * The existing keyword where the match type should be more broad.
        * </pre>
        *
-       * <code>.google.protobuf.Int64Value recommended_budget_amount_micros = 1;</code>
+       * <code>.google.ads.googleads.v1.common.KeywordInfo keyword = 1;</code>
        */
-      public com.google.protobuf.Int64Value.Builder getRecommendedBudgetAmountMicrosBuilder() {
+      public com.google.ads.googleads.v1.common.KeywordInfo.Builder getKeywordBuilder() {
         
         onChanged();
-        return getRecommendedBudgetAmountMicrosFieldBuilder().getBuilder();
+        return getKeywordFieldBuilder().getBuilder();
       }
       /**
        * <pre>
-       * The recommended new budget amount.
-       * Only set if the current budget is too high.
+       * The existing keyword where the match type should be more broad.
        * </pre>
        *
-       * <code>.google.protobuf.Int64Value recommended_budget_amount_micros = 1;</code>
+       * <code>.google.ads.googleads.v1.common.KeywordInfo keyword = 1;</code>
        */
-      public com.google.protobuf.Int64ValueOrBuilder getRecommendedBudgetAmountMicrosOrBuilder() {
-        if (recommendedBudgetAmountMicrosBuilder_ != null) {
-          return recommendedBudgetAmountMicrosBuilder_.getMessageOrBuilder();
+      public com.google.ads.googleads.v1.common.KeywordInfoOrBuilder getKeywordOrBuilder() {
+        if (keywordBuilder_ != null) {
+          return keywordBuilder_.getMessageOrBuilder();
         } else {
-          return recommendedBudgetAmountMicros_ == null ?
-              com.google.protobuf.Int64Value.getDefaultInstance() : recommendedBudgetAmountMicros_;
+          return keyword_ == null ?
+              com.google.ads.googleads.v1.common.KeywordInfo.getDefaultInstance() : keyword_;
         }
       }
       /**
        * <pre>
-       * The recommended new budget amount.
-       * Only set if the current budget is too high.
+       * The existing keyword where the match type should be more broad.
        * </pre>
        *
-       * <code>.google.protobuf.Int64Value recommended_budget_amount_micros = 1;</code>
+       * <code>.google.ads.googleads.v1.common.KeywordInfo keyword = 1;</code>
        */
       private com.google.protobuf.SingleFieldBuilderV3<
-          com.google.protobuf.Int64Value, com.google.protobuf.Int64Value.Builder, com.google.protobuf.Int64ValueOrBuilder> 
-          getRecommendedBudgetAmountMicrosFieldBuilder() {
-        if (recommendedBudgetAmountMicrosBuilder_ == null) {
-          recommendedBudgetAmountMicrosBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-              com.google.protobuf.Int64Value, com.google.protobuf.Int64Value.Builder, com.google.protobuf.Int64ValueOrBuilder>(
-                  getRecommendedBudgetAmountMicros(),
+          com.google.ads.googleads.v1.common.KeywordInfo, com.google.ads.googleads.v1.common.KeywordInfo.Builder, com.google.ads.googleads.v1.common.KeywordInfoOrBuilder> 
+          getKeywordFieldBuilder() {
+        if (keywordBuilder_ == null) {
+          keywordBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
+              com.google.ads.googleads.v1.common.KeywordInfo, com.google.ads.googleads.v1.common.KeywordInfo.Builder, com.google.ads.googleads.v1.common.KeywordInfoOrBuilder>(
+                  getKeyword(),
                   getParentForChildren(),
                   isClean());
-          recommendedBudgetAmountMicros_ = null;
+          keyword_ = null;
         }
-        return recommendedBudgetAmountMicrosBuilder_;
+        return keywordBuilder_;
+      }
+
+      private int recommendedMatchType_ = 0;
+      /**
+       * <pre>
+       * The recommended new match type.
+       * </pre>
+       *
+       * <code>.google.ads.googleads.v1.enums.KeywordMatchTypeEnum.KeywordMatchType recommended_match_type = 2;</code>
+       */
+      public int getRecommendedMatchTypeValue() {
+        return recommendedMatchType_;
+      }
+      /**
+       * <pre>
+       * The recommended new match type.
+       * </pre>
+       *
+       * <code>.google.ads.googleads.v1.enums.KeywordMatchTypeEnum.KeywordMatchType recommended_match_type = 2;</code>
+       */
+      public Builder setRecommendedMatchTypeValue(int value) {
+        recommendedMatchType_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * The recommended new match type.
+       * </pre>
+       *
+       * <code>.google.ads.googleads.v1.enums.KeywordMatchTypeEnum.KeywordMatchType recommended_match_type = 2;</code>
+       */
+      public com.google.ads.googleads.v1.enums.KeywordMatchTypeEnum.KeywordMatchType getRecommendedMatchType() {
+        @SuppressWarnings("deprecation")
+        com.google.ads.googleads.v1.enums.KeywordMatchTypeEnum.KeywordMatchType result = com.google.ads.googleads.v1.enums.KeywordMatchTypeEnum.KeywordMatchType.valueOf(recommendedMatchType_);
+        return result == null ? com.google.ads.googleads.v1.enums.KeywordMatchTypeEnum.KeywordMatchType.UNRECOGNIZED : result;
+      }
+      /**
+       * <pre>
+       * The recommended new match type.
+       * </pre>
+       *
+       * <code>.google.ads.googleads.v1.enums.KeywordMatchTypeEnum.KeywordMatchType recommended_match_type = 2;</code>
+       */
+      public Builder setRecommendedMatchType(com.google.ads.googleads.v1.enums.KeywordMatchTypeEnum.KeywordMatchType value) {
+        if (value == null) {
+          throw new NullPointerException();
+        }
+        
+        recommendedMatchType_ = value.getNumber();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * The recommended new match type.
+       * </pre>
+       *
+       * <code>.google.ads.googleads.v1.enums.KeywordMatchTypeEnum.KeywordMatchType recommended_match_type = 2;</code>
+       */
+      public Builder clearRecommendedMatchType() {
+        
+        recommendedMatchType_ = 0;
+        onChanged();
+        return this;
       }
       @java.lang.Override
       public final Builder setUnknownFields(
@@ -6941,41 +7056,41 @@ private static final long serialVersionUID = 0L;
       }
 
 
-      // @@protoc_insertion_point(builder_scope:google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation)
+      // @@protoc_insertion_point(builder_scope:google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation)
     }
 
-    // @@protoc_insertion_point(class_scope:google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation)
-    private static final com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation DEFAULT_INSTANCE;
+    // @@protoc_insertion_point(class_scope:google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation)
+    private static final com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation DEFAULT_INSTANCE;
     static {
-      DEFAULT_INSTANCE = new com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation();
+      DEFAULT_INSTANCE = new com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation();
     }
 
-    public static com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation getDefaultInstance() {
+    public static com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation getDefaultInstance() {
       return DEFAULT_INSTANCE;
     }
 
-    private static final com.google.protobuf.Parser<MaximizeClicksOptInRecommendation>
-        PARSER = new com.google.protobuf.AbstractParser<MaximizeClicksOptInRecommendation>() {
+    private static final com.google.protobuf.Parser<KeywordMatchTypeRecommendation>
+        PARSER = new com.google.protobuf.AbstractParser<KeywordMatchTypeRecommendation>() {
       @java.lang.Override
-      public MaximizeClicksOptInRecommendation parsePartialFrom(
+      public KeywordMatchTypeRecommendation parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new MaximizeClicksOptInRecommendation(input, extensionRegistry);
+        return new KeywordMatchTypeRecommendation(input, extensionRegistry);
       }
     };
 
-    public static com.google.protobuf.Parser<MaximizeClicksOptInRecommendation> parser() {
+    public static com.google.protobuf.Parser<KeywordMatchTypeRecommendation> parser() {
       return PARSER;
     }
 
     @java.lang.Override
-    public com.google.protobuf.Parser<MaximizeClicksOptInRecommendation> getParserForType() {
+    public com.google.protobuf.Parser<KeywordMatchTypeRecommendation> getParserForType() {
       return PARSER;
     }
 
     @java.lang.Override
-    public com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation getDefaultInstanceForType() {
+    public com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
 
@@ -8204,6 +8319,2018 @@ private static final long serialVersionUID = 0L;
 
     @java.lang.Override
     public com.google.ads.googleads.v1.resources.Recommendation.TextAdRecommendation getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
+  public interface SearchPartnersOptInRecommendationOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation)
+      com.google.protobuf.MessageOrBuilder {
+  }
+  /**
+   * <pre>
+   * The Search Partners Opt-In recommendation.
+   * </pre>
+   *
+   * Protobuf type {@code google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation}
+   */
+  public  static final class SearchPartnersOptInRecommendation extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation)
+      SearchPartnersOptInRecommendationOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use SearchPartnersOptInRecommendation.newBuilder() to construct.
+    private SearchPartnersOptInRecommendation(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private SearchPartnersOptInRecommendation() {
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private SearchPartnersOptInRecommendation(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!parseUnknownFieldProto3(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return com.google.ads.googleads.v1.resources.RecommendationProto.internal_static_google_ads_googleads_v1_resources_Recommendation_SearchPartnersOptInRecommendation_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return com.google.ads.googleads.v1.resources.RecommendationProto.internal_static_google_ads_googleads_v1_resources_Recommendation_SearchPartnersOptInRecommendation_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation.class, com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation.Builder.class);
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      unknownFields.writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation)) {
+        return super.equals(obj);
+      }
+      com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation other = (com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation) obj;
+
+      boolean result = true;
+      result = result && unknownFields.equals(other.unknownFields);
+      return result;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * <pre>
+     * The Search Partners Opt-In recommendation.
+     * </pre>
+     *
+     * Protobuf type {@code google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation)
+        com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendationOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return com.google.ads.googleads.v1.resources.RecommendationProto.internal_static_google_ads_googleads_v1_resources_Recommendation_SearchPartnersOptInRecommendation_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return com.google.ads.googleads.v1.resources.RecommendationProto.internal_static_google_ads_googleads_v1_resources_Recommendation_SearchPartnersOptInRecommendation_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation.class, com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation.Builder.class);
+      }
+
+      // Construct using com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return com.google.ads.googleads.v1.resources.RecommendationProto.internal_static_google_ads_googleads_v1_resources_Recommendation_SearchPartnersOptInRecommendation_descriptor;
+      }
+
+      @java.lang.Override
+      public com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation getDefaultInstanceForType() {
+        return com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation build() {
+        com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation buildPartial() {
+        com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation result = new com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation(this);
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return (Builder) super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return (Builder) super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return (Builder) super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return (Builder) super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return (Builder) super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return (Builder) super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation) {
+          return mergeFrom((com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation other) {
+        if (other == com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation.getDefaultInstance()) return this;
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFieldsProto3(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation)
+    }
+
+    // @@protoc_insertion_point(class_scope:google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation)
+    private static final com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation();
+    }
+
+    public static com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static final com.google.protobuf.Parser<SearchPartnersOptInRecommendation>
+        PARSER = new com.google.protobuf.AbstractParser<SearchPartnersOptInRecommendation>() {
+      @java.lang.Override
+      public SearchPartnersOptInRecommendation parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new SearchPartnersOptInRecommendation(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<SearchPartnersOptInRecommendation> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<SearchPartnersOptInRecommendation> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
+  public interface MaximizeClicksOptInRecommendationOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <pre>
+     * The recommended new budget amount.
+     * Only set if the current budget is too high.
+     * </pre>
+     *
+     * <code>.google.protobuf.Int64Value recommended_budget_amount_micros = 1;</code>
+     */
+    boolean hasRecommendedBudgetAmountMicros();
+    /**
+     * <pre>
+     * The recommended new budget amount.
+     * Only set if the current budget is too high.
+     * </pre>
+     *
+     * <code>.google.protobuf.Int64Value recommended_budget_amount_micros = 1;</code>
+     */
+    com.google.protobuf.Int64Value getRecommendedBudgetAmountMicros();
+    /**
+     * <pre>
+     * The recommended new budget amount.
+     * Only set if the current budget is too high.
+     * </pre>
+     *
+     * <code>.google.protobuf.Int64Value recommended_budget_amount_micros = 1;</code>
+     */
+    com.google.protobuf.Int64ValueOrBuilder getRecommendedBudgetAmountMicrosOrBuilder();
+  }
+  /**
+   * <pre>
+   * The Maximize Clicks opt-in recommendation.
+   * </pre>
+   *
+   * Protobuf type {@code google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation}
+   */
+  public  static final class MaximizeClicksOptInRecommendation extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation)
+      MaximizeClicksOptInRecommendationOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use MaximizeClicksOptInRecommendation.newBuilder() to construct.
+    private MaximizeClicksOptInRecommendation(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private MaximizeClicksOptInRecommendation() {
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private MaximizeClicksOptInRecommendation(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            case 10: {
+              com.google.protobuf.Int64Value.Builder subBuilder = null;
+              if (recommendedBudgetAmountMicros_ != null) {
+                subBuilder = recommendedBudgetAmountMicros_.toBuilder();
+              }
+              recommendedBudgetAmountMicros_ = input.readMessage(com.google.protobuf.Int64Value.parser(), extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(recommendedBudgetAmountMicros_);
+                recommendedBudgetAmountMicros_ = subBuilder.buildPartial();
+              }
+
+              break;
+            }
+            default: {
+              if (!parseUnknownFieldProto3(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return com.google.ads.googleads.v1.resources.RecommendationProto.internal_static_google_ads_googleads_v1_resources_Recommendation_MaximizeClicksOptInRecommendation_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return com.google.ads.googleads.v1.resources.RecommendationProto.internal_static_google_ads_googleads_v1_resources_Recommendation_MaximizeClicksOptInRecommendation_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation.class, com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation.Builder.class);
+    }
+
+    public static final int RECOMMENDED_BUDGET_AMOUNT_MICROS_FIELD_NUMBER = 1;
+    private com.google.protobuf.Int64Value recommendedBudgetAmountMicros_;
+    /**
+     * <pre>
+     * The recommended new budget amount.
+     * Only set if the current budget is too high.
+     * </pre>
+     *
+     * <code>.google.protobuf.Int64Value recommended_budget_amount_micros = 1;</code>
+     */
+    public boolean hasRecommendedBudgetAmountMicros() {
+      return recommendedBudgetAmountMicros_ != null;
+    }
+    /**
+     * <pre>
+     * The recommended new budget amount.
+     * Only set if the current budget is too high.
+     * </pre>
+     *
+     * <code>.google.protobuf.Int64Value recommended_budget_amount_micros = 1;</code>
+     */
+    public com.google.protobuf.Int64Value getRecommendedBudgetAmountMicros() {
+      return recommendedBudgetAmountMicros_ == null ? com.google.protobuf.Int64Value.getDefaultInstance() : recommendedBudgetAmountMicros_;
+    }
+    /**
+     * <pre>
+     * The recommended new budget amount.
+     * Only set if the current budget is too high.
+     * </pre>
+     *
+     * <code>.google.protobuf.Int64Value recommended_budget_amount_micros = 1;</code>
+     */
+    public com.google.protobuf.Int64ValueOrBuilder getRecommendedBudgetAmountMicrosOrBuilder() {
+      return getRecommendedBudgetAmountMicros();
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      if (recommendedBudgetAmountMicros_ != null) {
+        output.writeMessage(1, getRecommendedBudgetAmountMicros());
+      }
+      unknownFields.writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (recommendedBudgetAmountMicros_ != null) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(1, getRecommendedBudgetAmountMicros());
+      }
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation)) {
+        return super.equals(obj);
+      }
+      com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation other = (com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation) obj;
+
+      boolean result = true;
+      result = result && (hasRecommendedBudgetAmountMicros() == other.hasRecommendedBudgetAmountMicros());
+      if (hasRecommendedBudgetAmountMicros()) {
+        result = result && getRecommendedBudgetAmountMicros()
+            .equals(other.getRecommendedBudgetAmountMicros());
+      }
+      result = result && unknownFields.equals(other.unknownFields);
+      return result;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (hasRecommendedBudgetAmountMicros()) {
+        hash = (37 * hash) + RECOMMENDED_BUDGET_AMOUNT_MICROS_FIELD_NUMBER;
+        hash = (53 * hash) + getRecommendedBudgetAmountMicros().hashCode();
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * <pre>
+     * The Maximize Clicks opt-in recommendation.
+     * </pre>
+     *
+     * Protobuf type {@code google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation)
+        com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendationOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return com.google.ads.googleads.v1.resources.RecommendationProto.internal_static_google_ads_googleads_v1_resources_Recommendation_MaximizeClicksOptInRecommendation_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return com.google.ads.googleads.v1.resources.RecommendationProto.internal_static_google_ads_googleads_v1_resources_Recommendation_MaximizeClicksOptInRecommendation_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation.class, com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation.Builder.class);
+      }
+
+      // Construct using com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        if (recommendedBudgetAmountMicrosBuilder_ == null) {
+          recommendedBudgetAmountMicros_ = null;
+        } else {
+          recommendedBudgetAmountMicros_ = null;
+          recommendedBudgetAmountMicrosBuilder_ = null;
+        }
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return com.google.ads.googleads.v1.resources.RecommendationProto.internal_static_google_ads_googleads_v1_resources_Recommendation_MaximizeClicksOptInRecommendation_descriptor;
+      }
+
+      @java.lang.Override
+      public com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation getDefaultInstanceForType() {
+        return com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation build() {
+        com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation buildPartial() {
+        com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation result = new com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation(this);
+        if (recommendedBudgetAmountMicrosBuilder_ == null) {
+          result.recommendedBudgetAmountMicros_ = recommendedBudgetAmountMicros_;
+        } else {
+          result.recommendedBudgetAmountMicros_ = recommendedBudgetAmountMicrosBuilder_.build();
+        }
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return (Builder) super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return (Builder) super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return (Builder) super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return (Builder) super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return (Builder) super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return (Builder) super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation) {
+          return mergeFrom((com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation other) {
+        if (other == com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation.getDefaultInstance()) return this;
+        if (other.hasRecommendedBudgetAmountMicros()) {
+          mergeRecommendedBudgetAmountMicros(other.getRecommendedBudgetAmountMicros());
+        }
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+
+      private com.google.protobuf.Int64Value recommendedBudgetAmountMicros_ = null;
+      private com.google.protobuf.SingleFieldBuilderV3<
+          com.google.protobuf.Int64Value, com.google.protobuf.Int64Value.Builder, com.google.protobuf.Int64ValueOrBuilder> recommendedBudgetAmountMicrosBuilder_;
+      /**
+       * <pre>
+       * The recommended new budget amount.
+       * Only set if the current budget is too high.
+       * </pre>
+       *
+       * <code>.google.protobuf.Int64Value recommended_budget_amount_micros = 1;</code>
+       */
+      public boolean hasRecommendedBudgetAmountMicros() {
+        return recommendedBudgetAmountMicrosBuilder_ != null || recommendedBudgetAmountMicros_ != null;
+      }
+      /**
+       * <pre>
+       * The recommended new budget amount.
+       * Only set if the current budget is too high.
+       * </pre>
+       *
+       * <code>.google.protobuf.Int64Value recommended_budget_amount_micros = 1;</code>
+       */
+      public com.google.protobuf.Int64Value getRecommendedBudgetAmountMicros() {
+        if (recommendedBudgetAmountMicrosBuilder_ == null) {
+          return recommendedBudgetAmountMicros_ == null ? com.google.protobuf.Int64Value.getDefaultInstance() : recommendedBudgetAmountMicros_;
+        } else {
+          return recommendedBudgetAmountMicrosBuilder_.getMessage();
+        }
+      }
+      /**
+       * <pre>
+       * The recommended new budget amount.
+       * Only set if the current budget is too high.
+       * </pre>
+       *
+       * <code>.google.protobuf.Int64Value recommended_budget_amount_micros = 1;</code>
+       */
+      public Builder setRecommendedBudgetAmountMicros(com.google.protobuf.Int64Value value) {
+        if (recommendedBudgetAmountMicrosBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          recommendedBudgetAmountMicros_ = value;
+          onChanged();
+        } else {
+          recommendedBudgetAmountMicrosBuilder_.setMessage(value);
+        }
+
+        return this;
+      }
+      /**
+       * <pre>
+       * The recommended new budget amount.
+       * Only set if the current budget is too high.
+       * </pre>
+       *
+       * <code>.google.protobuf.Int64Value recommended_budget_amount_micros = 1;</code>
+       */
+      public Builder setRecommendedBudgetAmountMicros(
+          com.google.protobuf.Int64Value.Builder builderForValue) {
+        if (recommendedBudgetAmountMicrosBuilder_ == null) {
+          recommendedBudgetAmountMicros_ = builderForValue.build();
+          onChanged();
+        } else {
+          recommendedBudgetAmountMicrosBuilder_.setMessage(builderForValue.build());
+        }
+
+        return this;
+      }
+      /**
+       * <pre>
+       * The recommended new budget amount.
+       * Only set if the current budget is too high.
+       * </pre>
+       *
+       * <code>.google.protobuf.Int64Value recommended_budget_amount_micros = 1;</code>
+       */
+      public Builder mergeRecommendedBudgetAmountMicros(com.google.protobuf.Int64Value value) {
+        if (recommendedBudgetAmountMicrosBuilder_ == null) {
+          if (recommendedBudgetAmountMicros_ != null) {
+            recommendedBudgetAmountMicros_ =
+              com.google.protobuf.Int64Value.newBuilder(recommendedBudgetAmountMicros_).mergeFrom(value).buildPartial();
+          } else {
+            recommendedBudgetAmountMicros_ = value;
+          }
+          onChanged();
+        } else {
+          recommendedBudgetAmountMicrosBuilder_.mergeFrom(value);
+        }
+
+        return this;
+      }
+      /**
+       * <pre>
+       * The recommended new budget amount.
+       * Only set if the current budget is too high.
+       * </pre>
+       *
+       * <code>.google.protobuf.Int64Value recommended_budget_amount_micros = 1;</code>
+       */
+      public Builder clearRecommendedBudgetAmountMicros() {
+        if (recommendedBudgetAmountMicrosBuilder_ == null) {
+          recommendedBudgetAmountMicros_ = null;
+          onChanged();
+        } else {
+          recommendedBudgetAmountMicros_ = null;
+          recommendedBudgetAmountMicrosBuilder_ = null;
+        }
+
+        return this;
+      }
+      /**
+       * <pre>
+       * The recommended new budget amount.
+       * Only set if the current budget is too high.
+       * </pre>
+       *
+       * <code>.google.protobuf.Int64Value recommended_budget_amount_micros = 1;</code>
+       */
+      public com.google.protobuf.Int64Value.Builder getRecommendedBudgetAmountMicrosBuilder() {
+        
+        onChanged();
+        return getRecommendedBudgetAmountMicrosFieldBuilder().getBuilder();
+      }
+      /**
+       * <pre>
+       * The recommended new budget amount.
+       * Only set if the current budget is too high.
+       * </pre>
+       *
+       * <code>.google.protobuf.Int64Value recommended_budget_amount_micros = 1;</code>
+       */
+      public com.google.protobuf.Int64ValueOrBuilder getRecommendedBudgetAmountMicrosOrBuilder() {
+        if (recommendedBudgetAmountMicrosBuilder_ != null) {
+          return recommendedBudgetAmountMicrosBuilder_.getMessageOrBuilder();
+        } else {
+          return recommendedBudgetAmountMicros_ == null ?
+              com.google.protobuf.Int64Value.getDefaultInstance() : recommendedBudgetAmountMicros_;
+        }
+      }
+      /**
+       * <pre>
+       * The recommended new budget amount.
+       * Only set if the current budget is too high.
+       * </pre>
+       *
+       * <code>.google.protobuf.Int64Value recommended_budget_amount_micros = 1;</code>
+       */
+      private com.google.protobuf.SingleFieldBuilderV3<
+          com.google.protobuf.Int64Value, com.google.protobuf.Int64Value.Builder, com.google.protobuf.Int64ValueOrBuilder> 
+          getRecommendedBudgetAmountMicrosFieldBuilder() {
+        if (recommendedBudgetAmountMicrosBuilder_ == null) {
+          recommendedBudgetAmountMicrosBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
+              com.google.protobuf.Int64Value, com.google.protobuf.Int64Value.Builder, com.google.protobuf.Int64ValueOrBuilder>(
+                  getRecommendedBudgetAmountMicros(),
+                  getParentForChildren(),
+                  isClean());
+          recommendedBudgetAmountMicros_ = null;
+        }
+        return recommendedBudgetAmountMicrosBuilder_;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFieldsProto3(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation)
+    }
+
+    // @@protoc_insertion_point(class_scope:google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation)
+    private static final com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation();
+    }
+
+    public static com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static final com.google.protobuf.Parser<MaximizeClicksOptInRecommendation>
+        PARSER = new com.google.protobuf.AbstractParser<MaximizeClicksOptInRecommendation>() {
+      @java.lang.Override
+      public MaximizeClicksOptInRecommendation parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new MaximizeClicksOptInRecommendation(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<MaximizeClicksOptInRecommendation> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<MaximizeClicksOptInRecommendation> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.ads.googleads.v1.resources.Recommendation.MaximizeClicksOptInRecommendation getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
+  public interface CalloutExtensionRecommendationOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <pre>
+     * Callout extensions recommended to be added.
+     * </pre>
+     *
+     * <code>repeated .google.ads.googleads.v1.common.CalloutFeedItem recommended_extensions = 1;</code>
+     */
+    java.util.List<com.google.ads.googleads.v1.common.CalloutFeedItem> 
+        getRecommendedExtensionsList();
+    /**
+     * <pre>
+     * Callout extensions recommended to be added.
+     * </pre>
+     *
+     * <code>repeated .google.ads.googleads.v1.common.CalloutFeedItem recommended_extensions = 1;</code>
+     */
+    com.google.ads.googleads.v1.common.CalloutFeedItem getRecommendedExtensions(int index);
+    /**
+     * <pre>
+     * Callout extensions recommended to be added.
+     * </pre>
+     *
+     * <code>repeated .google.ads.googleads.v1.common.CalloutFeedItem recommended_extensions = 1;</code>
+     */
+    int getRecommendedExtensionsCount();
+    /**
+     * <pre>
+     * Callout extensions recommended to be added.
+     * </pre>
+     *
+     * <code>repeated .google.ads.googleads.v1.common.CalloutFeedItem recommended_extensions = 1;</code>
+     */
+    java.util.List<? extends com.google.ads.googleads.v1.common.CalloutFeedItemOrBuilder> 
+        getRecommendedExtensionsOrBuilderList();
+    /**
+     * <pre>
+     * Callout extensions recommended to be added.
+     * </pre>
+     *
+     * <code>repeated .google.ads.googleads.v1.common.CalloutFeedItem recommended_extensions = 1;</code>
+     */
+    com.google.ads.googleads.v1.common.CalloutFeedItemOrBuilder getRecommendedExtensionsOrBuilder(
+        int index);
+  }
+  /**
+   * <pre>
+   * The Callout extension recommendation.
+   * </pre>
+   *
+   * Protobuf type {@code google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation}
+   */
+  public  static final class CalloutExtensionRecommendation extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation)
+      CalloutExtensionRecommendationOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use CalloutExtensionRecommendation.newBuilder() to construct.
+    private CalloutExtensionRecommendation(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private CalloutExtensionRecommendation() {
+      recommendedExtensions_ = java.util.Collections.emptyList();
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private CalloutExtensionRecommendation(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            case 10: {
+              if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+                recommendedExtensions_ = new java.util.ArrayList<com.google.ads.googleads.v1.common.CalloutFeedItem>();
+                mutable_bitField0_ |= 0x00000001;
+              }
+              recommendedExtensions_.add(
+                  input.readMessage(com.google.ads.googleads.v1.common.CalloutFeedItem.parser(), extensionRegistry));
+              break;
+            }
+            default: {
+              if (!parseUnknownFieldProto3(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+          recommendedExtensions_ = java.util.Collections.unmodifiableList(recommendedExtensions_);
+        }
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return com.google.ads.googleads.v1.resources.RecommendationProto.internal_static_google_ads_googleads_v1_resources_Recommendation_CalloutExtensionRecommendation_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return com.google.ads.googleads.v1.resources.RecommendationProto.internal_static_google_ads_googleads_v1_resources_Recommendation_CalloutExtensionRecommendation_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation.class, com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation.Builder.class);
+    }
+
+    public static final int RECOMMENDED_EXTENSIONS_FIELD_NUMBER = 1;
+    private java.util.List<com.google.ads.googleads.v1.common.CalloutFeedItem> recommendedExtensions_;
+    /**
+     * <pre>
+     * Callout extensions recommended to be added.
+     * </pre>
+     *
+     * <code>repeated .google.ads.googleads.v1.common.CalloutFeedItem recommended_extensions = 1;</code>
+     */
+    public java.util.List<com.google.ads.googleads.v1.common.CalloutFeedItem> getRecommendedExtensionsList() {
+      return recommendedExtensions_;
+    }
+    /**
+     * <pre>
+     * Callout extensions recommended to be added.
+     * </pre>
+     *
+     * <code>repeated .google.ads.googleads.v1.common.CalloutFeedItem recommended_extensions = 1;</code>
+     */
+    public java.util.List<? extends com.google.ads.googleads.v1.common.CalloutFeedItemOrBuilder> 
+        getRecommendedExtensionsOrBuilderList() {
+      return recommendedExtensions_;
+    }
+    /**
+     * <pre>
+     * Callout extensions recommended to be added.
+     * </pre>
+     *
+     * <code>repeated .google.ads.googleads.v1.common.CalloutFeedItem recommended_extensions = 1;</code>
+     */
+    public int getRecommendedExtensionsCount() {
+      return recommendedExtensions_.size();
+    }
+    /**
+     * <pre>
+     * Callout extensions recommended to be added.
+     * </pre>
+     *
+     * <code>repeated .google.ads.googleads.v1.common.CalloutFeedItem recommended_extensions = 1;</code>
+     */
+    public com.google.ads.googleads.v1.common.CalloutFeedItem getRecommendedExtensions(int index) {
+      return recommendedExtensions_.get(index);
+    }
+    /**
+     * <pre>
+     * Callout extensions recommended to be added.
+     * </pre>
+     *
+     * <code>repeated .google.ads.googleads.v1.common.CalloutFeedItem recommended_extensions = 1;</code>
+     */
+    public com.google.ads.googleads.v1.common.CalloutFeedItemOrBuilder getRecommendedExtensionsOrBuilder(
+        int index) {
+      return recommendedExtensions_.get(index);
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      for (int i = 0; i < recommendedExtensions_.size(); i++) {
+        output.writeMessage(1, recommendedExtensions_.get(i));
+      }
+      unknownFields.writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      for (int i = 0; i < recommendedExtensions_.size(); i++) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(1, recommendedExtensions_.get(i));
+      }
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation)) {
+        return super.equals(obj);
+      }
+      com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation other = (com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation) obj;
+
+      boolean result = true;
+      result = result && getRecommendedExtensionsList()
+          .equals(other.getRecommendedExtensionsList());
+      result = result && unknownFields.equals(other.unknownFields);
+      return result;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (getRecommendedExtensionsCount() > 0) {
+        hash = (37 * hash) + RECOMMENDED_EXTENSIONS_FIELD_NUMBER;
+        hash = (53 * hash) + getRecommendedExtensionsList().hashCode();
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * <pre>
+     * The Callout extension recommendation.
+     * </pre>
+     *
+     * Protobuf type {@code google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation)
+        com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendationOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return com.google.ads.googleads.v1.resources.RecommendationProto.internal_static_google_ads_googleads_v1_resources_Recommendation_CalloutExtensionRecommendation_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return com.google.ads.googleads.v1.resources.RecommendationProto.internal_static_google_ads_googleads_v1_resources_Recommendation_CalloutExtensionRecommendation_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation.class, com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation.Builder.class);
+      }
+
+      // Construct using com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+          getRecommendedExtensionsFieldBuilder();
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        if (recommendedExtensionsBuilder_ == null) {
+          recommendedExtensions_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000001);
+        } else {
+          recommendedExtensionsBuilder_.clear();
+        }
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return com.google.ads.googleads.v1.resources.RecommendationProto.internal_static_google_ads_googleads_v1_resources_Recommendation_CalloutExtensionRecommendation_descriptor;
+      }
+
+      @java.lang.Override
+      public com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation getDefaultInstanceForType() {
+        return com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation build() {
+        com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation buildPartial() {
+        com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation result = new com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation(this);
+        int from_bitField0_ = bitField0_;
+        if (recommendedExtensionsBuilder_ == null) {
+          if (((bitField0_ & 0x00000001) == 0x00000001)) {
+            recommendedExtensions_ = java.util.Collections.unmodifiableList(recommendedExtensions_);
+            bitField0_ = (bitField0_ & ~0x00000001);
+          }
+          result.recommendedExtensions_ = recommendedExtensions_;
+        } else {
+          result.recommendedExtensions_ = recommendedExtensionsBuilder_.build();
+        }
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return (Builder) super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return (Builder) super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return (Builder) super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return (Builder) super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return (Builder) super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return (Builder) super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation) {
+          return mergeFrom((com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation other) {
+        if (other == com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation.getDefaultInstance()) return this;
+        if (recommendedExtensionsBuilder_ == null) {
+          if (!other.recommendedExtensions_.isEmpty()) {
+            if (recommendedExtensions_.isEmpty()) {
+              recommendedExtensions_ = other.recommendedExtensions_;
+              bitField0_ = (bitField0_ & ~0x00000001);
+            } else {
+              ensureRecommendedExtensionsIsMutable();
+              recommendedExtensions_.addAll(other.recommendedExtensions_);
+            }
+            onChanged();
+          }
+        } else {
+          if (!other.recommendedExtensions_.isEmpty()) {
+            if (recommendedExtensionsBuilder_.isEmpty()) {
+              recommendedExtensionsBuilder_.dispose();
+              recommendedExtensionsBuilder_ = null;
+              recommendedExtensions_ = other.recommendedExtensions_;
+              bitField0_ = (bitField0_ & ~0x00000001);
+              recommendedExtensionsBuilder_ = 
+                com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
+                   getRecommendedExtensionsFieldBuilder() : null;
+            } else {
+              recommendedExtensionsBuilder_.addAllMessages(other.recommendedExtensions_);
+            }
+          }
+        }
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      private java.util.List<com.google.ads.googleads.v1.common.CalloutFeedItem> recommendedExtensions_ =
+        java.util.Collections.emptyList();
+      private void ensureRecommendedExtensionsIsMutable() {
+        if (!((bitField0_ & 0x00000001) == 0x00000001)) {
+          recommendedExtensions_ = new java.util.ArrayList<com.google.ads.googleads.v1.common.CalloutFeedItem>(recommendedExtensions_);
+          bitField0_ |= 0x00000001;
+         }
+      }
+
+      private com.google.protobuf.RepeatedFieldBuilderV3<
+          com.google.ads.googleads.v1.common.CalloutFeedItem, com.google.ads.googleads.v1.common.CalloutFeedItem.Builder, com.google.ads.googleads.v1.common.CalloutFeedItemOrBuilder> recommendedExtensionsBuilder_;
+
+      /**
+       * <pre>
+       * Callout extensions recommended to be added.
+       * </pre>
+       *
+       * <code>repeated .google.ads.googleads.v1.common.CalloutFeedItem recommended_extensions = 1;</code>
+       */
+      public java.util.List<com.google.ads.googleads.v1.common.CalloutFeedItem> getRecommendedExtensionsList() {
+        if (recommendedExtensionsBuilder_ == null) {
+          return java.util.Collections.unmodifiableList(recommendedExtensions_);
+        } else {
+          return recommendedExtensionsBuilder_.getMessageList();
+        }
+      }
+      /**
+       * <pre>
+       * Callout extensions recommended to be added.
+       * </pre>
+       *
+       * <code>repeated .google.ads.googleads.v1.common.CalloutFeedItem recommended_extensions = 1;</code>
+       */
+      public int getRecommendedExtensionsCount() {
+        if (recommendedExtensionsBuilder_ == null) {
+          return recommendedExtensions_.size();
+        } else {
+          return recommendedExtensionsBuilder_.getCount();
+        }
+      }
+      /**
+       * <pre>
+       * Callout extensions recommended to be added.
+       * </pre>
+       *
+       * <code>repeated .google.ads.googleads.v1.common.CalloutFeedItem recommended_extensions = 1;</code>
+       */
+      public com.google.ads.googleads.v1.common.CalloutFeedItem getRecommendedExtensions(int index) {
+        if (recommendedExtensionsBuilder_ == null) {
+          return recommendedExtensions_.get(index);
+        } else {
+          return recommendedExtensionsBuilder_.getMessage(index);
+        }
+      }
+      /**
+       * <pre>
+       * Callout extensions recommended to be added.
+       * </pre>
+       *
+       * <code>repeated .google.ads.googleads.v1.common.CalloutFeedItem recommended_extensions = 1;</code>
+       */
+      public Builder setRecommendedExtensions(
+          int index, com.google.ads.googleads.v1.common.CalloutFeedItem value) {
+        if (recommendedExtensionsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureRecommendedExtensionsIsMutable();
+          recommendedExtensions_.set(index, value);
+          onChanged();
+        } else {
+          recommendedExtensionsBuilder_.setMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <pre>
+       * Callout extensions recommended to be added.
+       * </pre>
+       *
+       * <code>repeated .google.ads.googleads.v1.common.CalloutFeedItem recommended_extensions = 1;</code>
+       */
+      public Builder setRecommendedExtensions(
+          int index, com.google.ads.googleads.v1.common.CalloutFeedItem.Builder builderForValue) {
+        if (recommendedExtensionsBuilder_ == null) {
+          ensureRecommendedExtensionsIsMutable();
+          recommendedExtensions_.set(index, builderForValue.build());
+          onChanged();
+        } else {
+          recommendedExtensionsBuilder_.setMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <pre>
+       * Callout extensions recommended to be added.
+       * </pre>
+       *
+       * <code>repeated .google.ads.googleads.v1.common.CalloutFeedItem recommended_extensions = 1;</code>
+       */
+      public Builder addRecommendedExtensions(com.google.ads.googleads.v1.common.CalloutFeedItem value) {
+        if (recommendedExtensionsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureRecommendedExtensionsIsMutable();
+          recommendedExtensions_.add(value);
+          onChanged();
+        } else {
+          recommendedExtensionsBuilder_.addMessage(value);
+        }
+        return this;
+      }
+      /**
+       * <pre>
+       * Callout extensions recommended to be added.
+       * </pre>
+       *
+       * <code>repeated .google.ads.googleads.v1.common.CalloutFeedItem recommended_extensions = 1;</code>
+       */
+      public Builder addRecommendedExtensions(
+          int index, com.google.ads.googleads.v1.common.CalloutFeedItem value) {
+        if (recommendedExtensionsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureRecommendedExtensionsIsMutable();
+          recommendedExtensions_.add(index, value);
+          onChanged();
+        } else {
+          recommendedExtensionsBuilder_.addMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <pre>
+       * Callout extensions recommended to be added.
+       * </pre>
+       *
+       * <code>repeated .google.ads.googleads.v1.common.CalloutFeedItem recommended_extensions = 1;</code>
+       */
+      public Builder addRecommendedExtensions(
+          com.google.ads.googleads.v1.common.CalloutFeedItem.Builder builderForValue) {
+        if (recommendedExtensionsBuilder_ == null) {
+          ensureRecommendedExtensionsIsMutable();
+          recommendedExtensions_.add(builderForValue.build());
+          onChanged();
+        } else {
+          recommendedExtensionsBuilder_.addMessage(builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <pre>
+       * Callout extensions recommended to be added.
+       * </pre>
+       *
+       * <code>repeated .google.ads.googleads.v1.common.CalloutFeedItem recommended_extensions = 1;</code>
+       */
+      public Builder addRecommendedExtensions(
+          int index, com.google.ads.googleads.v1.common.CalloutFeedItem.Builder builderForValue) {
+        if (recommendedExtensionsBuilder_ == null) {
+          ensureRecommendedExtensionsIsMutable();
+          recommendedExtensions_.add(index, builderForValue.build());
+          onChanged();
+        } else {
+          recommendedExtensionsBuilder_.addMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <pre>
+       * Callout extensions recommended to be added.
+       * </pre>
+       *
+       * <code>repeated .google.ads.googleads.v1.common.CalloutFeedItem recommended_extensions = 1;</code>
+       */
+      public Builder addAllRecommendedExtensions(
+          java.lang.Iterable<? extends com.google.ads.googleads.v1.common.CalloutFeedItem> values) {
+        if (recommendedExtensionsBuilder_ == null) {
+          ensureRecommendedExtensionsIsMutable();
+          com.google.protobuf.AbstractMessageLite.Builder.addAll(
+              values, recommendedExtensions_);
+          onChanged();
+        } else {
+          recommendedExtensionsBuilder_.addAllMessages(values);
+        }
+        return this;
+      }
+      /**
+       * <pre>
+       * Callout extensions recommended to be added.
+       * </pre>
+       *
+       * <code>repeated .google.ads.googleads.v1.common.CalloutFeedItem recommended_extensions = 1;</code>
+       */
+      public Builder clearRecommendedExtensions() {
+        if (recommendedExtensionsBuilder_ == null) {
+          recommendedExtensions_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000001);
+          onChanged();
+        } else {
+          recommendedExtensionsBuilder_.clear();
+        }
+        return this;
+      }
+      /**
+       * <pre>
+       * Callout extensions recommended to be added.
+       * </pre>
+       *
+       * <code>repeated .google.ads.googleads.v1.common.CalloutFeedItem recommended_extensions = 1;</code>
+       */
+      public Builder removeRecommendedExtensions(int index) {
+        if (recommendedExtensionsBuilder_ == null) {
+          ensureRecommendedExtensionsIsMutable();
+          recommendedExtensions_.remove(index);
+          onChanged();
+        } else {
+          recommendedExtensionsBuilder_.remove(index);
+        }
+        return this;
+      }
+      /**
+       * <pre>
+       * Callout extensions recommended to be added.
+       * </pre>
+       *
+       * <code>repeated .google.ads.googleads.v1.common.CalloutFeedItem recommended_extensions = 1;</code>
+       */
+      public com.google.ads.googleads.v1.common.CalloutFeedItem.Builder getRecommendedExtensionsBuilder(
+          int index) {
+        return getRecommendedExtensionsFieldBuilder().getBuilder(index);
+      }
+      /**
+       * <pre>
+       * Callout extensions recommended to be added.
+       * </pre>
+       *
+       * <code>repeated .google.ads.googleads.v1.common.CalloutFeedItem recommended_extensions = 1;</code>
+       */
+      public com.google.ads.googleads.v1.common.CalloutFeedItemOrBuilder getRecommendedExtensionsOrBuilder(
+          int index) {
+        if (recommendedExtensionsBuilder_ == null) {
+          return recommendedExtensions_.get(index);  } else {
+          return recommendedExtensionsBuilder_.getMessageOrBuilder(index);
+        }
+      }
+      /**
+       * <pre>
+       * Callout extensions recommended to be added.
+       * </pre>
+       *
+       * <code>repeated .google.ads.googleads.v1.common.CalloutFeedItem recommended_extensions = 1;</code>
+       */
+      public java.util.List<? extends com.google.ads.googleads.v1.common.CalloutFeedItemOrBuilder> 
+           getRecommendedExtensionsOrBuilderList() {
+        if (recommendedExtensionsBuilder_ != null) {
+          return recommendedExtensionsBuilder_.getMessageOrBuilderList();
+        } else {
+          return java.util.Collections.unmodifiableList(recommendedExtensions_);
+        }
+      }
+      /**
+       * <pre>
+       * Callout extensions recommended to be added.
+       * </pre>
+       *
+       * <code>repeated .google.ads.googleads.v1.common.CalloutFeedItem recommended_extensions = 1;</code>
+       */
+      public com.google.ads.googleads.v1.common.CalloutFeedItem.Builder addRecommendedExtensionsBuilder() {
+        return getRecommendedExtensionsFieldBuilder().addBuilder(
+            com.google.ads.googleads.v1.common.CalloutFeedItem.getDefaultInstance());
+      }
+      /**
+       * <pre>
+       * Callout extensions recommended to be added.
+       * </pre>
+       *
+       * <code>repeated .google.ads.googleads.v1.common.CalloutFeedItem recommended_extensions = 1;</code>
+       */
+      public com.google.ads.googleads.v1.common.CalloutFeedItem.Builder addRecommendedExtensionsBuilder(
+          int index) {
+        return getRecommendedExtensionsFieldBuilder().addBuilder(
+            index, com.google.ads.googleads.v1.common.CalloutFeedItem.getDefaultInstance());
+      }
+      /**
+       * <pre>
+       * Callout extensions recommended to be added.
+       * </pre>
+       *
+       * <code>repeated .google.ads.googleads.v1.common.CalloutFeedItem recommended_extensions = 1;</code>
+       */
+      public java.util.List<com.google.ads.googleads.v1.common.CalloutFeedItem.Builder> 
+           getRecommendedExtensionsBuilderList() {
+        return getRecommendedExtensionsFieldBuilder().getBuilderList();
+      }
+      private com.google.protobuf.RepeatedFieldBuilderV3<
+          com.google.ads.googleads.v1.common.CalloutFeedItem, com.google.ads.googleads.v1.common.CalloutFeedItem.Builder, com.google.ads.googleads.v1.common.CalloutFeedItemOrBuilder> 
+          getRecommendedExtensionsFieldBuilder() {
+        if (recommendedExtensionsBuilder_ == null) {
+          recommendedExtensionsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
+              com.google.ads.googleads.v1.common.CalloutFeedItem, com.google.ads.googleads.v1.common.CalloutFeedItem.Builder, com.google.ads.googleads.v1.common.CalloutFeedItemOrBuilder>(
+                  recommendedExtensions_,
+                  ((bitField0_ & 0x00000001) == 0x00000001),
+                  getParentForChildren(),
+                  isClean());
+          recommendedExtensions_ = null;
+        }
+        return recommendedExtensionsBuilder_;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFieldsProto3(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation)
+    }
+
+    // @@protoc_insertion_point(class_scope:google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation)
+    private static final com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation();
+    }
+
+    public static com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static final com.google.protobuf.Parser<CalloutExtensionRecommendation>
+        PARSER = new com.google.protobuf.AbstractParser<CalloutExtensionRecommendation>() {
+      @java.lang.Override
+      public CalloutExtensionRecommendation parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new CalloutExtensionRecommendation(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<CalloutExtensionRecommendation> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<CalloutExtensionRecommendation> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
 
@@ -11836,72 +13963,27 @@ private static final long serialVersionUID = 0L;
 
   }
 
-  public interface CalloutExtensionRecommendationOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation)
+  public interface OptimizeAdRotationRecommendationOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation)
       com.google.protobuf.MessageOrBuilder {
-
-    /**
-     * <pre>
-     * Callout extensions recommended to be added.
-     * </pre>
-     *
-     * <code>repeated .google.ads.googleads.v1.common.CalloutFeedItem recommended_extensions = 1;</code>
-     */
-    java.util.List<com.google.ads.googleads.v1.common.CalloutFeedItem> 
-        getRecommendedExtensionsList();
-    /**
-     * <pre>
-     * Callout extensions recommended to be added.
-     * </pre>
-     *
-     * <code>repeated .google.ads.googleads.v1.common.CalloutFeedItem recommended_extensions = 1;</code>
-     */
-    com.google.ads.googleads.v1.common.CalloutFeedItem getRecommendedExtensions(int index);
-    /**
-     * <pre>
-     * Callout extensions recommended to be added.
-     * </pre>
-     *
-     * <code>repeated .google.ads.googleads.v1.common.CalloutFeedItem recommended_extensions = 1;</code>
-     */
-    int getRecommendedExtensionsCount();
-    /**
-     * <pre>
-     * Callout extensions recommended to be added.
-     * </pre>
-     *
-     * <code>repeated .google.ads.googleads.v1.common.CalloutFeedItem recommended_extensions = 1;</code>
-     */
-    java.util.List<? extends com.google.ads.googleads.v1.common.CalloutFeedItemOrBuilder> 
-        getRecommendedExtensionsOrBuilderList();
-    /**
-     * <pre>
-     * Callout extensions recommended to be added.
-     * </pre>
-     *
-     * <code>repeated .google.ads.googleads.v1.common.CalloutFeedItem recommended_extensions = 1;</code>
-     */
-    com.google.ads.googleads.v1.common.CalloutFeedItemOrBuilder getRecommendedExtensionsOrBuilder(
-        int index);
   }
   /**
    * <pre>
-   * The Callout extension recommendation.
+   * The Optimize Ad Rotation recommendation.
    * </pre>
    *
-   * Protobuf type {@code google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation}
+   * Protobuf type {@code google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation}
    */
-  public  static final class CalloutExtensionRecommendation extends
+  public  static final class OptimizeAdRotationRecommendation extends
       com.google.protobuf.GeneratedMessageV3 implements
-      // @@protoc_insertion_point(message_implements:google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation)
-      CalloutExtensionRecommendationOrBuilder {
+      // @@protoc_insertion_point(message_implements:google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation)
+      OptimizeAdRotationRecommendationOrBuilder {
   private static final long serialVersionUID = 0L;
-    // Use CalloutExtensionRecommendation.newBuilder() to construct.
-    private CalloutExtensionRecommendation(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+    // Use OptimizeAdRotationRecommendation.newBuilder() to construct.
+    private OptimizeAdRotationRecommendation(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
     }
-    private CalloutExtensionRecommendation() {
-      recommendedExtensions_ = java.util.Collections.emptyList();
+    private OptimizeAdRotationRecommendation() {
     }
 
     @java.lang.Override
@@ -11909,7 +13991,7 @@ private static final long serialVersionUID = 0L;
     getUnknownFields() {
       return this.unknownFields;
     }
-    private CalloutExtensionRecommendation(
+    private OptimizeAdRotationRecommendation(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
@@ -11917,7 +13999,6 @@ private static final long serialVersionUID = 0L;
       if (extensionRegistry == null) {
         throw new java.lang.NullPointerException();
       }
-      int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
       try {
@@ -11928,15 +14009,6 @@ private static final long serialVersionUID = 0L;
             case 0:
               done = true;
               break;
-            case 10: {
-              if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
-                recommendedExtensions_ = new java.util.ArrayList<com.google.ads.googleads.v1.common.CalloutFeedItem>();
-                mutable_bitField0_ |= 0x00000001;
-              }
-              recommendedExtensions_.add(
-                  input.readMessage(com.google.ads.googleads.v1.common.CalloutFeedItem.parser(), extensionRegistry));
-              break;
-            }
             default: {
               if (!parseUnknownFieldProto3(
                   input, unknownFields, extensionRegistry, tag)) {
@@ -11952,79 +14024,21 @@ private static final long serialVersionUID = 0L;
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
       } finally {
-        if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
-          recommendedExtensions_ = java.util.Collections.unmodifiableList(recommendedExtensions_);
-        }
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
       }
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.google.ads.googleads.v1.resources.RecommendationProto.internal_static_google_ads_googleads_v1_resources_Recommendation_CalloutExtensionRecommendation_descriptor;
+      return com.google.ads.googleads.v1.resources.RecommendationProto.internal_static_google_ads_googleads_v1_resources_Recommendation_OptimizeAdRotationRecommendation_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.google.ads.googleads.v1.resources.RecommendationProto.internal_static_google_ads_googleads_v1_resources_Recommendation_CalloutExtensionRecommendation_fieldAccessorTable
+      return com.google.ads.googleads.v1.resources.RecommendationProto.internal_static_google_ads_googleads_v1_resources_Recommendation_OptimizeAdRotationRecommendation_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation.class, com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation.Builder.class);
-    }
-
-    public static final int RECOMMENDED_EXTENSIONS_FIELD_NUMBER = 1;
-    private java.util.List<com.google.ads.googleads.v1.common.CalloutFeedItem> recommendedExtensions_;
-    /**
-     * <pre>
-     * Callout extensions recommended to be added.
-     * </pre>
-     *
-     * <code>repeated .google.ads.googleads.v1.common.CalloutFeedItem recommended_extensions = 1;</code>
-     */
-    public java.util.List<com.google.ads.googleads.v1.common.CalloutFeedItem> getRecommendedExtensionsList() {
-      return recommendedExtensions_;
-    }
-    /**
-     * <pre>
-     * Callout extensions recommended to be added.
-     * </pre>
-     *
-     * <code>repeated .google.ads.googleads.v1.common.CalloutFeedItem recommended_extensions = 1;</code>
-     */
-    public java.util.List<? extends com.google.ads.googleads.v1.common.CalloutFeedItemOrBuilder> 
-        getRecommendedExtensionsOrBuilderList() {
-      return recommendedExtensions_;
-    }
-    /**
-     * <pre>
-     * Callout extensions recommended to be added.
-     * </pre>
-     *
-     * <code>repeated .google.ads.googleads.v1.common.CalloutFeedItem recommended_extensions = 1;</code>
-     */
-    public int getRecommendedExtensionsCount() {
-      return recommendedExtensions_.size();
-    }
-    /**
-     * <pre>
-     * Callout extensions recommended to be added.
-     * </pre>
-     *
-     * <code>repeated .google.ads.googleads.v1.common.CalloutFeedItem recommended_extensions = 1;</code>
-     */
-    public com.google.ads.googleads.v1.common.CalloutFeedItem getRecommendedExtensions(int index) {
-      return recommendedExtensions_.get(index);
-    }
-    /**
-     * <pre>
-     * Callout extensions recommended to be added.
-     * </pre>
-     *
-     * <code>repeated .google.ads.googleads.v1.common.CalloutFeedItem recommended_extensions = 1;</code>
-     */
-    public com.google.ads.googleads.v1.common.CalloutFeedItemOrBuilder getRecommendedExtensionsOrBuilder(
-        int index) {
-      return recommendedExtensions_.get(index);
+              com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation.class, com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation.Builder.class);
     }
 
     private byte memoizedIsInitialized = -1;
@@ -12041,9 +14055,6 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      for (int i = 0; i < recommendedExtensions_.size(); i++) {
-        output.writeMessage(1, recommendedExtensions_.get(i));
-      }
       unknownFields.writeTo(output);
     }
 
@@ -12053,10 +14064,6 @@ private static final long serialVersionUID = 0L;
       if (size != -1) return size;
 
       size = 0;
-      for (int i = 0; i < recommendedExtensions_.size(); i++) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(1, recommendedExtensions_.get(i));
-      }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
       return size;
@@ -12067,14 +14074,12 @@ private static final long serialVersionUID = 0L;
       if (obj == this) {
        return true;
       }
-      if (!(obj instanceof com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation)) {
+      if (!(obj instanceof com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation)) {
         return super.equals(obj);
       }
-      com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation other = (com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation) obj;
+      com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation other = (com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation) obj;
 
       boolean result = true;
-      result = result && getRecommendedExtensionsList()
-          .equals(other.getRecommendedExtensionsList());
       result = result && unknownFields.equals(other.unknownFields);
       return result;
     }
@@ -12086,78 +14091,74 @@ private static final long serialVersionUID = 0L;
       }
       int hash = 41;
       hash = (19 * hash) + getDescriptor().hashCode();
-      if (getRecommendedExtensionsCount() > 0) {
-        hash = (37 * hash) + RECOMMENDED_EXTENSIONS_FIELD_NUMBER;
-        hash = (53 * hash) + getRecommendedExtensionsList().hashCode();
-      }
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
       return hash;
     }
 
-    public static com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation parseFrom(
+    public static com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation parseFrom(
         java.nio.ByteBuffer data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation parseFrom(
+    public static com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation parseFrom(
         java.nio.ByteBuffer data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation parseFrom(
+    public static com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation parseFrom(
+    public static com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation parseFrom(byte[] data)
+    public static com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation parseFrom(
+    public static com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation parseFrom(java.io.InputStream input)
+    public static com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation parseFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation parseFrom(
+    public static com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
-    public static com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation parseDelimitedFrom(java.io.InputStream input)
+    public static com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
-    public static com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation parseDelimitedFrom(
+    public static com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
-    public static com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation parseFrom(
+    public static com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation parseFrom(
+    public static com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
@@ -12170,7 +14171,7 @@ private static final long serialVersionUID = 0L;
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
     }
-    public static Builder newBuilder(com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation prototype) {
+    public static Builder newBuilder(com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
     @java.lang.Override
@@ -12187,29 +14188,29 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The Callout extension recommendation.
+     * The Optimize Ad Rotation recommendation.
      * </pre>
      *
-     * Protobuf type {@code google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation}
+     * Protobuf type {@code google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation}
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation)
-        com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendationOrBuilder {
+        // @@protoc_insertion_point(builder_implements:google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation)
+        com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendationOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return com.google.ads.googleads.v1.resources.RecommendationProto.internal_static_google_ads_googleads_v1_resources_Recommendation_CalloutExtensionRecommendation_descriptor;
+        return com.google.ads.googleads.v1.resources.RecommendationProto.internal_static_google_ads_googleads_v1_resources_Recommendation_OptimizeAdRotationRecommendation_descriptor;
       }
 
       @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return com.google.ads.googleads.v1.resources.RecommendationProto.internal_static_google_ads_googleads_v1_resources_Recommendation_CalloutExtensionRecommendation_fieldAccessorTable
+        return com.google.ads.googleads.v1.resources.RecommendationProto.internal_static_google_ads_googleads_v1_resources_Recommendation_OptimizeAdRotationRecommendation_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
-                com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation.class, com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation.Builder.class);
+                com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation.class, com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation.Builder.class);
       }
 
-      // Construct using com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation.newBuilder()
+      // Construct using com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation.newBuilder()
       private Builder() {
         maybeForceBuilderInitialization();
       }
@@ -12222,35 +14223,28 @@ private static final long serialVersionUID = 0L;
       private void maybeForceBuilderInitialization() {
         if (com.google.protobuf.GeneratedMessageV3
                 .alwaysUseFieldBuilders) {
-          getRecommendedExtensionsFieldBuilder();
         }
       }
       @java.lang.Override
       public Builder clear() {
         super.clear();
-        if (recommendedExtensionsBuilder_ == null) {
-          recommendedExtensions_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000001);
-        } else {
-          recommendedExtensionsBuilder_.clear();
-        }
         return this;
       }
 
       @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return com.google.ads.googleads.v1.resources.RecommendationProto.internal_static_google_ads_googleads_v1_resources_Recommendation_CalloutExtensionRecommendation_descriptor;
+        return com.google.ads.googleads.v1.resources.RecommendationProto.internal_static_google_ads_googleads_v1_resources_Recommendation_OptimizeAdRotationRecommendation_descriptor;
       }
 
       @java.lang.Override
-      public com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation getDefaultInstanceForType() {
-        return com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation.getDefaultInstance();
+      public com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation getDefaultInstanceForType() {
+        return com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation.getDefaultInstance();
       }
 
       @java.lang.Override
-      public com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation build() {
-        com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation result = buildPartial();
+      public com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation build() {
+        com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation result = buildPartial();
         if (!result.isInitialized()) {
           throw newUninitializedMessageException(result);
         }
@@ -12258,18 +14252,8 @@ private static final long serialVersionUID = 0L;
       }
 
       @java.lang.Override
-      public com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation buildPartial() {
-        com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation result = new com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation(this);
-        int from_bitField0_ = bitField0_;
-        if (recommendedExtensionsBuilder_ == null) {
-          if (((bitField0_ & 0x00000001) == 0x00000001)) {
-            recommendedExtensions_ = java.util.Collections.unmodifiableList(recommendedExtensions_);
-            bitField0_ = (bitField0_ & ~0x00000001);
-          }
-          result.recommendedExtensions_ = recommendedExtensions_;
-        } else {
-          result.recommendedExtensions_ = recommendedExtensionsBuilder_.build();
-        }
+      public com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation buildPartial() {
+        com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation result = new com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation(this);
         onBuilt();
         return result;
       }
@@ -12308,42 +14292,16 @@ private static final long serialVersionUID = 0L;
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation) {
-          return mergeFrom((com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation)other);
+        if (other instanceof com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation) {
+          return mergeFrom((com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation)other);
         } else {
           super.mergeFrom(other);
           return this;
         }
       }
 
-      public Builder mergeFrom(com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation other) {
-        if (other == com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation.getDefaultInstance()) return this;
-        if (recommendedExtensionsBuilder_ == null) {
-          if (!other.recommendedExtensions_.isEmpty()) {
-            if (recommendedExtensions_.isEmpty()) {
-              recommendedExtensions_ = other.recommendedExtensions_;
-              bitField0_ = (bitField0_ & ~0x00000001);
-            } else {
-              ensureRecommendedExtensionsIsMutable();
-              recommendedExtensions_.addAll(other.recommendedExtensions_);
-            }
-            onChanged();
-          }
-        } else {
-          if (!other.recommendedExtensions_.isEmpty()) {
-            if (recommendedExtensionsBuilder_.isEmpty()) {
-              recommendedExtensionsBuilder_.dispose();
-              recommendedExtensionsBuilder_ = null;
-              recommendedExtensions_ = other.recommendedExtensions_;
-              bitField0_ = (bitField0_ & ~0x00000001);
-              recommendedExtensionsBuilder_ = 
-                com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
-                   getRecommendedExtensionsFieldBuilder() : null;
-            } else {
-              recommendedExtensionsBuilder_.addAllMessages(other.recommendedExtensions_);
-            }
-          }
-        }
+      public Builder mergeFrom(com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation other) {
+        if (other == com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation.getDefaultInstance()) return this;
         this.mergeUnknownFields(other.unknownFields);
         onChanged();
         return this;
@@ -12359,11 +14317,11 @@ private static final long serialVersionUID = 0L;
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation parsedMessage = null;
+        com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation parsedMessage = null;
         try {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation) e.getUnfinishedMessage();
+          parsedMessage = (com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
@@ -12371,319 +14329,6 @@ private static final long serialVersionUID = 0L;
           }
         }
         return this;
-      }
-      private int bitField0_;
-
-      private java.util.List<com.google.ads.googleads.v1.common.CalloutFeedItem> recommendedExtensions_ =
-        java.util.Collections.emptyList();
-      private void ensureRecommendedExtensionsIsMutable() {
-        if (!((bitField0_ & 0x00000001) == 0x00000001)) {
-          recommendedExtensions_ = new java.util.ArrayList<com.google.ads.googleads.v1.common.CalloutFeedItem>(recommendedExtensions_);
-          bitField0_ |= 0x00000001;
-         }
-      }
-
-      private com.google.protobuf.RepeatedFieldBuilderV3<
-          com.google.ads.googleads.v1.common.CalloutFeedItem, com.google.ads.googleads.v1.common.CalloutFeedItem.Builder, com.google.ads.googleads.v1.common.CalloutFeedItemOrBuilder> recommendedExtensionsBuilder_;
-
-      /**
-       * <pre>
-       * Callout extensions recommended to be added.
-       * </pre>
-       *
-       * <code>repeated .google.ads.googleads.v1.common.CalloutFeedItem recommended_extensions = 1;</code>
-       */
-      public java.util.List<com.google.ads.googleads.v1.common.CalloutFeedItem> getRecommendedExtensionsList() {
-        if (recommendedExtensionsBuilder_ == null) {
-          return java.util.Collections.unmodifiableList(recommendedExtensions_);
-        } else {
-          return recommendedExtensionsBuilder_.getMessageList();
-        }
-      }
-      /**
-       * <pre>
-       * Callout extensions recommended to be added.
-       * </pre>
-       *
-       * <code>repeated .google.ads.googleads.v1.common.CalloutFeedItem recommended_extensions = 1;</code>
-       */
-      public int getRecommendedExtensionsCount() {
-        if (recommendedExtensionsBuilder_ == null) {
-          return recommendedExtensions_.size();
-        } else {
-          return recommendedExtensionsBuilder_.getCount();
-        }
-      }
-      /**
-       * <pre>
-       * Callout extensions recommended to be added.
-       * </pre>
-       *
-       * <code>repeated .google.ads.googleads.v1.common.CalloutFeedItem recommended_extensions = 1;</code>
-       */
-      public com.google.ads.googleads.v1.common.CalloutFeedItem getRecommendedExtensions(int index) {
-        if (recommendedExtensionsBuilder_ == null) {
-          return recommendedExtensions_.get(index);
-        } else {
-          return recommendedExtensionsBuilder_.getMessage(index);
-        }
-      }
-      /**
-       * <pre>
-       * Callout extensions recommended to be added.
-       * </pre>
-       *
-       * <code>repeated .google.ads.googleads.v1.common.CalloutFeedItem recommended_extensions = 1;</code>
-       */
-      public Builder setRecommendedExtensions(
-          int index, com.google.ads.googleads.v1.common.CalloutFeedItem value) {
-        if (recommendedExtensionsBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          ensureRecommendedExtensionsIsMutable();
-          recommendedExtensions_.set(index, value);
-          onChanged();
-        } else {
-          recommendedExtensionsBuilder_.setMessage(index, value);
-        }
-        return this;
-      }
-      /**
-       * <pre>
-       * Callout extensions recommended to be added.
-       * </pre>
-       *
-       * <code>repeated .google.ads.googleads.v1.common.CalloutFeedItem recommended_extensions = 1;</code>
-       */
-      public Builder setRecommendedExtensions(
-          int index, com.google.ads.googleads.v1.common.CalloutFeedItem.Builder builderForValue) {
-        if (recommendedExtensionsBuilder_ == null) {
-          ensureRecommendedExtensionsIsMutable();
-          recommendedExtensions_.set(index, builderForValue.build());
-          onChanged();
-        } else {
-          recommendedExtensionsBuilder_.setMessage(index, builderForValue.build());
-        }
-        return this;
-      }
-      /**
-       * <pre>
-       * Callout extensions recommended to be added.
-       * </pre>
-       *
-       * <code>repeated .google.ads.googleads.v1.common.CalloutFeedItem recommended_extensions = 1;</code>
-       */
-      public Builder addRecommendedExtensions(com.google.ads.googleads.v1.common.CalloutFeedItem value) {
-        if (recommendedExtensionsBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          ensureRecommendedExtensionsIsMutable();
-          recommendedExtensions_.add(value);
-          onChanged();
-        } else {
-          recommendedExtensionsBuilder_.addMessage(value);
-        }
-        return this;
-      }
-      /**
-       * <pre>
-       * Callout extensions recommended to be added.
-       * </pre>
-       *
-       * <code>repeated .google.ads.googleads.v1.common.CalloutFeedItem recommended_extensions = 1;</code>
-       */
-      public Builder addRecommendedExtensions(
-          int index, com.google.ads.googleads.v1.common.CalloutFeedItem value) {
-        if (recommendedExtensionsBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          ensureRecommendedExtensionsIsMutable();
-          recommendedExtensions_.add(index, value);
-          onChanged();
-        } else {
-          recommendedExtensionsBuilder_.addMessage(index, value);
-        }
-        return this;
-      }
-      /**
-       * <pre>
-       * Callout extensions recommended to be added.
-       * </pre>
-       *
-       * <code>repeated .google.ads.googleads.v1.common.CalloutFeedItem recommended_extensions = 1;</code>
-       */
-      public Builder addRecommendedExtensions(
-          com.google.ads.googleads.v1.common.CalloutFeedItem.Builder builderForValue) {
-        if (recommendedExtensionsBuilder_ == null) {
-          ensureRecommendedExtensionsIsMutable();
-          recommendedExtensions_.add(builderForValue.build());
-          onChanged();
-        } else {
-          recommendedExtensionsBuilder_.addMessage(builderForValue.build());
-        }
-        return this;
-      }
-      /**
-       * <pre>
-       * Callout extensions recommended to be added.
-       * </pre>
-       *
-       * <code>repeated .google.ads.googleads.v1.common.CalloutFeedItem recommended_extensions = 1;</code>
-       */
-      public Builder addRecommendedExtensions(
-          int index, com.google.ads.googleads.v1.common.CalloutFeedItem.Builder builderForValue) {
-        if (recommendedExtensionsBuilder_ == null) {
-          ensureRecommendedExtensionsIsMutable();
-          recommendedExtensions_.add(index, builderForValue.build());
-          onChanged();
-        } else {
-          recommendedExtensionsBuilder_.addMessage(index, builderForValue.build());
-        }
-        return this;
-      }
-      /**
-       * <pre>
-       * Callout extensions recommended to be added.
-       * </pre>
-       *
-       * <code>repeated .google.ads.googleads.v1.common.CalloutFeedItem recommended_extensions = 1;</code>
-       */
-      public Builder addAllRecommendedExtensions(
-          java.lang.Iterable<? extends com.google.ads.googleads.v1.common.CalloutFeedItem> values) {
-        if (recommendedExtensionsBuilder_ == null) {
-          ensureRecommendedExtensionsIsMutable();
-          com.google.protobuf.AbstractMessageLite.Builder.addAll(
-              values, recommendedExtensions_);
-          onChanged();
-        } else {
-          recommendedExtensionsBuilder_.addAllMessages(values);
-        }
-        return this;
-      }
-      /**
-       * <pre>
-       * Callout extensions recommended to be added.
-       * </pre>
-       *
-       * <code>repeated .google.ads.googleads.v1.common.CalloutFeedItem recommended_extensions = 1;</code>
-       */
-      public Builder clearRecommendedExtensions() {
-        if (recommendedExtensionsBuilder_ == null) {
-          recommendedExtensions_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000001);
-          onChanged();
-        } else {
-          recommendedExtensionsBuilder_.clear();
-        }
-        return this;
-      }
-      /**
-       * <pre>
-       * Callout extensions recommended to be added.
-       * </pre>
-       *
-       * <code>repeated .google.ads.googleads.v1.common.CalloutFeedItem recommended_extensions = 1;</code>
-       */
-      public Builder removeRecommendedExtensions(int index) {
-        if (recommendedExtensionsBuilder_ == null) {
-          ensureRecommendedExtensionsIsMutable();
-          recommendedExtensions_.remove(index);
-          onChanged();
-        } else {
-          recommendedExtensionsBuilder_.remove(index);
-        }
-        return this;
-      }
-      /**
-       * <pre>
-       * Callout extensions recommended to be added.
-       * </pre>
-       *
-       * <code>repeated .google.ads.googleads.v1.common.CalloutFeedItem recommended_extensions = 1;</code>
-       */
-      public com.google.ads.googleads.v1.common.CalloutFeedItem.Builder getRecommendedExtensionsBuilder(
-          int index) {
-        return getRecommendedExtensionsFieldBuilder().getBuilder(index);
-      }
-      /**
-       * <pre>
-       * Callout extensions recommended to be added.
-       * </pre>
-       *
-       * <code>repeated .google.ads.googleads.v1.common.CalloutFeedItem recommended_extensions = 1;</code>
-       */
-      public com.google.ads.googleads.v1.common.CalloutFeedItemOrBuilder getRecommendedExtensionsOrBuilder(
-          int index) {
-        if (recommendedExtensionsBuilder_ == null) {
-          return recommendedExtensions_.get(index);  } else {
-          return recommendedExtensionsBuilder_.getMessageOrBuilder(index);
-        }
-      }
-      /**
-       * <pre>
-       * Callout extensions recommended to be added.
-       * </pre>
-       *
-       * <code>repeated .google.ads.googleads.v1.common.CalloutFeedItem recommended_extensions = 1;</code>
-       */
-      public java.util.List<? extends com.google.ads.googleads.v1.common.CalloutFeedItemOrBuilder> 
-           getRecommendedExtensionsOrBuilderList() {
-        if (recommendedExtensionsBuilder_ != null) {
-          return recommendedExtensionsBuilder_.getMessageOrBuilderList();
-        } else {
-          return java.util.Collections.unmodifiableList(recommendedExtensions_);
-        }
-      }
-      /**
-       * <pre>
-       * Callout extensions recommended to be added.
-       * </pre>
-       *
-       * <code>repeated .google.ads.googleads.v1.common.CalloutFeedItem recommended_extensions = 1;</code>
-       */
-      public com.google.ads.googleads.v1.common.CalloutFeedItem.Builder addRecommendedExtensionsBuilder() {
-        return getRecommendedExtensionsFieldBuilder().addBuilder(
-            com.google.ads.googleads.v1.common.CalloutFeedItem.getDefaultInstance());
-      }
-      /**
-       * <pre>
-       * Callout extensions recommended to be added.
-       * </pre>
-       *
-       * <code>repeated .google.ads.googleads.v1.common.CalloutFeedItem recommended_extensions = 1;</code>
-       */
-      public com.google.ads.googleads.v1.common.CalloutFeedItem.Builder addRecommendedExtensionsBuilder(
-          int index) {
-        return getRecommendedExtensionsFieldBuilder().addBuilder(
-            index, com.google.ads.googleads.v1.common.CalloutFeedItem.getDefaultInstance());
-      }
-      /**
-       * <pre>
-       * Callout extensions recommended to be added.
-       * </pre>
-       *
-       * <code>repeated .google.ads.googleads.v1.common.CalloutFeedItem recommended_extensions = 1;</code>
-       */
-      public java.util.List<com.google.ads.googleads.v1.common.CalloutFeedItem.Builder> 
-           getRecommendedExtensionsBuilderList() {
-        return getRecommendedExtensionsFieldBuilder().getBuilderList();
-      }
-      private com.google.protobuf.RepeatedFieldBuilderV3<
-          com.google.ads.googleads.v1.common.CalloutFeedItem, com.google.ads.googleads.v1.common.CalloutFeedItem.Builder, com.google.ads.googleads.v1.common.CalloutFeedItemOrBuilder> 
-          getRecommendedExtensionsFieldBuilder() {
-        if (recommendedExtensionsBuilder_ == null) {
-          recommendedExtensionsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-              com.google.ads.googleads.v1.common.CalloutFeedItem, com.google.ads.googleads.v1.common.CalloutFeedItem.Builder, com.google.ads.googleads.v1.common.CalloutFeedItemOrBuilder>(
-                  recommendedExtensions_,
-                  ((bitField0_ & 0x00000001) == 0x00000001),
-                  getParentForChildren(),
-                  isClean());
-          recommendedExtensions_ = null;
-        }
-        return recommendedExtensionsBuilder_;
       }
       @java.lang.Override
       public final Builder setUnknownFields(
@@ -12698,41 +14343,41 @@ private static final long serialVersionUID = 0L;
       }
 
 
-      // @@protoc_insertion_point(builder_scope:google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation)
+      // @@protoc_insertion_point(builder_scope:google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation)
     }
 
-    // @@protoc_insertion_point(class_scope:google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation)
-    private static final com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation DEFAULT_INSTANCE;
+    // @@protoc_insertion_point(class_scope:google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation)
+    private static final com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation DEFAULT_INSTANCE;
     static {
-      DEFAULT_INSTANCE = new com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation();
+      DEFAULT_INSTANCE = new com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation();
     }
 
-    public static com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation getDefaultInstance() {
+    public static com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation getDefaultInstance() {
       return DEFAULT_INSTANCE;
     }
 
-    private static final com.google.protobuf.Parser<CalloutExtensionRecommendation>
-        PARSER = new com.google.protobuf.AbstractParser<CalloutExtensionRecommendation>() {
+    private static final com.google.protobuf.Parser<OptimizeAdRotationRecommendation>
+        PARSER = new com.google.protobuf.AbstractParser<OptimizeAdRotationRecommendation>() {
       @java.lang.Override
-      public CalloutExtensionRecommendation parsePartialFrom(
+      public OptimizeAdRotationRecommendation parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new CalloutExtensionRecommendation(input, extensionRegistry);
+        return new OptimizeAdRotationRecommendation(input, extensionRegistry);
       }
     };
 
-    public static com.google.protobuf.Parser<CalloutExtensionRecommendation> parser() {
+    public static com.google.protobuf.Parser<OptimizeAdRotationRecommendation> parser() {
       return PARSER;
     }
 
     @java.lang.Override
-    public com.google.protobuf.Parser<CalloutExtensionRecommendation> getParserForType() {
+    public com.google.protobuf.Parser<OptimizeAdRotationRecommendation> getParserForType() {
       return PARSER;
     }
 
     @java.lang.Override
-    public com.google.ads.googleads.v1.resources.Recommendation.CalloutExtensionRecommendation getDefaultInstanceForType() {
+    public com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
 
@@ -13640,27 +15285,72 @@ private static final long serialVersionUID = 0L;
 
   }
 
-  public interface SearchPartnersOptInRecommendationOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation)
+  public interface CallExtensionRecommendationOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation)
       com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <pre>
+     * Call extensions recommended to be added.
+     * </pre>
+     *
+     * <code>repeated .google.ads.googleads.v1.common.CallFeedItem recommended_extensions = 1;</code>
+     */
+    java.util.List<com.google.ads.googleads.v1.common.CallFeedItem> 
+        getRecommendedExtensionsList();
+    /**
+     * <pre>
+     * Call extensions recommended to be added.
+     * </pre>
+     *
+     * <code>repeated .google.ads.googleads.v1.common.CallFeedItem recommended_extensions = 1;</code>
+     */
+    com.google.ads.googleads.v1.common.CallFeedItem getRecommendedExtensions(int index);
+    /**
+     * <pre>
+     * Call extensions recommended to be added.
+     * </pre>
+     *
+     * <code>repeated .google.ads.googleads.v1.common.CallFeedItem recommended_extensions = 1;</code>
+     */
+    int getRecommendedExtensionsCount();
+    /**
+     * <pre>
+     * Call extensions recommended to be added.
+     * </pre>
+     *
+     * <code>repeated .google.ads.googleads.v1.common.CallFeedItem recommended_extensions = 1;</code>
+     */
+    java.util.List<? extends com.google.ads.googleads.v1.common.CallFeedItemOrBuilder> 
+        getRecommendedExtensionsOrBuilderList();
+    /**
+     * <pre>
+     * Call extensions recommended to be added.
+     * </pre>
+     *
+     * <code>repeated .google.ads.googleads.v1.common.CallFeedItem recommended_extensions = 1;</code>
+     */
+    com.google.ads.googleads.v1.common.CallFeedItemOrBuilder getRecommendedExtensionsOrBuilder(
+        int index);
   }
   /**
    * <pre>
-   * The Search Partners Opt-In recommendation.
+   * The Call extension recommendation.
    * </pre>
    *
-   * Protobuf type {@code google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation}
+   * Protobuf type {@code google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation}
    */
-  public  static final class SearchPartnersOptInRecommendation extends
+  public  static final class CallExtensionRecommendation extends
       com.google.protobuf.GeneratedMessageV3 implements
-      // @@protoc_insertion_point(message_implements:google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation)
-      SearchPartnersOptInRecommendationOrBuilder {
+      // @@protoc_insertion_point(message_implements:google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation)
+      CallExtensionRecommendationOrBuilder {
   private static final long serialVersionUID = 0L;
-    // Use SearchPartnersOptInRecommendation.newBuilder() to construct.
-    private SearchPartnersOptInRecommendation(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+    // Use CallExtensionRecommendation.newBuilder() to construct.
+    private CallExtensionRecommendation(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
     }
-    private SearchPartnersOptInRecommendation() {
+    private CallExtensionRecommendation() {
+      recommendedExtensions_ = java.util.Collections.emptyList();
     }
 
     @java.lang.Override
@@ -13668,470 +15358,7 @@ private static final long serialVersionUID = 0L;
     getUnknownFields() {
       return this.unknownFields;
     }
-    private SearchPartnersOptInRecommendation(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            default: {
-              if (!parseUnknownFieldProto3(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e).setUnfinishedMessage(this);
-      } finally {
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return com.google.ads.googleads.v1.resources.RecommendationProto.internal_static_google_ads_googleads_v1_resources_Recommendation_SearchPartnersOptInRecommendation_descriptor;
-    }
-
-    @java.lang.Override
-    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-        internalGetFieldAccessorTable() {
-      return com.google.ads.googleads.v1.resources.RecommendationProto.internal_static_google_ads_googleads_v1_resources_Recommendation_SearchPartnersOptInRecommendation_fieldAccessorTable
-          .ensureFieldAccessorsInitialized(
-              com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation.class, com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation.Builder.class);
-    }
-
-    private byte memoizedIsInitialized = -1;
-    @java.lang.Override
-    public final boolean isInitialized() {
-      byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
-
-      memoizedIsInitialized = 1;
-      return true;
-    }
-
-    @java.lang.Override
-    public void writeTo(com.google.protobuf.CodedOutputStream output)
-                        throws java.io.IOException {
-      unknownFields.writeTo(output);
-    }
-
-    @java.lang.Override
-    public int getSerializedSize() {
-      int size = memoizedSize;
-      if (size != -1) return size;
-
-      size = 0;
-      size += unknownFields.getSerializedSize();
-      memoizedSize = size;
-      return size;
-    }
-
-    @java.lang.Override
-    public boolean equals(final java.lang.Object obj) {
-      if (obj == this) {
-       return true;
-      }
-      if (!(obj instanceof com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation)) {
-        return super.equals(obj);
-      }
-      com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation other = (com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation) obj;
-
-      boolean result = true;
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
-    }
-
-    @java.lang.Override
-    public int hashCode() {
-      if (memoizedHashCode != 0) {
-        return memoizedHashCode;
-      }
-      int hash = 41;
-      hash = (19 * hash) + getDescriptor().hashCode();
-      hash = (29 * hash) + unknownFields.hashCode();
-      memoizedHashCode = hash;
-      return hash;
-    }
-
-    public static com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation parseFrom(
-        java.nio.ByteBuffer data)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
-    }
-    public static com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation parseFrom(
-        java.nio.ByteBuffer data,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
-    }
-    public static com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation parseFrom(
-        com.google.protobuf.ByteString data)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
-    }
-    public static com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation parseFrom(
-        com.google.protobuf.ByteString data,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
-    }
-    public static com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation parseFrom(byte[] data)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
-    }
-    public static com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation parseFrom(
-        byte[] data,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
-    }
-    public static com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation parseFrom(java.io.InputStream input)
-        throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
-          .parseWithIOException(PARSER, input);
-    }
-    public static com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation parseFrom(
-        java.io.InputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
-          .parseWithIOException(PARSER, input, extensionRegistry);
-    }
-    public static com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation parseDelimitedFrom(java.io.InputStream input)
-        throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
-          .parseDelimitedWithIOException(PARSER, input);
-    }
-    public static com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation parseDelimitedFrom(
-        java.io.InputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
-          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
-    }
-    public static com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation parseFrom(
-        com.google.protobuf.CodedInputStream input)
-        throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
-          .parseWithIOException(PARSER, input);
-    }
-    public static com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation parseFrom(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
-          .parseWithIOException(PARSER, input, extensionRegistry);
-    }
-
-    @java.lang.Override
-    public Builder newBuilderForType() { return newBuilder(); }
-    public static Builder newBuilder() {
-      return DEFAULT_INSTANCE.toBuilder();
-    }
-    public static Builder newBuilder(com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation prototype) {
-      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
-    }
-    @java.lang.Override
-    public Builder toBuilder() {
-      return this == DEFAULT_INSTANCE
-          ? new Builder() : new Builder().mergeFrom(this);
-    }
-
-    @java.lang.Override
-    protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
-      Builder builder = new Builder(parent);
-      return builder;
-    }
-    /**
-     * <pre>
-     * The Search Partners Opt-In recommendation.
-     * </pre>
-     *
-     * Protobuf type {@code google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation}
-     */
-    public static final class Builder extends
-        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation)
-        com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendationOrBuilder {
-      public static final com.google.protobuf.Descriptors.Descriptor
-          getDescriptor() {
-        return com.google.ads.googleads.v1.resources.RecommendationProto.internal_static_google_ads_googleads_v1_resources_Recommendation_SearchPartnersOptInRecommendation_descriptor;
-      }
-
-      @java.lang.Override
-      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-          internalGetFieldAccessorTable() {
-        return com.google.ads.googleads.v1.resources.RecommendationProto.internal_static_google_ads_googleads_v1_resources_Recommendation_SearchPartnersOptInRecommendation_fieldAccessorTable
-            .ensureFieldAccessorsInitialized(
-                com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation.class, com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation.Builder.class);
-      }
-
-      // Construct using com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation.newBuilder()
-      private Builder() {
-        maybeForceBuilderInitialization();
-      }
-
-      private Builder(
-          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
-        super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessageV3
-                .alwaysUseFieldBuilders) {
-        }
-      }
-      @java.lang.Override
-      public Builder clear() {
-        super.clear();
-        return this;
-      }
-
-      @java.lang.Override
-      public com.google.protobuf.Descriptors.Descriptor
-          getDescriptorForType() {
-        return com.google.ads.googleads.v1.resources.RecommendationProto.internal_static_google_ads_googleads_v1_resources_Recommendation_SearchPartnersOptInRecommendation_descriptor;
-      }
-
-      @java.lang.Override
-      public com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation getDefaultInstanceForType() {
-        return com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation.getDefaultInstance();
-      }
-
-      @java.lang.Override
-      public com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation build() {
-        com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation result = buildPartial();
-        if (!result.isInitialized()) {
-          throw newUninitializedMessageException(result);
-        }
-        return result;
-      }
-
-      @java.lang.Override
-      public com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation buildPartial() {
-        com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation result = new com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation(this);
-        onBuilt();
-        return result;
-      }
-
-      @java.lang.Override
-      public Builder clone() {
-        return (Builder) super.clone();
-      }
-      @java.lang.Override
-      public Builder setField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return (Builder) super.setField(field, value);
-      }
-      @java.lang.Override
-      public Builder clearField(
-          com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
-      }
-      @java.lang.Override
-      public Builder clearOneof(
-          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
-      }
-      @java.lang.Override
-      public Builder setRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
-      }
-      @java.lang.Override
-      public Builder addRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
-      }
-      @java.lang.Override
-      public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation) {
-          return mergeFrom((com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation)other);
-        } else {
-          super.mergeFrom(other);
-          return this;
-        }
-      }
-
-      public Builder mergeFrom(com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation other) {
-        if (other == com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation.getDefaultInstance()) return this;
-        this.mergeUnknownFields(other.unknownFields);
-        onChanged();
-        return this;
-      }
-
-      @java.lang.Override
-      public final boolean isInitialized() {
-        return true;
-      }
-
-      @java.lang.Override
-      public Builder mergeFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws java.io.IOException {
-        com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation parsedMessage = null;
-        try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation) e.getUnfinishedMessage();
-          throw e.unwrapIOException();
-        } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
-        return this;
-      }
-      @java.lang.Override
-      public final Builder setUnknownFields(
-          final com.google.protobuf.UnknownFieldSet unknownFields) {
-        return super.setUnknownFieldsProto3(unknownFields);
-      }
-
-      @java.lang.Override
-      public final Builder mergeUnknownFields(
-          final com.google.protobuf.UnknownFieldSet unknownFields) {
-        return super.mergeUnknownFields(unknownFields);
-      }
-
-
-      // @@protoc_insertion_point(builder_scope:google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation)
-    }
-
-    // @@protoc_insertion_point(class_scope:google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation)
-    private static final com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation DEFAULT_INSTANCE;
-    static {
-      DEFAULT_INSTANCE = new com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation();
-    }
-
-    public static com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation getDefaultInstance() {
-      return DEFAULT_INSTANCE;
-    }
-
-    private static final com.google.protobuf.Parser<SearchPartnersOptInRecommendation>
-        PARSER = new com.google.protobuf.AbstractParser<SearchPartnersOptInRecommendation>() {
-      @java.lang.Override
-      public SearchPartnersOptInRecommendation parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new SearchPartnersOptInRecommendation(input, extensionRegistry);
-      }
-    };
-
-    public static com.google.protobuf.Parser<SearchPartnersOptInRecommendation> parser() {
-      return PARSER;
-    }
-
-    @java.lang.Override
-    public com.google.protobuf.Parser<SearchPartnersOptInRecommendation> getParserForType() {
-      return PARSER;
-    }
-
-    @java.lang.Override
-    public com.google.ads.googleads.v1.resources.Recommendation.SearchPartnersOptInRecommendation getDefaultInstanceForType() {
-      return DEFAULT_INSTANCE;
-    }
-
-  }
-
-  public interface KeywordMatchTypeRecommendationOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation)
-      com.google.protobuf.MessageOrBuilder {
-
-    /**
-     * <pre>
-     * The existing keyword where the match type should be more broad.
-     * </pre>
-     *
-     * <code>.google.ads.googleads.v1.common.KeywordInfo keyword = 1;</code>
-     */
-    boolean hasKeyword();
-    /**
-     * <pre>
-     * The existing keyword where the match type should be more broad.
-     * </pre>
-     *
-     * <code>.google.ads.googleads.v1.common.KeywordInfo keyword = 1;</code>
-     */
-    com.google.ads.googleads.v1.common.KeywordInfo getKeyword();
-    /**
-     * <pre>
-     * The existing keyword where the match type should be more broad.
-     * </pre>
-     *
-     * <code>.google.ads.googleads.v1.common.KeywordInfo keyword = 1;</code>
-     */
-    com.google.ads.googleads.v1.common.KeywordInfoOrBuilder getKeywordOrBuilder();
-
-    /**
-     * <pre>
-     * The recommended new match type.
-     * </pre>
-     *
-     * <code>.google.ads.googleads.v1.enums.KeywordMatchTypeEnum.KeywordMatchType recommended_match_type = 2;</code>
-     */
-    int getRecommendedMatchTypeValue();
-    /**
-     * <pre>
-     * The recommended new match type.
-     * </pre>
-     *
-     * <code>.google.ads.googleads.v1.enums.KeywordMatchTypeEnum.KeywordMatchType recommended_match_type = 2;</code>
-     */
-    com.google.ads.googleads.v1.enums.KeywordMatchTypeEnum.KeywordMatchType getRecommendedMatchType();
-  }
-  /**
-   * <pre>
-   * The keyword match type recommendation.
-   * </pre>
-   *
-   * Protobuf type {@code google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation}
-   */
-  public  static final class KeywordMatchTypeRecommendation extends
-      com.google.protobuf.GeneratedMessageV3 implements
-      // @@protoc_insertion_point(message_implements:google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation)
-      KeywordMatchTypeRecommendationOrBuilder {
-  private static final long serialVersionUID = 0L;
-    // Use KeywordMatchTypeRecommendation.newBuilder() to construct.
-    private KeywordMatchTypeRecommendation(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
-      super(builder);
-    }
-    private KeywordMatchTypeRecommendation() {
-      recommendedMatchType_ = 0;
-    }
-
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
-    private KeywordMatchTypeRecommendation(
+    private CallExtensionRecommendation(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
@@ -14151,22 +15378,12 @@ private static final long serialVersionUID = 0L;
               done = true;
               break;
             case 10: {
-              com.google.ads.googleads.v1.common.KeywordInfo.Builder subBuilder = null;
-              if (keyword_ != null) {
-                subBuilder = keyword_.toBuilder();
+              if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+                recommendedExtensions_ = new java.util.ArrayList<com.google.ads.googleads.v1.common.CallFeedItem>();
+                mutable_bitField0_ |= 0x00000001;
               }
-              keyword_ = input.readMessage(com.google.ads.googleads.v1.common.KeywordInfo.parser(), extensionRegistry);
-              if (subBuilder != null) {
-                subBuilder.mergeFrom(keyword_);
-                keyword_ = subBuilder.buildPartial();
-              }
-
-              break;
-            }
-            case 16: {
-              int rawValue = input.readEnum();
-
-              recommendedMatchType_ = rawValue;
+              recommendedExtensions_.add(
+                  input.readMessage(com.google.ads.googleads.v1.common.CallFeedItem.parser(), extensionRegistry));
               break;
             }
             default: {
@@ -14184,79 +15401,79 @@ private static final long serialVersionUID = 0L;
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
       } finally {
+        if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+          recommendedExtensions_ = java.util.Collections.unmodifiableList(recommendedExtensions_);
+        }
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
       }
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return com.google.ads.googleads.v1.resources.RecommendationProto.internal_static_google_ads_googleads_v1_resources_Recommendation_KeywordMatchTypeRecommendation_descriptor;
+      return com.google.ads.googleads.v1.resources.RecommendationProto.internal_static_google_ads_googleads_v1_resources_Recommendation_CallExtensionRecommendation_descriptor;
     }
 
     @java.lang.Override
     protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return com.google.ads.googleads.v1.resources.RecommendationProto.internal_static_google_ads_googleads_v1_resources_Recommendation_KeywordMatchTypeRecommendation_fieldAccessorTable
+      return com.google.ads.googleads.v1.resources.RecommendationProto.internal_static_google_ads_googleads_v1_resources_Recommendation_CallExtensionRecommendation_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation.class, com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation.Builder.class);
+              com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation.class, com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation.Builder.class);
     }
 
-    public static final int KEYWORD_FIELD_NUMBER = 1;
-    private com.google.ads.googleads.v1.common.KeywordInfo keyword_;
+    public static final int RECOMMENDED_EXTENSIONS_FIELD_NUMBER = 1;
+    private java.util.List<com.google.ads.googleads.v1.common.CallFeedItem> recommendedExtensions_;
     /**
      * <pre>
-     * The existing keyword where the match type should be more broad.
+     * Call extensions recommended to be added.
      * </pre>
      *
-     * <code>.google.ads.googleads.v1.common.KeywordInfo keyword = 1;</code>
+     * <code>repeated .google.ads.googleads.v1.common.CallFeedItem recommended_extensions = 1;</code>
      */
-    public boolean hasKeyword() {
-      return keyword_ != null;
+    public java.util.List<com.google.ads.googleads.v1.common.CallFeedItem> getRecommendedExtensionsList() {
+      return recommendedExtensions_;
     }
     /**
      * <pre>
-     * The existing keyword where the match type should be more broad.
+     * Call extensions recommended to be added.
      * </pre>
      *
-     * <code>.google.ads.googleads.v1.common.KeywordInfo keyword = 1;</code>
+     * <code>repeated .google.ads.googleads.v1.common.CallFeedItem recommended_extensions = 1;</code>
      */
-    public com.google.ads.googleads.v1.common.KeywordInfo getKeyword() {
-      return keyword_ == null ? com.google.ads.googleads.v1.common.KeywordInfo.getDefaultInstance() : keyword_;
+    public java.util.List<? extends com.google.ads.googleads.v1.common.CallFeedItemOrBuilder> 
+        getRecommendedExtensionsOrBuilderList() {
+      return recommendedExtensions_;
     }
     /**
      * <pre>
-     * The existing keyword where the match type should be more broad.
+     * Call extensions recommended to be added.
      * </pre>
      *
-     * <code>.google.ads.googleads.v1.common.KeywordInfo keyword = 1;</code>
+     * <code>repeated .google.ads.googleads.v1.common.CallFeedItem recommended_extensions = 1;</code>
      */
-    public com.google.ads.googleads.v1.common.KeywordInfoOrBuilder getKeywordOrBuilder() {
-      return getKeyword();
-    }
-
-    public static final int RECOMMENDED_MATCH_TYPE_FIELD_NUMBER = 2;
-    private int recommendedMatchType_;
-    /**
-     * <pre>
-     * The recommended new match type.
-     * </pre>
-     *
-     * <code>.google.ads.googleads.v1.enums.KeywordMatchTypeEnum.KeywordMatchType recommended_match_type = 2;</code>
-     */
-    public int getRecommendedMatchTypeValue() {
-      return recommendedMatchType_;
+    public int getRecommendedExtensionsCount() {
+      return recommendedExtensions_.size();
     }
     /**
      * <pre>
-     * The recommended new match type.
+     * Call extensions recommended to be added.
      * </pre>
      *
-     * <code>.google.ads.googleads.v1.enums.KeywordMatchTypeEnum.KeywordMatchType recommended_match_type = 2;</code>
+     * <code>repeated .google.ads.googleads.v1.common.CallFeedItem recommended_extensions = 1;</code>
      */
-    public com.google.ads.googleads.v1.enums.KeywordMatchTypeEnum.KeywordMatchType getRecommendedMatchType() {
-      @SuppressWarnings("deprecation")
-      com.google.ads.googleads.v1.enums.KeywordMatchTypeEnum.KeywordMatchType result = com.google.ads.googleads.v1.enums.KeywordMatchTypeEnum.KeywordMatchType.valueOf(recommendedMatchType_);
-      return result == null ? com.google.ads.googleads.v1.enums.KeywordMatchTypeEnum.KeywordMatchType.UNRECOGNIZED : result;
+    public com.google.ads.googleads.v1.common.CallFeedItem getRecommendedExtensions(int index) {
+      return recommendedExtensions_.get(index);
+    }
+    /**
+     * <pre>
+     * Call extensions recommended to be added.
+     * </pre>
+     *
+     * <code>repeated .google.ads.googleads.v1.common.CallFeedItem recommended_extensions = 1;</code>
+     */
+    public com.google.ads.googleads.v1.common.CallFeedItemOrBuilder getRecommendedExtensionsOrBuilder(
+        int index) {
+      return recommendedExtensions_.get(index);
     }
 
     private byte memoizedIsInitialized = -1;
@@ -14273,11 +15490,8 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (keyword_ != null) {
-        output.writeMessage(1, getKeyword());
-      }
-      if (recommendedMatchType_ != com.google.ads.googleads.v1.enums.KeywordMatchTypeEnum.KeywordMatchType.UNSPECIFIED.getNumber()) {
-        output.writeEnum(2, recommendedMatchType_);
+      for (int i = 0; i < recommendedExtensions_.size(); i++) {
+        output.writeMessage(1, recommendedExtensions_.get(i));
       }
       unknownFields.writeTo(output);
     }
@@ -14288,13 +15502,9 @@ private static final long serialVersionUID = 0L;
       if (size != -1) return size;
 
       size = 0;
-      if (keyword_ != null) {
+      for (int i = 0; i < recommendedExtensions_.size(); i++) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(1, getKeyword());
-      }
-      if (recommendedMatchType_ != com.google.ads.googleads.v1.enums.KeywordMatchTypeEnum.KeywordMatchType.UNSPECIFIED.getNumber()) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeEnumSize(2, recommendedMatchType_);
+          .computeMessageSize(1, recommendedExtensions_.get(i));
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -14306,18 +15516,14 @@ private static final long serialVersionUID = 0L;
       if (obj == this) {
        return true;
       }
-      if (!(obj instanceof com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation)) {
+      if (!(obj instanceof com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation)) {
         return super.equals(obj);
       }
-      com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation other = (com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation) obj;
+      com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation other = (com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation) obj;
 
       boolean result = true;
-      result = result && (hasKeyword() == other.hasKeyword());
-      if (hasKeyword()) {
-        result = result && getKeyword()
-            .equals(other.getKeyword());
-      }
-      result = result && recommendedMatchType_ == other.recommendedMatchType_;
+      result = result && getRecommendedExtensionsList()
+          .equals(other.getRecommendedExtensionsList());
       result = result && unknownFields.equals(other.unknownFields);
       return result;
     }
@@ -14329,80 +15535,78 @@ private static final long serialVersionUID = 0L;
       }
       int hash = 41;
       hash = (19 * hash) + getDescriptor().hashCode();
-      if (hasKeyword()) {
-        hash = (37 * hash) + KEYWORD_FIELD_NUMBER;
-        hash = (53 * hash) + getKeyword().hashCode();
+      if (getRecommendedExtensionsCount() > 0) {
+        hash = (37 * hash) + RECOMMENDED_EXTENSIONS_FIELD_NUMBER;
+        hash = (53 * hash) + getRecommendedExtensionsList().hashCode();
       }
-      hash = (37 * hash) + RECOMMENDED_MATCH_TYPE_FIELD_NUMBER;
-      hash = (53 * hash) + recommendedMatchType_;
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
       return hash;
     }
 
-    public static com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation parseFrom(
+    public static com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation parseFrom(
         java.nio.ByteBuffer data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation parseFrom(
+    public static com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation parseFrom(
         java.nio.ByteBuffer data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation parseFrom(
+    public static com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation parseFrom(
+    public static com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation parseFrom(byte[] data)
+    public static com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation parseFrom(
+    public static com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation parseFrom(java.io.InputStream input)
+    public static com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation parseFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation parseFrom(
+    public static com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
-    public static com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation parseDelimitedFrom(java.io.InputStream input)
+    public static com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
-    public static com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation parseDelimitedFrom(
+    public static com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
-    public static com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation parseFrom(
+    public static com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation parseFrom(
+    public static com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
@@ -14415,7 +15619,7 @@ private static final long serialVersionUID = 0L;
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
     }
-    public static Builder newBuilder(com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation prototype) {
+    public static Builder newBuilder(com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
     @java.lang.Override
@@ -14432,29 +15636,29 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The keyword match type recommendation.
+     * The Call extension recommendation.
      * </pre>
      *
-     * Protobuf type {@code google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation}
+     * Protobuf type {@code google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation}
      */
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation)
-        com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendationOrBuilder {
+        // @@protoc_insertion_point(builder_implements:google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation)
+        com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendationOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return com.google.ads.googleads.v1.resources.RecommendationProto.internal_static_google_ads_googleads_v1_resources_Recommendation_KeywordMatchTypeRecommendation_descriptor;
+        return com.google.ads.googleads.v1.resources.RecommendationProto.internal_static_google_ads_googleads_v1_resources_Recommendation_CallExtensionRecommendation_descriptor;
       }
 
       @java.lang.Override
       protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return com.google.ads.googleads.v1.resources.RecommendationProto.internal_static_google_ads_googleads_v1_resources_Recommendation_KeywordMatchTypeRecommendation_fieldAccessorTable
+        return com.google.ads.googleads.v1.resources.RecommendationProto.internal_static_google_ads_googleads_v1_resources_Recommendation_CallExtensionRecommendation_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
-                com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation.class, com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation.Builder.class);
+                com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation.class, com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation.Builder.class);
       }
 
-      // Construct using com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation.newBuilder()
+      // Construct using com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation.newBuilder()
       private Builder() {
         maybeForceBuilderInitialization();
       }
@@ -14467,36 +15671,35 @@ private static final long serialVersionUID = 0L;
       private void maybeForceBuilderInitialization() {
         if (com.google.protobuf.GeneratedMessageV3
                 .alwaysUseFieldBuilders) {
+          getRecommendedExtensionsFieldBuilder();
         }
       }
       @java.lang.Override
       public Builder clear() {
         super.clear();
-        if (keywordBuilder_ == null) {
-          keyword_ = null;
+        if (recommendedExtensionsBuilder_ == null) {
+          recommendedExtensions_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000001);
         } else {
-          keyword_ = null;
-          keywordBuilder_ = null;
+          recommendedExtensionsBuilder_.clear();
         }
-        recommendedMatchType_ = 0;
-
         return this;
       }
 
       @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return com.google.ads.googleads.v1.resources.RecommendationProto.internal_static_google_ads_googleads_v1_resources_Recommendation_KeywordMatchTypeRecommendation_descriptor;
+        return com.google.ads.googleads.v1.resources.RecommendationProto.internal_static_google_ads_googleads_v1_resources_Recommendation_CallExtensionRecommendation_descriptor;
       }
 
       @java.lang.Override
-      public com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation getDefaultInstanceForType() {
-        return com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation.getDefaultInstance();
+      public com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation getDefaultInstanceForType() {
+        return com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation.getDefaultInstance();
       }
 
       @java.lang.Override
-      public com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation build() {
-        com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation result = buildPartial();
+      public com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation build() {
+        com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation result = buildPartial();
         if (!result.isInitialized()) {
           throw newUninitializedMessageException(result);
         }
@@ -14504,14 +15707,18 @@ private static final long serialVersionUID = 0L;
       }
 
       @java.lang.Override
-      public com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation buildPartial() {
-        com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation result = new com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation(this);
-        if (keywordBuilder_ == null) {
-          result.keyword_ = keyword_;
+      public com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation buildPartial() {
+        com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation result = new com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation(this);
+        int from_bitField0_ = bitField0_;
+        if (recommendedExtensionsBuilder_ == null) {
+          if (((bitField0_ & 0x00000001) == 0x00000001)) {
+            recommendedExtensions_ = java.util.Collections.unmodifiableList(recommendedExtensions_);
+            bitField0_ = (bitField0_ & ~0x00000001);
+          }
+          result.recommendedExtensions_ = recommendedExtensions_;
         } else {
-          result.keyword_ = keywordBuilder_.build();
+          result.recommendedExtensions_ = recommendedExtensionsBuilder_.build();
         }
-        result.recommendedMatchType_ = recommendedMatchType_;
         onBuilt();
         return result;
       }
@@ -14550,21 +15757,41 @@ private static final long serialVersionUID = 0L;
       }
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation) {
-          return mergeFrom((com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation)other);
+        if (other instanceof com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation) {
+          return mergeFrom((com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation)other);
         } else {
           super.mergeFrom(other);
           return this;
         }
       }
 
-      public Builder mergeFrom(com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation other) {
-        if (other == com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation.getDefaultInstance()) return this;
-        if (other.hasKeyword()) {
-          mergeKeyword(other.getKeyword());
-        }
-        if (other.recommendedMatchType_ != 0) {
-          setRecommendedMatchTypeValue(other.getRecommendedMatchTypeValue());
+      public Builder mergeFrom(com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation other) {
+        if (other == com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation.getDefaultInstance()) return this;
+        if (recommendedExtensionsBuilder_ == null) {
+          if (!other.recommendedExtensions_.isEmpty()) {
+            if (recommendedExtensions_.isEmpty()) {
+              recommendedExtensions_ = other.recommendedExtensions_;
+              bitField0_ = (bitField0_ & ~0x00000001);
+            } else {
+              ensureRecommendedExtensionsIsMutable();
+              recommendedExtensions_.addAll(other.recommendedExtensions_);
+            }
+            onChanged();
+          }
+        } else {
+          if (!other.recommendedExtensions_.isEmpty()) {
+            if (recommendedExtensionsBuilder_.isEmpty()) {
+              recommendedExtensionsBuilder_.dispose();
+              recommendedExtensionsBuilder_ = null;
+              recommendedExtensions_ = other.recommendedExtensions_;
+              bitField0_ = (bitField0_ & ~0x00000001);
+              recommendedExtensionsBuilder_ = 
+                com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
+                   getRecommendedExtensionsFieldBuilder() : null;
+            } else {
+              recommendedExtensionsBuilder_.addAllMessages(other.recommendedExtensions_);
+            }
+          }
         }
         this.mergeUnknownFields(other.unknownFields);
         onChanged();
@@ -14581,11 +15808,11 @@ private static final long serialVersionUID = 0L;
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation parsedMessage = null;
+        com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation parsedMessage = null;
         try {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation) e.getUnfinishedMessage();
+          parsedMessage = (com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
@@ -14594,223 +15821,318 @@ private static final long serialVersionUID = 0L;
         }
         return this;
       }
+      private int bitField0_;
 
-      private com.google.ads.googleads.v1.common.KeywordInfo keyword_ = null;
-      private com.google.protobuf.SingleFieldBuilderV3<
-          com.google.ads.googleads.v1.common.KeywordInfo, com.google.ads.googleads.v1.common.KeywordInfo.Builder, com.google.ads.googleads.v1.common.KeywordInfoOrBuilder> keywordBuilder_;
-      /**
-       * <pre>
-       * The existing keyword where the match type should be more broad.
-       * </pre>
-       *
-       * <code>.google.ads.googleads.v1.common.KeywordInfo keyword = 1;</code>
-       */
-      public boolean hasKeyword() {
-        return keywordBuilder_ != null || keyword_ != null;
+      private java.util.List<com.google.ads.googleads.v1.common.CallFeedItem> recommendedExtensions_ =
+        java.util.Collections.emptyList();
+      private void ensureRecommendedExtensionsIsMutable() {
+        if (!((bitField0_ & 0x00000001) == 0x00000001)) {
+          recommendedExtensions_ = new java.util.ArrayList<com.google.ads.googleads.v1.common.CallFeedItem>(recommendedExtensions_);
+          bitField0_ |= 0x00000001;
+         }
       }
+
+      private com.google.protobuf.RepeatedFieldBuilderV3<
+          com.google.ads.googleads.v1.common.CallFeedItem, com.google.ads.googleads.v1.common.CallFeedItem.Builder, com.google.ads.googleads.v1.common.CallFeedItemOrBuilder> recommendedExtensionsBuilder_;
+
       /**
        * <pre>
-       * The existing keyword where the match type should be more broad.
+       * Call extensions recommended to be added.
        * </pre>
        *
-       * <code>.google.ads.googleads.v1.common.KeywordInfo keyword = 1;</code>
+       * <code>repeated .google.ads.googleads.v1.common.CallFeedItem recommended_extensions = 1;</code>
        */
-      public com.google.ads.googleads.v1.common.KeywordInfo getKeyword() {
-        if (keywordBuilder_ == null) {
-          return keyword_ == null ? com.google.ads.googleads.v1.common.KeywordInfo.getDefaultInstance() : keyword_;
+      public java.util.List<com.google.ads.googleads.v1.common.CallFeedItem> getRecommendedExtensionsList() {
+        if (recommendedExtensionsBuilder_ == null) {
+          return java.util.Collections.unmodifiableList(recommendedExtensions_);
         } else {
-          return keywordBuilder_.getMessage();
+          return recommendedExtensionsBuilder_.getMessageList();
         }
       }
       /**
        * <pre>
-       * The existing keyword where the match type should be more broad.
+       * Call extensions recommended to be added.
        * </pre>
        *
-       * <code>.google.ads.googleads.v1.common.KeywordInfo keyword = 1;</code>
+       * <code>repeated .google.ads.googleads.v1.common.CallFeedItem recommended_extensions = 1;</code>
        */
-      public Builder setKeyword(com.google.ads.googleads.v1.common.KeywordInfo value) {
-        if (keywordBuilder_ == null) {
+      public int getRecommendedExtensionsCount() {
+        if (recommendedExtensionsBuilder_ == null) {
+          return recommendedExtensions_.size();
+        } else {
+          return recommendedExtensionsBuilder_.getCount();
+        }
+      }
+      /**
+       * <pre>
+       * Call extensions recommended to be added.
+       * </pre>
+       *
+       * <code>repeated .google.ads.googleads.v1.common.CallFeedItem recommended_extensions = 1;</code>
+       */
+      public com.google.ads.googleads.v1.common.CallFeedItem getRecommendedExtensions(int index) {
+        if (recommendedExtensionsBuilder_ == null) {
+          return recommendedExtensions_.get(index);
+        } else {
+          return recommendedExtensionsBuilder_.getMessage(index);
+        }
+      }
+      /**
+       * <pre>
+       * Call extensions recommended to be added.
+       * </pre>
+       *
+       * <code>repeated .google.ads.googleads.v1.common.CallFeedItem recommended_extensions = 1;</code>
+       */
+      public Builder setRecommendedExtensions(
+          int index, com.google.ads.googleads.v1.common.CallFeedItem value) {
+        if (recommendedExtensionsBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
           }
-          keyword_ = value;
+          ensureRecommendedExtensionsIsMutable();
+          recommendedExtensions_.set(index, value);
           onChanged();
         } else {
-          keywordBuilder_.setMessage(value);
+          recommendedExtensionsBuilder_.setMessage(index, value);
         }
-
         return this;
       }
       /**
        * <pre>
-       * The existing keyword where the match type should be more broad.
+       * Call extensions recommended to be added.
        * </pre>
        *
-       * <code>.google.ads.googleads.v1.common.KeywordInfo keyword = 1;</code>
+       * <code>repeated .google.ads.googleads.v1.common.CallFeedItem recommended_extensions = 1;</code>
        */
-      public Builder setKeyword(
-          com.google.ads.googleads.v1.common.KeywordInfo.Builder builderForValue) {
-        if (keywordBuilder_ == null) {
-          keyword_ = builderForValue.build();
+      public Builder setRecommendedExtensions(
+          int index, com.google.ads.googleads.v1.common.CallFeedItem.Builder builderForValue) {
+        if (recommendedExtensionsBuilder_ == null) {
+          ensureRecommendedExtensionsIsMutable();
+          recommendedExtensions_.set(index, builderForValue.build());
           onChanged();
         } else {
-          keywordBuilder_.setMessage(builderForValue.build());
+          recommendedExtensionsBuilder_.setMessage(index, builderForValue.build());
         }
-
         return this;
       }
       /**
        * <pre>
-       * The existing keyword where the match type should be more broad.
+       * Call extensions recommended to be added.
        * </pre>
        *
-       * <code>.google.ads.googleads.v1.common.KeywordInfo keyword = 1;</code>
+       * <code>repeated .google.ads.googleads.v1.common.CallFeedItem recommended_extensions = 1;</code>
        */
-      public Builder mergeKeyword(com.google.ads.googleads.v1.common.KeywordInfo value) {
-        if (keywordBuilder_ == null) {
-          if (keyword_ != null) {
-            keyword_ =
-              com.google.ads.googleads.v1.common.KeywordInfo.newBuilder(keyword_).mergeFrom(value).buildPartial();
-          } else {
-            keyword_ = value;
+      public Builder addRecommendedExtensions(com.google.ads.googleads.v1.common.CallFeedItem value) {
+        if (recommendedExtensionsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
           }
+          ensureRecommendedExtensionsIsMutable();
+          recommendedExtensions_.add(value);
           onChanged();
         } else {
-          keywordBuilder_.mergeFrom(value);
+          recommendedExtensionsBuilder_.addMessage(value);
         }
-
         return this;
       }
       /**
        * <pre>
-       * The existing keyword where the match type should be more broad.
+       * Call extensions recommended to be added.
        * </pre>
        *
-       * <code>.google.ads.googleads.v1.common.KeywordInfo keyword = 1;</code>
+       * <code>repeated .google.ads.googleads.v1.common.CallFeedItem recommended_extensions = 1;</code>
        */
-      public Builder clearKeyword() {
-        if (keywordBuilder_ == null) {
-          keyword_ = null;
+      public Builder addRecommendedExtensions(
+          int index, com.google.ads.googleads.v1.common.CallFeedItem value) {
+        if (recommendedExtensionsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureRecommendedExtensionsIsMutable();
+          recommendedExtensions_.add(index, value);
           onChanged();
         } else {
-          keyword_ = null;
-          keywordBuilder_ = null;
+          recommendedExtensionsBuilder_.addMessage(index, value);
         }
-
         return this;
       }
       /**
        * <pre>
-       * The existing keyword where the match type should be more broad.
+       * Call extensions recommended to be added.
        * </pre>
        *
-       * <code>.google.ads.googleads.v1.common.KeywordInfo keyword = 1;</code>
+       * <code>repeated .google.ads.googleads.v1.common.CallFeedItem recommended_extensions = 1;</code>
        */
-      public com.google.ads.googleads.v1.common.KeywordInfo.Builder getKeywordBuilder() {
-        
-        onChanged();
-        return getKeywordFieldBuilder().getBuilder();
+      public Builder addRecommendedExtensions(
+          com.google.ads.googleads.v1.common.CallFeedItem.Builder builderForValue) {
+        if (recommendedExtensionsBuilder_ == null) {
+          ensureRecommendedExtensionsIsMutable();
+          recommendedExtensions_.add(builderForValue.build());
+          onChanged();
+        } else {
+          recommendedExtensionsBuilder_.addMessage(builderForValue.build());
+        }
+        return this;
       }
       /**
        * <pre>
-       * The existing keyword where the match type should be more broad.
+       * Call extensions recommended to be added.
        * </pre>
        *
-       * <code>.google.ads.googleads.v1.common.KeywordInfo keyword = 1;</code>
+       * <code>repeated .google.ads.googleads.v1.common.CallFeedItem recommended_extensions = 1;</code>
        */
-      public com.google.ads.googleads.v1.common.KeywordInfoOrBuilder getKeywordOrBuilder() {
-        if (keywordBuilder_ != null) {
-          return keywordBuilder_.getMessageOrBuilder();
+      public Builder addRecommendedExtensions(
+          int index, com.google.ads.googleads.v1.common.CallFeedItem.Builder builderForValue) {
+        if (recommendedExtensionsBuilder_ == null) {
+          ensureRecommendedExtensionsIsMutable();
+          recommendedExtensions_.add(index, builderForValue.build());
+          onChanged();
         } else {
-          return keyword_ == null ?
-              com.google.ads.googleads.v1.common.KeywordInfo.getDefaultInstance() : keyword_;
+          recommendedExtensionsBuilder_.addMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <pre>
+       * Call extensions recommended to be added.
+       * </pre>
+       *
+       * <code>repeated .google.ads.googleads.v1.common.CallFeedItem recommended_extensions = 1;</code>
+       */
+      public Builder addAllRecommendedExtensions(
+          java.lang.Iterable<? extends com.google.ads.googleads.v1.common.CallFeedItem> values) {
+        if (recommendedExtensionsBuilder_ == null) {
+          ensureRecommendedExtensionsIsMutable();
+          com.google.protobuf.AbstractMessageLite.Builder.addAll(
+              values, recommendedExtensions_);
+          onChanged();
+        } else {
+          recommendedExtensionsBuilder_.addAllMessages(values);
+        }
+        return this;
+      }
+      /**
+       * <pre>
+       * Call extensions recommended to be added.
+       * </pre>
+       *
+       * <code>repeated .google.ads.googleads.v1.common.CallFeedItem recommended_extensions = 1;</code>
+       */
+      public Builder clearRecommendedExtensions() {
+        if (recommendedExtensionsBuilder_ == null) {
+          recommendedExtensions_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000001);
+          onChanged();
+        } else {
+          recommendedExtensionsBuilder_.clear();
+        }
+        return this;
+      }
+      /**
+       * <pre>
+       * Call extensions recommended to be added.
+       * </pre>
+       *
+       * <code>repeated .google.ads.googleads.v1.common.CallFeedItem recommended_extensions = 1;</code>
+       */
+      public Builder removeRecommendedExtensions(int index) {
+        if (recommendedExtensionsBuilder_ == null) {
+          ensureRecommendedExtensionsIsMutable();
+          recommendedExtensions_.remove(index);
+          onChanged();
+        } else {
+          recommendedExtensionsBuilder_.remove(index);
+        }
+        return this;
+      }
+      /**
+       * <pre>
+       * Call extensions recommended to be added.
+       * </pre>
+       *
+       * <code>repeated .google.ads.googleads.v1.common.CallFeedItem recommended_extensions = 1;</code>
+       */
+      public com.google.ads.googleads.v1.common.CallFeedItem.Builder getRecommendedExtensionsBuilder(
+          int index) {
+        return getRecommendedExtensionsFieldBuilder().getBuilder(index);
+      }
+      /**
+       * <pre>
+       * Call extensions recommended to be added.
+       * </pre>
+       *
+       * <code>repeated .google.ads.googleads.v1.common.CallFeedItem recommended_extensions = 1;</code>
+       */
+      public com.google.ads.googleads.v1.common.CallFeedItemOrBuilder getRecommendedExtensionsOrBuilder(
+          int index) {
+        if (recommendedExtensionsBuilder_ == null) {
+          return recommendedExtensions_.get(index);  } else {
+          return recommendedExtensionsBuilder_.getMessageOrBuilder(index);
         }
       }
       /**
        * <pre>
-       * The existing keyword where the match type should be more broad.
+       * Call extensions recommended to be added.
        * </pre>
        *
-       * <code>.google.ads.googleads.v1.common.KeywordInfo keyword = 1;</code>
+       * <code>repeated .google.ads.googleads.v1.common.CallFeedItem recommended_extensions = 1;</code>
        */
-      private com.google.protobuf.SingleFieldBuilderV3<
-          com.google.ads.googleads.v1.common.KeywordInfo, com.google.ads.googleads.v1.common.KeywordInfo.Builder, com.google.ads.googleads.v1.common.KeywordInfoOrBuilder> 
-          getKeywordFieldBuilder() {
-        if (keywordBuilder_ == null) {
-          keywordBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-              com.google.ads.googleads.v1.common.KeywordInfo, com.google.ads.googleads.v1.common.KeywordInfo.Builder, com.google.ads.googleads.v1.common.KeywordInfoOrBuilder>(
-                  getKeyword(),
+      public java.util.List<? extends com.google.ads.googleads.v1.common.CallFeedItemOrBuilder> 
+           getRecommendedExtensionsOrBuilderList() {
+        if (recommendedExtensionsBuilder_ != null) {
+          return recommendedExtensionsBuilder_.getMessageOrBuilderList();
+        } else {
+          return java.util.Collections.unmodifiableList(recommendedExtensions_);
+        }
+      }
+      /**
+       * <pre>
+       * Call extensions recommended to be added.
+       * </pre>
+       *
+       * <code>repeated .google.ads.googleads.v1.common.CallFeedItem recommended_extensions = 1;</code>
+       */
+      public com.google.ads.googleads.v1.common.CallFeedItem.Builder addRecommendedExtensionsBuilder() {
+        return getRecommendedExtensionsFieldBuilder().addBuilder(
+            com.google.ads.googleads.v1.common.CallFeedItem.getDefaultInstance());
+      }
+      /**
+       * <pre>
+       * Call extensions recommended to be added.
+       * </pre>
+       *
+       * <code>repeated .google.ads.googleads.v1.common.CallFeedItem recommended_extensions = 1;</code>
+       */
+      public com.google.ads.googleads.v1.common.CallFeedItem.Builder addRecommendedExtensionsBuilder(
+          int index) {
+        return getRecommendedExtensionsFieldBuilder().addBuilder(
+            index, com.google.ads.googleads.v1.common.CallFeedItem.getDefaultInstance());
+      }
+      /**
+       * <pre>
+       * Call extensions recommended to be added.
+       * </pre>
+       *
+       * <code>repeated .google.ads.googleads.v1.common.CallFeedItem recommended_extensions = 1;</code>
+       */
+      public java.util.List<com.google.ads.googleads.v1.common.CallFeedItem.Builder> 
+           getRecommendedExtensionsBuilderList() {
+        return getRecommendedExtensionsFieldBuilder().getBuilderList();
+      }
+      private com.google.protobuf.RepeatedFieldBuilderV3<
+          com.google.ads.googleads.v1.common.CallFeedItem, com.google.ads.googleads.v1.common.CallFeedItem.Builder, com.google.ads.googleads.v1.common.CallFeedItemOrBuilder> 
+          getRecommendedExtensionsFieldBuilder() {
+        if (recommendedExtensionsBuilder_ == null) {
+          recommendedExtensionsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
+              com.google.ads.googleads.v1.common.CallFeedItem, com.google.ads.googleads.v1.common.CallFeedItem.Builder, com.google.ads.googleads.v1.common.CallFeedItemOrBuilder>(
+                  recommendedExtensions_,
+                  ((bitField0_ & 0x00000001) == 0x00000001),
                   getParentForChildren(),
                   isClean());
-          keyword_ = null;
+          recommendedExtensions_ = null;
         }
-        return keywordBuilder_;
-      }
-
-      private int recommendedMatchType_ = 0;
-      /**
-       * <pre>
-       * The recommended new match type.
-       * </pre>
-       *
-       * <code>.google.ads.googleads.v1.enums.KeywordMatchTypeEnum.KeywordMatchType recommended_match_type = 2;</code>
-       */
-      public int getRecommendedMatchTypeValue() {
-        return recommendedMatchType_;
-      }
-      /**
-       * <pre>
-       * The recommended new match type.
-       * </pre>
-       *
-       * <code>.google.ads.googleads.v1.enums.KeywordMatchTypeEnum.KeywordMatchType recommended_match_type = 2;</code>
-       */
-      public Builder setRecommendedMatchTypeValue(int value) {
-        recommendedMatchType_ = value;
-        onChanged();
-        return this;
-      }
-      /**
-       * <pre>
-       * The recommended new match type.
-       * </pre>
-       *
-       * <code>.google.ads.googleads.v1.enums.KeywordMatchTypeEnum.KeywordMatchType recommended_match_type = 2;</code>
-       */
-      public com.google.ads.googleads.v1.enums.KeywordMatchTypeEnum.KeywordMatchType getRecommendedMatchType() {
-        @SuppressWarnings("deprecation")
-        com.google.ads.googleads.v1.enums.KeywordMatchTypeEnum.KeywordMatchType result = com.google.ads.googleads.v1.enums.KeywordMatchTypeEnum.KeywordMatchType.valueOf(recommendedMatchType_);
-        return result == null ? com.google.ads.googleads.v1.enums.KeywordMatchTypeEnum.KeywordMatchType.UNRECOGNIZED : result;
-      }
-      /**
-       * <pre>
-       * The recommended new match type.
-       * </pre>
-       *
-       * <code>.google.ads.googleads.v1.enums.KeywordMatchTypeEnum.KeywordMatchType recommended_match_type = 2;</code>
-       */
-      public Builder setRecommendedMatchType(com.google.ads.googleads.v1.enums.KeywordMatchTypeEnum.KeywordMatchType value) {
-        if (value == null) {
-          throw new NullPointerException();
-        }
-        
-        recommendedMatchType_ = value.getNumber();
-        onChanged();
-        return this;
-      }
-      /**
-       * <pre>
-       * The recommended new match type.
-       * </pre>
-       *
-       * <code>.google.ads.googleads.v1.enums.KeywordMatchTypeEnum.KeywordMatchType recommended_match_type = 2;</code>
-       */
-      public Builder clearRecommendedMatchType() {
-        
-        recommendedMatchType_ = 0;
-        onChanged();
-        return this;
+        return recommendedExtensionsBuilder_;
       }
       @java.lang.Override
       public final Builder setUnknownFields(
@@ -14825,41 +16147,41 @@ private static final long serialVersionUID = 0L;
       }
 
 
-      // @@protoc_insertion_point(builder_scope:google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation)
+      // @@protoc_insertion_point(builder_scope:google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation)
     }
 
-    // @@protoc_insertion_point(class_scope:google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation)
-    private static final com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation DEFAULT_INSTANCE;
+    // @@protoc_insertion_point(class_scope:google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation)
+    private static final com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation DEFAULT_INSTANCE;
     static {
-      DEFAULT_INSTANCE = new com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation();
+      DEFAULT_INSTANCE = new com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation();
     }
 
-    public static com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation getDefaultInstance() {
+    public static com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation getDefaultInstance() {
       return DEFAULT_INSTANCE;
     }
 
-    private static final com.google.protobuf.Parser<KeywordMatchTypeRecommendation>
-        PARSER = new com.google.protobuf.AbstractParser<KeywordMatchTypeRecommendation>() {
+    private static final com.google.protobuf.Parser<CallExtensionRecommendation>
+        PARSER = new com.google.protobuf.AbstractParser<CallExtensionRecommendation>() {
       @java.lang.Override
-      public KeywordMatchTypeRecommendation parsePartialFrom(
+      public CallExtensionRecommendation parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws com.google.protobuf.InvalidProtocolBufferException {
-        return new KeywordMatchTypeRecommendation(input, extensionRegistry);
+        return new CallExtensionRecommendation(input, extensionRegistry);
       }
     };
 
-    public static com.google.protobuf.Parser<KeywordMatchTypeRecommendation> parser() {
+    public static com.google.protobuf.Parser<CallExtensionRecommendation> parser() {
       return PARSER;
     }
 
     @java.lang.Override
-    public com.google.protobuf.Parser<KeywordMatchTypeRecommendation> getParserForType() {
+    public com.google.protobuf.Parser<CallExtensionRecommendation> getParserForType() {
       return PARSER;
     }
 
     @java.lang.Override
-    public com.google.ads.googleads.v1.resources.Recommendation.KeywordMatchTypeRecommendation getDefaultInstanceForType() {
+    public com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
 
@@ -15789,1328 +17111,6 @@ private static final long serialVersionUID = 0L;
 
     @java.lang.Override
     public com.google.ads.googleads.v1.resources.Recommendation.MoveUnusedBudgetRecommendation getDefaultInstanceForType() {
-      return DEFAULT_INSTANCE;
-    }
-
-  }
-
-  public interface OptimizeAdRotationRecommendationOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation)
-      com.google.protobuf.MessageOrBuilder {
-  }
-  /**
-   * <pre>
-   * The Optimize Ad Rotation recommendation.
-   * </pre>
-   *
-   * Protobuf type {@code google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation}
-   */
-  public  static final class OptimizeAdRotationRecommendation extends
-      com.google.protobuf.GeneratedMessageV3 implements
-      // @@protoc_insertion_point(message_implements:google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation)
-      OptimizeAdRotationRecommendationOrBuilder {
-  private static final long serialVersionUID = 0L;
-    // Use OptimizeAdRotationRecommendation.newBuilder() to construct.
-    private OptimizeAdRotationRecommendation(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
-      super(builder);
-    }
-    private OptimizeAdRotationRecommendation() {
-    }
-
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
-    private OptimizeAdRotationRecommendation(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            default: {
-              if (!parseUnknownFieldProto3(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e).setUnfinishedMessage(this);
-      } finally {
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return com.google.ads.googleads.v1.resources.RecommendationProto.internal_static_google_ads_googleads_v1_resources_Recommendation_OptimizeAdRotationRecommendation_descriptor;
-    }
-
-    @java.lang.Override
-    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-        internalGetFieldAccessorTable() {
-      return com.google.ads.googleads.v1.resources.RecommendationProto.internal_static_google_ads_googleads_v1_resources_Recommendation_OptimizeAdRotationRecommendation_fieldAccessorTable
-          .ensureFieldAccessorsInitialized(
-              com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation.class, com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation.Builder.class);
-    }
-
-    private byte memoizedIsInitialized = -1;
-    @java.lang.Override
-    public final boolean isInitialized() {
-      byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
-
-      memoizedIsInitialized = 1;
-      return true;
-    }
-
-    @java.lang.Override
-    public void writeTo(com.google.protobuf.CodedOutputStream output)
-                        throws java.io.IOException {
-      unknownFields.writeTo(output);
-    }
-
-    @java.lang.Override
-    public int getSerializedSize() {
-      int size = memoizedSize;
-      if (size != -1) return size;
-
-      size = 0;
-      size += unknownFields.getSerializedSize();
-      memoizedSize = size;
-      return size;
-    }
-
-    @java.lang.Override
-    public boolean equals(final java.lang.Object obj) {
-      if (obj == this) {
-       return true;
-      }
-      if (!(obj instanceof com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation)) {
-        return super.equals(obj);
-      }
-      com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation other = (com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation) obj;
-
-      boolean result = true;
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
-    }
-
-    @java.lang.Override
-    public int hashCode() {
-      if (memoizedHashCode != 0) {
-        return memoizedHashCode;
-      }
-      int hash = 41;
-      hash = (19 * hash) + getDescriptor().hashCode();
-      hash = (29 * hash) + unknownFields.hashCode();
-      memoizedHashCode = hash;
-      return hash;
-    }
-
-    public static com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation parseFrom(
-        java.nio.ByteBuffer data)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
-    }
-    public static com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation parseFrom(
-        java.nio.ByteBuffer data,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
-    }
-    public static com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation parseFrom(
-        com.google.protobuf.ByteString data)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
-    }
-    public static com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation parseFrom(
-        com.google.protobuf.ByteString data,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
-    }
-    public static com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation parseFrom(byte[] data)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
-    }
-    public static com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation parseFrom(
-        byte[] data,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
-    }
-    public static com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation parseFrom(java.io.InputStream input)
-        throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
-          .parseWithIOException(PARSER, input);
-    }
-    public static com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation parseFrom(
-        java.io.InputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
-          .parseWithIOException(PARSER, input, extensionRegistry);
-    }
-    public static com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation parseDelimitedFrom(java.io.InputStream input)
-        throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
-          .parseDelimitedWithIOException(PARSER, input);
-    }
-    public static com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation parseDelimitedFrom(
-        java.io.InputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
-          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
-    }
-    public static com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation parseFrom(
-        com.google.protobuf.CodedInputStream input)
-        throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
-          .parseWithIOException(PARSER, input);
-    }
-    public static com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation parseFrom(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
-          .parseWithIOException(PARSER, input, extensionRegistry);
-    }
-
-    @java.lang.Override
-    public Builder newBuilderForType() { return newBuilder(); }
-    public static Builder newBuilder() {
-      return DEFAULT_INSTANCE.toBuilder();
-    }
-    public static Builder newBuilder(com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation prototype) {
-      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
-    }
-    @java.lang.Override
-    public Builder toBuilder() {
-      return this == DEFAULT_INSTANCE
-          ? new Builder() : new Builder().mergeFrom(this);
-    }
-
-    @java.lang.Override
-    protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
-      Builder builder = new Builder(parent);
-      return builder;
-    }
-    /**
-     * <pre>
-     * The Optimize Ad Rotation recommendation.
-     * </pre>
-     *
-     * Protobuf type {@code google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation}
-     */
-    public static final class Builder extends
-        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation)
-        com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendationOrBuilder {
-      public static final com.google.protobuf.Descriptors.Descriptor
-          getDescriptor() {
-        return com.google.ads.googleads.v1.resources.RecommendationProto.internal_static_google_ads_googleads_v1_resources_Recommendation_OptimizeAdRotationRecommendation_descriptor;
-      }
-
-      @java.lang.Override
-      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-          internalGetFieldAccessorTable() {
-        return com.google.ads.googleads.v1.resources.RecommendationProto.internal_static_google_ads_googleads_v1_resources_Recommendation_OptimizeAdRotationRecommendation_fieldAccessorTable
-            .ensureFieldAccessorsInitialized(
-                com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation.class, com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation.Builder.class);
-      }
-
-      // Construct using com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation.newBuilder()
-      private Builder() {
-        maybeForceBuilderInitialization();
-      }
-
-      private Builder(
-          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
-        super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessageV3
-                .alwaysUseFieldBuilders) {
-        }
-      }
-      @java.lang.Override
-      public Builder clear() {
-        super.clear();
-        return this;
-      }
-
-      @java.lang.Override
-      public com.google.protobuf.Descriptors.Descriptor
-          getDescriptorForType() {
-        return com.google.ads.googleads.v1.resources.RecommendationProto.internal_static_google_ads_googleads_v1_resources_Recommendation_OptimizeAdRotationRecommendation_descriptor;
-      }
-
-      @java.lang.Override
-      public com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation getDefaultInstanceForType() {
-        return com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation.getDefaultInstance();
-      }
-
-      @java.lang.Override
-      public com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation build() {
-        com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation result = buildPartial();
-        if (!result.isInitialized()) {
-          throw newUninitializedMessageException(result);
-        }
-        return result;
-      }
-
-      @java.lang.Override
-      public com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation buildPartial() {
-        com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation result = new com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation(this);
-        onBuilt();
-        return result;
-      }
-
-      @java.lang.Override
-      public Builder clone() {
-        return (Builder) super.clone();
-      }
-      @java.lang.Override
-      public Builder setField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return (Builder) super.setField(field, value);
-      }
-      @java.lang.Override
-      public Builder clearField(
-          com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
-      }
-      @java.lang.Override
-      public Builder clearOneof(
-          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
-      }
-      @java.lang.Override
-      public Builder setRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
-      }
-      @java.lang.Override
-      public Builder addRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
-      }
-      @java.lang.Override
-      public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation) {
-          return mergeFrom((com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation)other);
-        } else {
-          super.mergeFrom(other);
-          return this;
-        }
-      }
-
-      public Builder mergeFrom(com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation other) {
-        if (other == com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation.getDefaultInstance()) return this;
-        this.mergeUnknownFields(other.unknownFields);
-        onChanged();
-        return this;
-      }
-
-      @java.lang.Override
-      public final boolean isInitialized() {
-        return true;
-      }
-
-      @java.lang.Override
-      public Builder mergeFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws java.io.IOException {
-        com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation parsedMessage = null;
-        try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation) e.getUnfinishedMessage();
-          throw e.unwrapIOException();
-        } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
-        return this;
-      }
-      @java.lang.Override
-      public final Builder setUnknownFields(
-          final com.google.protobuf.UnknownFieldSet unknownFields) {
-        return super.setUnknownFieldsProto3(unknownFields);
-      }
-
-      @java.lang.Override
-      public final Builder mergeUnknownFields(
-          final com.google.protobuf.UnknownFieldSet unknownFields) {
-        return super.mergeUnknownFields(unknownFields);
-      }
-
-
-      // @@protoc_insertion_point(builder_scope:google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation)
-    }
-
-    // @@protoc_insertion_point(class_scope:google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation)
-    private static final com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation DEFAULT_INSTANCE;
-    static {
-      DEFAULT_INSTANCE = new com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation();
-    }
-
-    public static com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation getDefaultInstance() {
-      return DEFAULT_INSTANCE;
-    }
-
-    private static final com.google.protobuf.Parser<OptimizeAdRotationRecommendation>
-        PARSER = new com.google.protobuf.AbstractParser<OptimizeAdRotationRecommendation>() {
-      @java.lang.Override
-      public OptimizeAdRotationRecommendation parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new OptimizeAdRotationRecommendation(input, extensionRegistry);
-      }
-    };
-
-    public static com.google.protobuf.Parser<OptimizeAdRotationRecommendation> parser() {
-      return PARSER;
-    }
-
-    @java.lang.Override
-    public com.google.protobuf.Parser<OptimizeAdRotationRecommendation> getParserForType() {
-      return PARSER;
-    }
-
-    @java.lang.Override
-    public com.google.ads.googleads.v1.resources.Recommendation.OptimizeAdRotationRecommendation getDefaultInstanceForType() {
-      return DEFAULT_INSTANCE;
-    }
-
-  }
-
-  public interface CallExtensionRecommendationOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation)
-      com.google.protobuf.MessageOrBuilder {
-
-    /**
-     * <pre>
-     * Call extensions recommended to be added.
-     * </pre>
-     *
-     * <code>repeated .google.ads.googleads.v1.common.CallFeedItem recommended_extensions = 1;</code>
-     */
-    java.util.List<com.google.ads.googleads.v1.common.CallFeedItem> 
-        getRecommendedExtensionsList();
-    /**
-     * <pre>
-     * Call extensions recommended to be added.
-     * </pre>
-     *
-     * <code>repeated .google.ads.googleads.v1.common.CallFeedItem recommended_extensions = 1;</code>
-     */
-    com.google.ads.googleads.v1.common.CallFeedItem getRecommendedExtensions(int index);
-    /**
-     * <pre>
-     * Call extensions recommended to be added.
-     * </pre>
-     *
-     * <code>repeated .google.ads.googleads.v1.common.CallFeedItem recommended_extensions = 1;</code>
-     */
-    int getRecommendedExtensionsCount();
-    /**
-     * <pre>
-     * Call extensions recommended to be added.
-     * </pre>
-     *
-     * <code>repeated .google.ads.googleads.v1.common.CallFeedItem recommended_extensions = 1;</code>
-     */
-    java.util.List<? extends com.google.ads.googleads.v1.common.CallFeedItemOrBuilder> 
-        getRecommendedExtensionsOrBuilderList();
-    /**
-     * <pre>
-     * Call extensions recommended to be added.
-     * </pre>
-     *
-     * <code>repeated .google.ads.googleads.v1.common.CallFeedItem recommended_extensions = 1;</code>
-     */
-    com.google.ads.googleads.v1.common.CallFeedItemOrBuilder getRecommendedExtensionsOrBuilder(
-        int index);
-  }
-  /**
-   * <pre>
-   * The Call extension recommendation.
-   * </pre>
-   *
-   * Protobuf type {@code google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation}
-   */
-  public  static final class CallExtensionRecommendation extends
-      com.google.protobuf.GeneratedMessageV3 implements
-      // @@protoc_insertion_point(message_implements:google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation)
-      CallExtensionRecommendationOrBuilder {
-  private static final long serialVersionUID = 0L;
-    // Use CallExtensionRecommendation.newBuilder() to construct.
-    private CallExtensionRecommendation(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
-      super(builder);
-    }
-    private CallExtensionRecommendation() {
-      recommendedExtensions_ = java.util.Collections.emptyList();
-    }
-
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
-    private CallExtensionRecommendation(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            case 10: {
-              if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
-                recommendedExtensions_ = new java.util.ArrayList<com.google.ads.googleads.v1.common.CallFeedItem>();
-                mutable_bitField0_ |= 0x00000001;
-              }
-              recommendedExtensions_.add(
-                  input.readMessage(com.google.ads.googleads.v1.common.CallFeedItem.parser(), extensionRegistry));
-              break;
-            }
-            default: {
-              if (!parseUnknownFieldProto3(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e).setUnfinishedMessage(this);
-      } finally {
-        if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
-          recommendedExtensions_ = java.util.Collections.unmodifiableList(recommendedExtensions_);
-        }
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return com.google.ads.googleads.v1.resources.RecommendationProto.internal_static_google_ads_googleads_v1_resources_Recommendation_CallExtensionRecommendation_descriptor;
-    }
-
-    @java.lang.Override
-    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-        internalGetFieldAccessorTable() {
-      return com.google.ads.googleads.v1.resources.RecommendationProto.internal_static_google_ads_googleads_v1_resources_Recommendation_CallExtensionRecommendation_fieldAccessorTable
-          .ensureFieldAccessorsInitialized(
-              com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation.class, com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation.Builder.class);
-    }
-
-    public static final int RECOMMENDED_EXTENSIONS_FIELD_NUMBER = 1;
-    private java.util.List<com.google.ads.googleads.v1.common.CallFeedItem> recommendedExtensions_;
-    /**
-     * <pre>
-     * Call extensions recommended to be added.
-     * </pre>
-     *
-     * <code>repeated .google.ads.googleads.v1.common.CallFeedItem recommended_extensions = 1;</code>
-     */
-    public java.util.List<com.google.ads.googleads.v1.common.CallFeedItem> getRecommendedExtensionsList() {
-      return recommendedExtensions_;
-    }
-    /**
-     * <pre>
-     * Call extensions recommended to be added.
-     * </pre>
-     *
-     * <code>repeated .google.ads.googleads.v1.common.CallFeedItem recommended_extensions = 1;</code>
-     */
-    public java.util.List<? extends com.google.ads.googleads.v1.common.CallFeedItemOrBuilder> 
-        getRecommendedExtensionsOrBuilderList() {
-      return recommendedExtensions_;
-    }
-    /**
-     * <pre>
-     * Call extensions recommended to be added.
-     * </pre>
-     *
-     * <code>repeated .google.ads.googleads.v1.common.CallFeedItem recommended_extensions = 1;</code>
-     */
-    public int getRecommendedExtensionsCount() {
-      return recommendedExtensions_.size();
-    }
-    /**
-     * <pre>
-     * Call extensions recommended to be added.
-     * </pre>
-     *
-     * <code>repeated .google.ads.googleads.v1.common.CallFeedItem recommended_extensions = 1;</code>
-     */
-    public com.google.ads.googleads.v1.common.CallFeedItem getRecommendedExtensions(int index) {
-      return recommendedExtensions_.get(index);
-    }
-    /**
-     * <pre>
-     * Call extensions recommended to be added.
-     * </pre>
-     *
-     * <code>repeated .google.ads.googleads.v1.common.CallFeedItem recommended_extensions = 1;</code>
-     */
-    public com.google.ads.googleads.v1.common.CallFeedItemOrBuilder getRecommendedExtensionsOrBuilder(
-        int index) {
-      return recommendedExtensions_.get(index);
-    }
-
-    private byte memoizedIsInitialized = -1;
-    @java.lang.Override
-    public final boolean isInitialized() {
-      byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
-
-      memoizedIsInitialized = 1;
-      return true;
-    }
-
-    @java.lang.Override
-    public void writeTo(com.google.protobuf.CodedOutputStream output)
-                        throws java.io.IOException {
-      for (int i = 0; i < recommendedExtensions_.size(); i++) {
-        output.writeMessage(1, recommendedExtensions_.get(i));
-      }
-      unknownFields.writeTo(output);
-    }
-
-    @java.lang.Override
-    public int getSerializedSize() {
-      int size = memoizedSize;
-      if (size != -1) return size;
-
-      size = 0;
-      for (int i = 0; i < recommendedExtensions_.size(); i++) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(1, recommendedExtensions_.get(i));
-      }
-      size += unknownFields.getSerializedSize();
-      memoizedSize = size;
-      return size;
-    }
-
-    @java.lang.Override
-    public boolean equals(final java.lang.Object obj) {
-      if (obj == this) {
-       return true;
-      }
-      if (!(obj instanceof com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation)) {
-        return super.equals(obj);
-      }
-      com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation other = (com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation) obj;
-
-      boolean result = true;
-      result = result && getRecommendedExtensionsList()
-          .equals(other.getRecommendedExtensionsList());
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
-    }
-
-    @java.lang.Override
-    public int hashCode() {
-      if (memoizedHashCode != 0) {
-        return memoizedHashCode;
-      }
-      int hash = 41;
-      hash = (19 * hash) + getDescriptor().hashCode();
-      if (getRecommendedExtensionsCount() > 0) {
-        hash = (37 * hash) + RECOMMENDED_EXTENSIONS_FIELD_NUMBER;
-        hash = (53 * hash) + getRecommendedExtensionsList().hashCode();
-      }
-      hash = (29 * hash) + unknownFields.hashCode();
-      memoizedHashCode = hash;
-      return hash;
-    }
-
-    public static com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation parseFrom(
-        java.nio.ByteBuffer data)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
-    }
-    public static com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation parseFrom(
-        java.nio.ByteBuffer data,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
-    }
-    public static com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation parseFrom(
-        com.google.protobuf.ByteString data)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
-    }
-    public static com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation parseFrom(
-        com.google.protobuf.ByteString data,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
-    }
-    public static com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation parseFrom(byte[] data)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
-    }
-    public static com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation parseFrom(
-        byte[] data,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
-    }
-    public static com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation parseFrom(java.io.InputStream input)
-        throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
-          .parseWithIOException(PARSER, input);
-    }
-    public static com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation parseFrom(
-        java.io.InputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
-          .parseWithIOException(PARSER, input, extensionRegistry);
-    }
-    public static com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation parseDelimitedFrom(java.io.InputStream input)
-        throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
-          .parseDelimitedWithIOException(PARSER, input);
-    }
-    public static com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation parseDelimitedFrom(
-        java.io.InputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
-          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
-    }
-    public static com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation parseFrom(
-        com.google.protobuf.CodedInputStream input)
-        throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
-          .parseWithIOException(PARSER, input);
-    }
-    public static com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation parseFrom(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
-          .parseWithIOException(PARSER, input, extensionRegistry);
-    }
-
-    @java.lang.Override
-    public Builder newBuilderForType() { return newBuilder(); }
-    public static Builder newBuilder() {
-      return DEFAULT_INSTANCE.toBuilder();
-    }
-    public static Builder newBuilder(com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation prototype) {
-      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
-    }
-    @java.lang.Override
-    public Builder toBuilder() {
-      return this == DEFAULT_INSTANCE
-          ? new Builder() : new Builder().mergeFrom(this);
-    }
-
-    @java.lang.Override
-    protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
-      Builder builder = new Builder(parent);
-      return builder;
-    }
-    /**
-     * <pre>
-     * The Call extension recommendation.
-     * </pre>
-     *
-     * Protobuf type {@code google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation}
-     */
-    public static final class Builder extends
-        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation)
-        com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendationOrBuilder {
-      public static final com.google.protobuf.Descriptors.Descriptor
-          getDescriptor() {
-        return com.google.ads.googleads.v1.resources.RecommendationProto.internal_static_google_ads_googleads_v1_resources_Recommendation_CallExtensionRecommendation_descriptor;
-      }
-
-      @java.lang.Override
-      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-          internalGetFieldAccessorTable() {
-        return com.google.ads.googleads.v1.resources.RecommendationProto.internal_static_google_ads_googleads_v1_resources_Recommendation_CallExtensionRecommendation_fieldAccessorTable
-            .ensureFieldAccessorsInitialized(
-                com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation.class, com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation.Builder.class);
-      }
-
-      // Construct using com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation.newBuilder()
-      private Builder() {
-        maybeForceBuilderInitialization();
-      }
-
-      private Builder(
-          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
-        super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessageV3
-                .alwaysUseFieldBuilders) {
-          getRecommendedExtensionsFieldBuilder();
-        }
-      }
-      @java.lang.Override
-      public Builder clear() {
-        super.clear();
-        if (recommendedExtensionsBuilder_ == null) {
-          recommendedExtensions_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000001);
-        } else {
-          recommendedExtensionsBuilder_.clear();
-        }
-        return this;
-      }
-
-      @java.lang.Override
-      public com.google.protobuf.Descriptors.Descriptor
-          getDescriptorForType() {
-        return com.google.ads.googleads.v1.resources.RecommendationProto.internal_static_google_ads_googleads_v1_resources_Recommendation_CallExtensionRecommendation_descriptor;
-      }
-
-      @java.lang.Override
-      public com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation getDefaultInstanceForType() {
-        return com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation.getDefaultInstance();
-      }
-
-      @java.lang.Override
-      public com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation build() {
-        com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation result = buildPartial();
-        if (!result.isInitialized()) {
-          throw newUninitializedMessageException(result);
-        }
-        return result;
-      }
-
-      @java.lang.Override
-      public com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation buildPartial() {
-        com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation result = new com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation(this);
-        int from_bitField0_ = bitField0_;
-        if (recommendedExtensionsBuilder_ == null) {
-          if (((bitField0_ & 0x00000001) == 0x00000001)) {
-            recommendedExtensions_ = java.util.Collections.unmodifiableList(recommendedExtensions_);
-            bitField0_ = (bitField0_ & ~0x00000001);
-          }
-          result.recommendedExtensions_ = recommendedExtensions_;
-        } else {
-          result.recommendedExtensions_ = recommendedExtensionsBuilder_.build();
-        }
-        onBuilt();
-        return result;
-      }
-
-      @java.lang.Override
-      public Builder clone() {
-        return (Builder) super.clone();
-      }
-      @java.lang.Override
-      public Builder setField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return (Builder) super.setField(field, value);
-      }
-      @java.lang.Override
-      public Builder clearField(
-          com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
-      }
-      @java.lang.Override
-      public Builder clearOneof(
-          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
-      }
-      @java.lang.Override
-      public Builder setRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
-      }
-      @java.lang.Override
-      public Builder addRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
-      }
-      @java.lang.Override
-      public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation) {
-          return mergeFrom((com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation)other);
-        } else {
-          super.mergeFrom(other);
-          return this;
-        }
-      }
-
-      public Builder mergeFrom(com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation other) {
-        if (other == com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation.getDefaultInstance()) return this;
-        if (recommendedExtensionsBuilder_ == null) {
-          if (!other.recommendedExtensions_.isEmpty()) {
-            if (recommendedExtensions_.isEmpty()) {
-              recommendedExtensions_ = other.recommendedExtensions_;
-              bitField0_ = (bitField0_ & ~0x00000001);
-            } else {
-              ensureRecommendedExtensionsIsMutable();
-              recommendedExtensions_.addAll(other.recommendedExtensions_);
-            }
-            onChanged();
-          }
-        } else {
-          if (!other.recommendedExtensions_.isEmpty()) {
-            if (recommendedExtensionsBuilder_.isEmpty()) {
-              recommendedExtensionsBuilder_.dispose();
-              recommendedExtensionsBuilder_ = null;
-              recommendedExtensions_ = other.recommendedExtensions_;
-              bitField0_ = (bitField0_ & ~0x00000001);
-              recommendedExtensionsBuilder_ = 
-                com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
-                   getRecommendedExtensionsFieldBuilder() : null;
-            } else {
-              recommendedExtensionsBuilder_.addAllMessages(other.recommendedExtensions_);
-            }
-          }
-        }
-        this.mergeUnknownFields(other.unknownFields);
-        onChanged();
-        return this;
-      }
-
-      @java.lang.Override
-      public final boolean isInitialized() {
-        return true;
-      }
-
-      @java.lang.Override
-      public Builder mergeFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws java.io.IOException {
-        com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation parsedMessage = null;
-        try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation) e.getUnfinishedMessage();
-          throw e.unwrapIOException();
-        } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
-        return this;
-      }
-      private int bitField0_;
-
-      private java.util.List<com.google.ads.googleads.v1.common.CallFeedItem> recommendedExtensions_ =
-        java.util.Collections.emptyList();
-      private void ensureRecommendedExtensionsIsMutable() {
-        if (!((bitField0_ & 0x00000001) == 0x00000001)) {
-          recommendedExtensions_ = new java.util.ArrayList<com.google.ads.googleads.v1.common.CallFeedItem>(recommendedExtensions_);
-          bitField0_ |= 0x00000001;
-         }
-      }
-
-      private com.google.protobuf.RepeatedFieldBuilderV3<
-          com.google.ads.googleads.v1.common.CallFeedItem, com.google.ads.googleads.v1.common.CallFeedItem.Builder, com.google.ads.googleads.v1.common.CallFeedItemOrBuilder> recommendedExtensionsBuilder_;
-
-      /**
-       * <pre>
-       * Call extensions recommended to be added.
-       * </pre>
-       *
-       * <code>repeated .google.ads.googleads.v1.common.CallFeedItem recommended_extensions = 1;</code>
-       */
-      public java.util.List<com.google.ads.googleads.v1.common.CallFeedItem> getRecommendedExtensionsList() {
-        if (recommendedExtensionsBuilder_ == null) {
-          return java.util.Collections.unmodifiableList(recommendedExtensions_);
-        } else {
-          return recommendedExtensionsBuilder_.getMessageList();
-        }
-      }
-      /**
-       * <pre>
-       * Call extensions recommended to be added.
-       * </pre>
-       *
-       * <code>repeated .google.ads.googleads.v1.common.CallFeedItem recommended_extensions = 1;</code>
-       */
-      public int getRecommendedExtensionsCount() {
-        if (recommendedExtensionsBuilder_ == null) {
-          return recommendedExtensions_.size();
-        } else {
-          return recommendedExtensionsBuilder_.getCount();
-        }
-      }
-      /**
-       * <pre>
-       * Call extensions recommended to be added.
-       * </pre>
-       *
-       * <code>repeated .google.ads.googleads.v1.common.CallFeedItem recommended_extensions = 1;</code>
-       */
-      public com.google.ads.googleads.v1.common.CallFeedItem getRecommendedExtensions(int index) {
-        if (recommendedExtensionsBuilder_ == null) {
-          return recommendedExtensions_.get(index);
-        } else {
-          return recommendedExtensionsBuilder_.getMessage(index);
-        }
-      }
-      /**
-       * <pre>
-       * Call extensions recommended to be added.
-       * </pre>
-       *
-       * <code>repeated .google.ads.googleads.v1.common.CallFeedItem recommended_extensions = 1;</code>
-       */
-      public Builder setRecommendedExtensions(
-          int index, com.google.ads.googleads.v1.common.CallFeedItem value) {
-        if (recommendedExtensionsBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          ensureRecommendedExtensionsIsMutable();
-          recommendedExtensions_.set(index, value);
-          onChanged();
-        } else {
-          recommendedExtensionsBuilder_.setMessage(index, value);
-        }
-        return this;
-      }
-      /**
-       * <pre>
-       * Call extensions recommended to be added.
-       * </pre>
-       *
-       * <code>repeated .google.ads.googleads.v1.common.CallFeedItem recommended_extensions = 1;</code>
-       */
-      public Builder setRecommendedExtensions(
-          int index, com.google.ads.googleads.v1.common.CallFeedItem.Builder builderForValue) {
-        if (recommendedExtensionsBuilder_ == null) {
-          ensureRecommendedExtensionsIsMutable();
-          recommendedExtensions_.set(index, builderForValue.build());
-          onChanged();
-        } else {
-          recommendedExtensionsBuilder_.setMessage(index, builderForValue.build());
-        }
-        return this;
-      }
-      /**
-       * <pre>
-       * Call extensions recommended to be added.
-       * </pre>
-       *
-       * <code>repeated .google.ads.googleads.v1.common.CallFeedItem recommended_extensions = 1;</code>
-       */
-      public Builder addRecommendedExtensions(com.google.ads.googleads.v1.common.CallFeedItem value) {
-        if (recommendedExtensionsBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          ensureRecommendedExtensionsIsMutable();
-          recommendedExtensions_.add(value);
-          onChanged();
-        } else {
-          recommendedExtensionsBuilder_.addMessage(value);
-        }
-        return this;
-      }
-      /**
-       * <pre>
-       * Call extensions recommended to be added.
-       * </pre>
-       *
-       * <code>repeated .google.ads.googleads.v1.common.CallFeedItem recommended_extensions = 1;</code>
-       */
-      public Builder addRecommendedExtensions(
-          int index, com.google.ads.googleads.v1.common.CallFeedItem value) {
-        if (recommendedExtensionsBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          ensureRecommendedExtensionsIsMutable();
-          recommendedExtensions_.add(index, value);
-          onChanged();
-        } else {
-          recommendedExtensionsBuilder_.addMessage(index, value);
-        }
-        return this;
-      }
-      /**
-       * <pre>
-       * Call extensions recommended to be added.
-       * </pre>
-       *
-       * <code>repeated .google.ads.googleads.v1.common.CallFeedItem recommended_extensions = 1;</code>
-       */
-      public Builder addRecommendedExtensions(
-          com.google.ads.googleads.v1.common.CallFeedItem.Builder builderForValue) {
-        if (recommendedExtensionsBuilder_ == null) {
-          ensureRecommendedExtensionsIsMutable();
-          recommendedExtensions_.add(builderForValue.build());
-          onChanged();
-        } else {
-          recommendedExtensionsBuilder_.addMessage(builderForValue.build());
-        }
-        return this;
-      }
-      /**
-       * <pre>
-       * Call extensions recommended to be added.
-       * </pre>
-       *
-       * <code>repeated .google.ads.googleads.v1.common.CallFeedItem recommended_extensions = 1;</code>
-       */
-      public Builder addRecommendedExtensions(
-          int index, com.google.ads.googleads.v1.common.CallFeedItem.Builder builderForValue) {
-        if (recommendedExtensionsBuilder_ == null) {
-          ensureRecommendedExtensionsIsMutable();
-          recommendedExtensions_.add(index, builderForValue.build());
-          onChanged();
-        } else {
-          recommendedExtensionsBuilder_.addMessage(index, builderForValue.build());
-        }
-        return this;
-      }
-      /**
-       * <pre>
-       * Call extensions recommended to be added.
-       * </pre>
-       *
-       * <code>repeated .google.ads.googleads.v1.common.CallFeedItem recommended_extensions = 1;</code>
-       */
-      public Builder addAllRecommendedExtensions(
-          java.lang.Iterable<? extends com.google.ads.googleads.v1.common.CallFeedItem> values) {
-        if (recommendedExtensionsBuilder_ == null) {
-          ensureRecommendedExtensionsIsMutable();
-          com.google.protobuf.AbstractMessageLite.Builder.addAll(
-              values, recommendedExtensions_);
-          onChanged();
-        } else {
-          recommendedExtensionsBuilder_.addAllMessages(values);
-        }
-        return this;
-      }
-      /**
-       * <pre>
-       * Call extensions recommended to be added.
-       * </pre>
-       *
-       * <code>repeated .google.ads.googleads.v1.common.CallFeedItem recommended_extensions = 1;</code>
-       */
-      public Builder clearRecommendedExtensions() {
-        if (recommendedExtensionsBuilder_ == null) {
-          recommendedExtensions_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00000001);
-          onChanged();
-        } else {
-          recommendedExtensionsBuilder_.clear();
-        }
-        return this;
-      }
-      /**
-       * <pre>
-       * Call extensions recommended to be added.
-       * </pre>
-       *
-       * <code>repeated .google.ads.googleads.v1.common.CallFeedItem recommended_extensions = 1;</code>
-       */
-      public Builder removeRecommendedExtensions(int index) {
-        if (recommendedExtensionsBuilder_ == null) {
-          ensureRecommendedExtensionsIsMutable();
-          recommendedExtensions_.remove(index);
-          onChanged();
-        } else {
-          recommendedExtensionsBuilder_.remove(index);
-        }
-        return this;
-      }
-      /**
-       * <pre>
-       * Call extensions recommended to be added.
-       * </pre>
-       *
-       * <code>repeated .google.ads.googleads.v1.common.CallFeedItem recommended_extensions = 1;</code>
-       */
-      public com.google.ads.googleads.v1.common.CallFeedItem.Builder getRecommendedExtensionsBuilder(
-          int index) {
-        return getRecommendedExtensionsFieldBuilder().getBuilder(index);
-      }
-      /**
-       * <pre>
-       * Call extensions recommended to be added.
-       * </pre>
-       *
-       * <code>repeated .google.ads.googleads.v1.common.CallFeedItem recommended_extensions = 1;</code>
-       */
-      public com.google.ads.googleads.v1.common.CallFeedItemOrBuilder getRecommendedExtensionsOrBuilder(
-          int index) {
-        if (recommendedExtensionsBuilder_ == null) {
-          return recommendedExtensions_.get(index);  } else {
-          return recommendedExtensionsBuilder_.getMessageOrBuilder(index);
-        }
-      }
-      /**
-       * <pre>
-       * Call extensions recommended to be added.
-       * </pre>
-       *
-       * <code>repeated .google.ads.googleads.v1.common.CallFeedItem recommended_extensions = 1;</code>
-       */
-      public java.util.List<? extends com.google.ads.googleads.v1.common.CallFeedItemOrBuilder> 
-           getRecommendedExtensionsOrBuilderList() {
-        if (recommendedExtensionsBuilder_ != null) {
-          return recommendedExtensionsBuilder_.getMessageOrBuilderList();
-        } else {
-          return java.util.Collections.unmodifiableList(recommendedExtensions_);
-        }
-      }
-      /**
-       * <pre>
-       * Call extensions recommended to be added.
-       * </pre>
-       *
-       * <code>repeated .google.ads.googleads.v1.common.CallFeedItem recommended_extensions = 1;</code>
-       */
-      public com.google.ads.googleads.v1.common.CallFeedItem.Builder addRecommendedExtensionsBuilder() {
-        return getRecommendedExtensionsFieldBuilder().addBuilder(
-            com.google.ads.googleads.v1.common.CallFeedItem.getDefaultInstance());
-      }
-      /**
-       * <pre>
-       * Call extensions recommended to be added.
-       * </pre>
-       *
-       * <code>repeated .google.ads.googleads.v1.common.CallFeedItem recommended_extensions = 1;</code>
-       */
-      public com.google.ads.googleads.v1.common.CallFeedItem.Builder addRecommendedExtensionsBuilder(
-          int index) {
-        return getRecommendedExtensionsFieldBuilder().addBuilder(
-            index, com.google.ads.googleads.v1.common.CallFeedItem.getDefaultInstance());
-      }
-      /**
-       * <pre>
-       * Call extensions recommended to be added.
-       * </pre>
-       *
-       * <code>repeated .google.ads.googleads.v1.common.CallFeedItem recommended_extensions = 1;</code>
-       */
-      public java.util.List<com.google.ads.googleads.v1.common.CallFeedItem.Builder> 
-           getRecommendedExtensionsBuilderList() {
-        return getRecommendedExtensionsFieldBuilder().getBuilderList();
-      }
-      private com.google.protobuf.RepeatedFieldBuilderV3<
-          com.google.ads.googleads.v1.common.CallFeedItem, com.google.ads.googleads.v1.common.CallFeedItem.Builder, com.google.ads.googleads.v1.common.CallFeedItemOrBuilder> 
-          getRecommendedExtensionsFieldBuilder() {
-        if (recommendedExtensionsBuilder_ == null) {
-          recommendedExtensionsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-              com.google.ads.googleads.v1.common.CallFeedItem, com.google.ads.googleads.v1.common.CallFeedItem.Builder, com.google.ads.googleads.v1.common.CallFeedItemOrBuilder>(
-                  recommendedExtensions_,
-                  ((bitField0_ & 0x00000001) == 0x00000001),
-                  getParentForChildren(),
-                  isClean());
-          recommendedExtensions_ = null;
-        }
-        return recommendedExtensionsBuilder_;
-      }
-      @java.lang.Override
-      public final Builder setUnknownFields(
-          final com.google.protobuf.UnknownFieldSet unknownFields) {
-        return super.setUnknownFieldsProto3(unknownFields);
-      }
-
-      @java.lang.Override
-      public final Builder mergeUnknownFields(
-          final com.google.protobuf.UnknownFieldSet unknownFields) {
-        return super.mergeUnknownFields(unknownFields);
-      }
-
-
-      // @@protoc_insertion_point(builder_scope:google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation)
-    }
-
-    // @@protoc_insertion_point(class_scope:google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation)
-    private static final com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation DEFAULT_INSTANCE;
-    static {
-      DEFAULT_INSTANCE = new com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation();
-    }
-
-    public static com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation getDefaultInstance() {
-      return DEFAULT_INSTANCE;
-    }
-
-    private static final com.google.protobuf.Parser<CallExtensionRecommendation>
-        PARSER = new com.google.protobuf.AbstractParser<CallExtensionRecommendation>() {
-      @java.lang.Override
-      public CallExtensionRecommendation parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new CallExtensionRecommendation(input, extensionRegistry);
-      }
-    };
-
-    public static com.google.protobuf.Parser<CallExtensionRecommendation> parser() {
-      return PARSER;
-    }
-
-    @java.lang.Override
-    public com.google.protobuf.Parser<CallExtensionRecommendation> getParserForType() {
-      return PARSER;
-    }
-
-    @java.lang.Override
-    public com.google.ads.googleads.v1.resources.Recommendation.CallExtensionRecommendation getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
 

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/resources/RecommendationProto.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/resources/RecommendationProto.java
@@ -45,15 +45,30 @@ public final class RecommendationProto {
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_ads_googleads_v1_resources_Recommendation_KeywordRecommendation_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_google_ads_googleads_v1_resources_Recommendation_MaximizeClicksOptInRecommendation_descriptor;
+    internal_static_google_ads_googleads_v1_resources_Recommendation_KeywordMatchTypeRecommendation_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_google_ads_googleads_v1_resources_Recommendation_MaximizeClicksOptInRecommendation_fieldAccessorTable;
+      internal_static_google_ads_googleads_v1_resources_Recommendation_KeywordMatchTypeRecommendation_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_ads_googleads_v1_resources_Recommendation_TextAdRecommendation_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_ads_googleads_v1_resources_Recommendation_TextAdRecommendation_fieldAccessorTable;
+  static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_google_ads_googleads_v1_resources_Recommendation_SearchPartnersOptInRecommendation_descriptor;
+  static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_google_ads_googleads_v1_resources_Recommendation_SearchPartnersOptInRecommendation_fieldAccessorTable;
+  static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_google_ads_googleads_v1_resources_Recommendation_MaximizeClicksOptInRecommendation_descriptor;
+  static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_google_ads_googleads_v1_resources_Recommendation_MaximizeClicksOptInRecommendation_fieldAccessorTable;
+  static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_google_ads_googleads_v1_resources_Recommendation_CalloutExtensionRecommendation_descriptor;
+  static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_google_ads_googleads_v1_resources_Recommendation_CalloutExtensionRecommendation_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_ads_googleads_v1_resources_Recommendation_TargetCpaOptInRecommendation_descriptor;
   static final 
@@ -75,40 +90,25 @@ public final class RecommendationProto {
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_ads_googleads_v1_resources_Recommendation_EnhancedCpcOptInRecommendation_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_google_ads_googleads_v1_resources_Recommendation_CalloutExtensionRecommendation_descriptor;
+    internal_static_google_ads_googleads_v1_resources_Recommendation_OptimizeAdRotationRecommendation_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_google_ads_googleads_v1_resources_Recommendation_CalloutExtensionRecommendation_fieldAccessorTable;
+      internal_static_google_ads_googleads_v1_resources_Recommendation_OptimizeAdRotationRecommendation_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_ads_googleads_v1_resources_Recommendation_SitelinkExtensionRecommendation_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_ads_googleads_v1_resources_Recommendation_SitelinkExtensionRecommendation_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_google_ads_googleads_v1_resources_Recommendation_SearchPartnersOptInRecommendation_descriptor;
+    internal_static_google_ads_googleads_v1_resources_Recommendation_CallExtensionRecommendation_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_google_ads_googleads_v1_resources_Recommendation_SearchPartnersOptInRecommendation_fieldAccessorTable;
-  static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_google_ads_googleads_v1_resources_Recommendation_KeywordMatchTypeRecommendation_descriptor;
-  static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_google_ads_googleads_v1_resources_Recommendation_KeywordMatchTypeRecommendation_fieldAccessorTable;
+      internal_static_google_ads_googleads_v1_resources_Recommendation_CallExtensionRecommendation_fieldAccessorTable;
   static final com.google.protobuf.Descriptors.Descriptor
     internal_static_google_ads_googleads_v1_resources_Recommendation_MoveUnusedBudgetRecommendation_descriptor;
   static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_google_ads_googleads_v1_resources_Recommendation_MoveUnusedBudgetRecommendation_fieldAccessorTable;
-  static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_google_ads_googleads_v1_resources_Recommendation_OptimizeAdRotationRecommendation_descriptor;
-  static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_google_ads_googleads_v1_resources_Recommendation_OptimizeAdRotationRecommendation_fieldAccessorTable;
-  static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_google_ads_googleads_v1_resources_Recommendation_CallExtensionRecommendation_descriptor;
-  static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_google_ads_googleads_v1_resources_Recommendation_CallExtensionRecommendation_fieldAccessorTable;
 
   public static com.google.protobuf.Descriptors.FileDescriptor
       getDescriptor() {
@@ -213,53 +213,53 @@ public final class RecommendationProto {
       "\007keyword\030\001 \001(\0132+.google.ads.googleads.v1" +
       ".common.KeywordInfo\022?\n\032recommended_cpc_b" +
       "id_micros\030\002 \001(\0132\033.google.protobuf.Int64V" +
-      "alue\032j\n!MaximizeClicksOptInRecommendatio" +
-      "n\022E\n recommended_budget_amount_micros\030\001 " +
-      "\001(\0132\033.google.protobuf.Int64Value\032\265\001\n\024Tex" +
-      "tAdRecommendation\0221\n\002ad\030\001 \001(\0132%.google.a" +
-      "ds.googleads.v1.resources.Ad\0223\n\rcreation" +
-      "_date\030\002 \001(\0132\034.google.protobuf.StringValu" +
-      "e\0225\n\017auto_apply_date\030\003 \001(\0132\034.google.prot" +
-      "obuf.StringValue\032\337\004\n\034TargetCpaOptInRecom" +
-      "mendation\022\202\001\n\007options\030\001 \003(\0132q.google.ads" +
-      ".googleads.v1.resources.Recommendation.T" +
-      "argetCpaOptInRecommendation.TargetCpaOpt" +
-      "InRecommendationOption\022B\n\035recommended_ta" +
-      "rget_cpa_micros\030\002 \001(\0132\033.google.protobuf." +
-      "Int64Value\032\365\002\n\"TargetCpaOptInRecommendat" +
-      "ionOption\022r\n\004goal\030\001 \001(\0162d.google.ads.goo" +
-      "gleads.v1.enums.TargetCpaOptInRecommenda" +
-      "tionGoalEnum.TargetCpaOptInRecommendatio" +
-      "nGoal\0226\n\021target_cpa_micros\030\002 \001(\0132\033.googl" +
-      "e.protobuf.Int64Value\022K\n&required_campai" +
-      "gn_budget_amount_micros\030\003 \001(\0132\033.google.p" +
-      "rotobuf.Int64Value\022V\n\006impact\030\004 \001(\0132F.goo" +
+      "alue\032\304\001\n\036KeywordMatchTypeRecommendation\022" +
+      "<\n\007keyword\030\001 \001(\0132+.google.ads.googleads." +
+      "v1.common.KeywordInfo\022d\n\026recommended_mat" +
+      "ch_type\030\002 \001(\0162D.google.ads.googleads.v1." +
+      "enums.KeywordMatchTypeEnum.KeywordMatchT" +
+      "ype\032\265\001\n\024TextAdRecommendation\0221\n\002ad\030\001 \001(\013" +
+      "2%.google.ads.googleads.v1.resources.Ad\022" +
+      "3\n\rcreation_date\030\002 \001(\0132\034.google.protobuf" +
+      ".StringValue\0225\n\017auto_apply_date\030\003 \001(\0132\034." +
+      "google.protobuf.StringValue\032#\n!SearchPar" +
+      "tnersOptInRecommendation\032j\n!MaximizeClic" +
+      "ksOptInRecommendation\022E\n recommended_bud" +
+      "get_amount_micros\030\001 \001(\0132\033.google.protobu" +
+      "f.Int64Value\032q\n\036CalloutExtensionRecommen" +
+      "dation\022O\n\026recommended_extensions\030\001 \003(\0132/" +
+      ".google.ads.googleads.v1.common.CalloutF" +
+      "eedItem\032\337\004\n\034TargetCpaOptInRecommendation" +
+      "\022\202\001\n\007options\030\001 \003(\0132q.google.ads.googlead" +
+      "s.v1.resources.Recommendation.TargetCpaO" +
+      "ptInRecommendation.TargetCpaOptInRecomme" +
+      "ndationOption\022B\n\035recommended_target_cpa_" +
+      "micros\030\002 \001(\0132\033.google.protobuf.Int64Valu" +
+      "e\032\365\002\n\"TargetCpaOptInRecommendationOption" +
+      "\022r\n\004goal\030\001 \001(\0162d.google.ads.googleads.v1" +
+      ".enums.TargetCpaOptInRecommendationGoalE" +
+      "num.TargetCpaOptInRecommendationGoal\0226\n\021" +
+      "target_cpa_micros\030\002 \001(\0132\033.google.protobu" +
+      "f.Int64Value\022K\n&required_campaign_budget" +
+      "_amount_micros\030\003 \001(\0132\033.google.protobuf.I" +
+      "nt64Value\022V\n\006impact\030\004 \001(\0132F.google.ads.g" +
+      "oogleads.v1.resources.Recommendation.Rec" +
+      "ommendationImpact\032o\n&MaximizeConversions" +
+      "OptInRecommendation\022E\n recommended_budge" +
+      "t_amount_micros\030\001 \001(\0132\033.google.protobuf." +
+      "Int64Value\032 \n\036EnhancedCpcOptInRecommenda" +
+      "tion\032\"\n OptimizeAdRotationRecommendation" +
+      "\032s\n\037SitelinkExtensionRecommendation\022P\n\026r" +
+      "ecommended_extensions\030\001 \003(\01320.google.ads" +
+      ".googleads.v1.common.SitelinkFeedItem\032k\n" +
+      "\033CallExtensionRecommendation\022L\n\026recommen" +
+      "ded_extensions\030\001 \003(\0132,.google.ads.google" +
+      "ads.v1.common.CallFeedItem\032\315\001\n\036MoveUnuse" +
+      "dBudgetRecommendation\022<\n\026excess_campaign" +
+      "_budget\030\001 \001(\0132\034.google.protobuf.StringVa" +
+      "lue\022m\n\025budget_recommendation\030\002 \001(\0132N.goo" +
       "gle.ads.googleads.v1.resources.Recommend" +
-      "ation.RecommendationImpact\032o\n&MaximizeCo" +
-      "nversionsOptInRecommendation\022E\n recommen" +
-      "ded_budget_amount_micros\030\001 \001(\0132\033.google." +
-      "protobuf.Int64Value\032 \n\036EnhancedCpcOptInR" +
-      "ecommendation\032q\n\036CalloutExtensionRecomme" +
-      "ndation\022O\n\026recommended_extensions\030\001 \003(\0132" +
-      "/.google.ads.googleads.v1.common.Callout" +
-      "FeedItem\032s\n\037SitelinkExtensionRecommendat" +
-      "ion\022P\n\026recommended_extensions\030\001 \003(\01320.go" +
-      "ogle.ads.googleads.v1.common.SitelinkFee" +
-      "dItem\032#\n!SearchPartnersOptInRecommendati" +
-      "on\032\304\001\n\036KeywordMatchTypeRecommendation\022<\n" +
-      "\007keyword\030\001 \001(\0132+.google.ads.googleads.v1" +
-      ".common.KeywordInfo\022d\n\026recommended_match" +
-      "_type\030\002 \001(\0162D.google.ads.googleads.v1.en" +
-      "ums.KeywordMatchTypeEnum.KeywordMatchTyp" +
-      "e\032\315\001\n\036MoveUnusedBudgetRecommendation\022<\n\026" +
-      "excess_campaign_budget\030\001 \001(\0132\034.google.pr" +
-      "otobuf.StringValue\022m\n\025budget_recommendat" +
-      "ion\030\002 \001(\0132N.google.ads.googleads.v1.reso" +
-      "urces.Recommendation.CampaignBudgetRecom" +
-      "mendation\032\"\n OptimizeAdRotationRecommend" +
-      "ation\032k\n\033CallExtensionRecommendation\022L\n\026" +
-      "recommended_extensions\030\001 \003(\0132,.google.ad" +
-      "s.googleads.v1.common.CallFeedItemB\020\n\016re" +
+      "ation.CampaignBudgetRecommendationB\020\n\016re" +
       "commendationB\200\002\n%com.google.ads.googlead" +
       "s.v1.resourcesB\023RecommendationProtoP\001ZJg" +
       "oogle.golang.org/genproto/googleapis/ads" +
@@ -324,20 +324,38 @@ public final class RecommendationProto {
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_ads_googleads_v1_resources_Recommendation_KeywordRecommendation_descriptor,
         new java.lang.String[] { "Keyword", "RecommendedCpcBidMicros", });
-    internal_static_google_ads_googleads_v1_resources_Recommendation_MaximizeClicksOptInRecommendation_descriptor =
+    internal_static_google_ads_googleads_v1_resources_Recommendation_KeywordMatchTypeRecommendation_descriptor =
       internal_static_google_ads_googleads_v1_resources_Recommendation_descriptor.getNestedTypes().get(4);
-    internal_static_google_ads_googleads_v1_resources_Recommendation_MaximizeClicksOptInRecommendation_fieldAccessorTable = new
+    internal_static_google_ads_googleads_v1_resources_Recommendation_KeywordMatchTypeRecommendation_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_google_ads_googleads_v1_resources_Recommendation_MaximizeClicksOptInRecommendation_descriptor,
-        new java.lang.String[] { "RecommendedBudgetAmountMicros", });
+        internal_static_google_ads_googleads_v1_resources_Recommendation_KeywordMatchTypeRecommendation_descriptor,
+        new java.lang.String[] { "Keyword", "RecommendedMatchType", });
     internal_static_google_ads_googleads_v1_resources_Recommendation_TextAdRecommendation_descriptor =
       internal_static_google_ads_googleads_v1_resources_Recommendation_descriptor.getNestedTypes().get(5);
     internal_static_google_ads_googleads_v1_resources_Recommendation_TextAdRecommendation_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_ads_googleads_v1_resources_Recommendation_TextAdRecommendation_descriptor,
         new java.lang.String[] { "Ad", "CreationDate", "AutoApplyDate", });
-    internal_static_google_ads_googleads_v1_resources_Recommendation_TargetCpaOptInRecommendation_descriptor =
+    internal_static_google_ads_googleads_v1_resources_Recommendation_SearchPartnersOptInRecommendation_descriptor =
       internal_static_google_ads_googleads_v1_resources_Recommendation_descriptor.getNestedTypes().get(6);
+    internal_static_google_ads_googleads_v1_resources_Recommendation_SearchPartnersOptInRecommendation_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_google_ads_googleads_v1_resources_Recommendation_SearchPartnersOptInRecommendation_descriptor,
+        new java.lang.String[] { });
+    internal_static_google_ads_googleads_v1_resources_Recommendation_MaximizeClicksOptInRecommendation_descriptor =
+      internal_static_google_ads_googleads_v1_resources_Recommendation_descriptor.getNestedTypes().get(7);
+    internal_static_google_ads_googleads_v1_resources_Recommendation_MaximizeClicksOptInRecommendation_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_google_ads_googleads_v1_resources_Recommendation_MaximizeClicksOptInRecommendation_descriptor,
+        new java.lang.String[] { "RecommendedBudgetAmountMicros", });
+    internal_static_google_ads_googleads_v1_resources_Recommendation_CalloutExtensionRecommendation_descriptor =
+      internal_static_google_ads_googleads_v1_resources_Recommendation_descriptor.getNestedTypes().get(8);
+    internal_static_google_ads_googleads_v1_resources_Recommendation_CalloutExtensionRecommendation_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_google_ads_googleads_v1_resources_Recommendation_CalloutExtensionRecommendation_descriptor,
+        new java.lang.String[] { "RecommendedExtensions", });
+    internal_static_google_ads_googleads_v1_resources_Recommendation_TargetCpaOptInRecommendation_descriptor =
+      internal_static_google_ads_googleads_v1_resources_Recommendation_descriptor.getNestedTypes().get(9);
     internal_static_google_ads_googleads_v1_resources_Recommendation_TargetCpaOptInRecommendation_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_ads_googleads_v1_resources_Recommendation_TargetCpaOptInRecommendation_descriptor,
@@ -349,59 +367,41 @@ public final class RecommendationProto {
         internal_static_google_ads_googleads_v1_resources_Recommendation_TargetCpaOptInRecommendation_TargetCpaOptInRecommendationOption_descriptor,
         new java.lang.String[] { "Goal", "TargetCpaMicros", "RequiredCampaignBudgetAmountMicros", "Impact", });
     internal_static_google_ads_googleads_v1_resources_Recommendation_MaximizeConversionsOptInRecommendation_descriptor =
-      internal_static_google_ads_googleads_v1_resources_Recommendation_descriptor.getNestedTypes().get(7);
+      internal_static_google_ads_googleads_v1_resources_Recommendation_descriptor.getNestedTypes().get(10);
     internal_static_google_ads_googleads_v1_resources_Recommendation_MaximizeConversionsOptInRecommendation_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_ads_googleads_v1_resources_Recommendation_MaximizeConversionsOptInRecommendation_descriptor,
         new java.lang.String[] { "RecommendedBudgetAmountMicros", });
     internal_static_google_ads_googleads_v1_resources_Recommendation_EnhancedCpcOptInRecommendation_descriptor =
-      internal_static_google_ads_googleads_v1_resources_Recommendation_descriptor.getNestedTypes().get(8);
+      internal_static_google_ads_googleads_v1_resources_Recommendation_descriptor.getNestedTypes().get(11);
     internal_static_google_ads_googleads_v1_resources_Recommendation_EnhancedCpcOptInRecommendation_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_ads_googleads_v1_resources_Recommendation_EnhancedCpcOptInRecommendation_descriptor,
         new java.lang.String[] { });
-    internal_static_google_ads_googleads_v1_resources_Recommendation_CalloutExtensionRecommendation_descriptor =
-      internal_static_google_ads_googleads_v1_resources_Recommendation_descriptor.getNestedTypes().get(9);
-    internal_static_google_ads_googleads_v1_resources_Recommendation_CalloutExtensionRecommendation_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_google_ads_googleads_v1_resources_Recommendation_CalloutExtensionRecommendation_descriptor,
-        new java.lang.String[] { "RecommendedExtensions", });
-    internal_static_google_ads_googleads_v1_resources_Recommendation_SitelinkExtensionRecommendation_descriptor =
-      internal_static_google_ads_googleads_v1_resources_Recommendation_descriptor.getNestedTypes().get(10);
-    internal_static_google_ads_googleads_v1_resources_Recommendation_SitelinkExtensionRecommendation_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_google_ads_googleads_v1_resources_Recommendation_SitelinkExtensionRecommendation_descriptor,
-        new java.lang.String[] { "RecommendedExtensions", });
-    internal_static_google_ads_googleads_v1_resources_Recommendation_SearchPartnersOptInRecommendation_descriptor =
-      internal_static_google_ads_googleads_v1_resources_Recommendation_descriptor.getNestedTypes().get(11);
-    internal_static_google_ads_googleads_v1_resources_Recommendation_SearchPartnersOptInRecommendation_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_google_ads_googleads_v1_resources_Recommendation_SearchPartnersOptInRecommendation_descriptor,
-        new java.lang.String[] { });
-    internal_static_google_ads_googleads_v1_resources_Recommendation_KeywordMatchTypeRecommendation_descriptor =
-      internal_static_google_ads_googleads_v1_resources_Recommendation_descriptor.getNestedTypes().get(12);
-    internal_static_google_ads_googleads_v1_resources_Recommendation_KeywordMatchTypeRecommendation_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_google_ads_googleads_v1_resources_Recommendation_KeywordMatchTypeRecommendation_descriptor,
-        new java.lang.String[] { "Keyword", "RecommendedMatchType", });
-    internal_static_google_ads_googleads_v1_resources_Recommendation_MoveUnusedBudgetRecommendation_descriptor =
-      internal_static_google_ads_googleads_v1_resources_Recommendation_descriptor.getNestedTypes().get(13);
-    internal_static_google_ads_googleads_v1_resources_Recommendation_MoveUnusedBudgetRecommendation_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_google_ads_googleads_v1_resources_Recommendation_MoveUnusedBudgetRecommendation_descriptor,
-        new java.lang.String[] { "ExcessCampaignBudget", "BudgetRecommendation", });
     internal_static_google_ads_googleads_v1_resources_Recommendation_OptimizeAdRotationRecommendation_descriptor =
-      internal_static_google_ads_googleads_v1_resources_Recommendation_descriptor.getNestedTypes().get(14);
+      internal_static_google_ads_googleads_v1_resources_Recommendation_descriptor.getNestedTypes().get(12);
     internal_static_google_ads_googleads_v1_resources_Recommendation_OptimizeAdRotationRecommendation_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_ads_googleads_v1_resources_Recommendation_OptimizeAdRotationRecommendation_descriptor,
         new java.lang.String[] { });
+    internal_static_google_ads_googleads_v1_resources_Recommendation_SitelinkExtensionRecommendation_descriptor =
+      internal_static_google_ads_googleads_v1_resources_Recommendation_descriptor.getNestedTypes().get(13);
+    internal_static_google_ads_googleads_v1_resources_Recommendation_SitelinkExtensionRecommendation_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_google_ads_googleads_v1_resources_Recommendation_SitelinkExtensionRecommendation_descriptor,
+        new java.lang.String[] { "RecommendedExtensions", });
     internal_static_google_ads_googleads_v1_resources_Recommendation_CallExtensionRecommendation_descriptor =
-      internal_static_google_ads_googleads_v1_resources_Recommendation_descriptor.getNestedTypes().get(15);
+      internal_static_google_ads_googleads_v1_resources_Recommendation_descriptor.getNestedTypes().get(14);
     internal_static_google_ads_googleads_v1_resources_Recommendation_CallExtensionRecommendation_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_google_ads_googleads_v1_resources_Recommendation_CallExtensionRecommendation_descriptor,
         new java.lang.String[] { "RecommendedExtensions", });
+    internal_static_google_ads_googleads_v1_resources_Recommendation_MoveUnusedBudgetRecommendation_descriptor =
+      internal_static_google_ads_googleads_v1_resources_Recommendation_descriptor.getNestedTypes().get(15);
+    internal_static_google_ads_googleads_v1_resources_Recommendation_MoveUnusedBudgetRecommendation_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_google_ads_googleads_v1_resources_Recommendation_MoveUnusedBudgetRecommendation_descriptor,
+        new java.lang.String[] { "ExcessCampaignBudget", "BudgetRecommendation", });
     com.google.ads.googleads.v1.common.CriteriaProto.getDescriptor();
     com.google.ads.googleads.v1.common.ExtensionsProto.getDescriptor();
     com.google.ads.googleads.v1.enums.KeywordMatchTypeProto.getDescriptor();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/GoogleAdsVersion.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/GoogleAdsVersion.java
@@ -21,41 +21,155 @@ import com.google.ads.googleads.v1.errors.GoogleAdsException;
 @VersionDescriptor(versionName = "v1", googleAdsExceptionFactory = GoogleAdsException.Factory.class)
 public interface GoogleAdsVersion {
 
-  @ServiceClientDescriptor(settingsClass = CustomInterestServiceSettings.class)
-  CustomInterestServiceClient createCustomInterestServiceClient();
+  @ServiceClientDescriptor(settingsClass = UserListServiceSettings.class)
+  UserListServiceClient createUserListServiceClient();
+
+  @ServiceClientDescriptor(settingsClass = GeoTargetConstantServiceSettings.class)
+  GeoTargetConstantServiceClient createGeoTargetConstantServiceClient();
+
+  @ServiceClientDescriptor(settingsClass = AdGroupCriterionServiceSettings.class)
+  AdGroupCriterionServiceClient createAdGroupCriterionServiceClient();
+
+  @ServiceClientDescriptor(settingsClass = ConversionAdjustmentUploadServiceSettings.class)
+  ConversionAdjustmentUploadServiceClient createConversionAdjustmentUploadServiceClient();
+
+  @ServiceClientDescriptor(settingsClass = CampaignFeedServiceSettings.class)
+  CampaignFeedServiceClient createCampaignFeedServiceClient();
+
+  @ServiceClientDescriptor(settingsClass = AdParameterServiceSettings.class)
+  AdParameterServiceClient createAdParameterServiceClient();
+
+  @ServiceClientDescriptor(settingsClass = GenderViewServiceSettings.class)
+  GenderViewServiceClient createGenderViewServiceClient();
 
   @ServiceClientDescriptor(settingsClass = ExpandedLandingPageViewServiceSettings.class)
   ExpandedLandingPageViewServiceClient createExpandedLandingPageViewServiceClient();
 
-  @ServiceClientDescriptor(settingsClass = SharedSetServiceSettings.class)
-  SharedSetServiceClient createSharedSetServiceClient();
+  @ServiceClientDescriptor(settingsClass = CampaignBudgetServiceSettings.class)
+  CampaignBudgetServiceClient createCampaignBudgetServiceClient();
 
-  @ServiceClientDescriptor(settingsClass = AdGroupAudienceViewServiceSettings.class)
-  AdGroupAudienceViewServiceClient createAdGroupAudienceViewServiceClient();
+  @ServiceClientDescriptor(settingsClass = LabelServiceSettings.class)
+  LabelServiceClient createLabelServiceClient();
 
-  @ServiceClientDescriptor(settingsClass = HotelGroupViewServiceSettings.class)
-  HotelGroupViewServiceClient createHotelGroupViewServiceClient();
+  @ServiceClientDescriptor(settingsClass = AdScheduleViewServiceSettings.class)
+  AdScheduleViewServiceClient createAdScheduleViewServiceClient();
 
-  @ServiceClientDescriptor(settingsClass = AdGroupAdLabelServiceSettings.class)
-  AdGroupAdLabelServiceClient createAdGroupAdLabelServiceClient();
+  @ServiceClientDescriptor(settingsClass = ManagedPlacementViewServiceSettings.class)
+  ManagedPlacementViewServiceClient createManagedPlacementViewServiceClient();
 
-  @ServiceClientDescriptor(settingsClass = AdGroupExtensionSettingServiceSettings.class)
-  AdGroupExtensionSettingServiceClient createAdGroupExtensionSettingServiceClient();
+  @ServiceClientDescriptor(settingsClass = KeywordPlanCampaignServiceSettings.class)
+  KeywordPlanCampaignServiceClient createKeywordPlanCampaignServiceClient();
 
-  @ServiceClientDescriptor(settingsClass = CampaignExperimentServiceSettings.class)
-  CampaignExperimentServiceClient createCampaignExperimentServiceClient();
+  @ServiceClientDescriptor(settingsClass = AdGroupCriterionSimulationServiceSettings.class)
+  AdGroupCriterionSimulationServiceClient createAdGroupCriterionSimulationServiceClient();
 
-  @ServiceClientDescriptor(settingsClass = DynamicSearchAdsSearchTermViewServiceSettings.class)
-  DynamicSearchAdsSearchTermViewServiceClient createDynamicSearchAdsSearchTermViewServiceClient();
+  @ServiceClientDescriptor(settingsClass = CustomerFeedServiceSettings.class)
+  CustomerFeedServiceClient createCustomerFeedServiceClient();
+
+  @ServiceClientDescriptor(settingsClass = FeedServiceSettings.class)
+  FeedServiceClient createFeedServiceClient();
+
+  @ServiceClientDescriptor(settingsClass = FeedPlaceholderViewServiceSettings.class)
+  FeedPlaceholderViewServiceClient createFeedPlaceholderViewServiceClient();
+
+  @ServiceClientDescriptor(settingsClass = MobileAppCategoryConstantServiceSettings.class)
+  MobileAppCategoryConstantServiceClient createMobileAppCategoryConstantServiceClient();
+
+  @ServiceClientDescriptor(settingsClass = FeedItemTargetServiceSettings.class)
+  FeedItemTargetServiceClient createFeedItemTargetServiceClient();
+
+  @ServiceClientDescriptor(settingsClass = AdGroupSimulationServiceSettings.class)
+  AdGroupSimulationServiceClient createAdGroupSimulationServiceClient();
+
+  @ServiceClientDescriptor(settingsClass = SharedCriterionServiceSettings.class)
+  SharedCriterionServiceClient createSharedCriterionServiceClient();
+
+  @ServiceClientDescriptor(settingsClass = KeywordPlanAdGroupServiceSettings.class)
+  KeywordPlanAdGroupServiceClient createKeywordPlanAdGroupServiceClient();
+
+  @ServiceClientDescriptor(settingsClass = LocationViewServiceSettings.class)
+  LocationViewServiceClient createLocationViewServiceClient();
+
+  @ServiceClientDescriptor(settingsClass = CarrierConstantServiceSettings.class)
+  CarrierConstantServiceClient createCarrierConstantServiceClient();
+
+  @ServiceClientDescriptor(settingsClass = AgeRangeViewServiceSettings.class)
+  AgeRangeViewServiceClient createAgeRangeViewServiceClient();
+
+  @ServiceClientDescriptor(settingsClass = DisplayKeywordViewServiceSettings.class)
+  DisplayKeywordViewServiceClient createDisplayKeywordViewServiceClient();
+
+  @ServiceClientDescriptor(settingsClass = DetailPlacementViewServiceSettings.class)
+  DetailPlacementViewServiceClient createDetailPlacementViewServiceClient();
+
+  @ServiceClientDescriptor(settingsClass = CampaignCriterionServiceSettings.class)
+  CampaignCriterionServiceClient createCampaignCriterionServiceClient();
+
+  @ServiceClientDescriptor(settingsClass = TopicConstantServiceSettings.class)
+  TopicConstantServiceClient createTopicConstantServiceClient();
+
+  @ServiceClientDescriptor(settingsClass = BiddingStrategyServiceSettings.class)
+  BiddingStrategyServiceClient createBiddingStrategyServiceClient();
+
+  @ServiceClientDescriptor(settingsClass = CampaignAudienceViewServiceSettings.class)
+  CampaignAudienceViewServiceClient createCampaignAudienceViewServiceClient();
+
+  @ServiceClientDescriptor(settingsClass = GoogleAdsServiceSettings.class)
+  GoogleAdsServiceClient createGoogleAdsServiceClient();
+
+  @ServiceClientDescriptor(settingsClass = RemarketingActionServiceSettings.class)
+  RemarketingActionServiceClient createRemarketingActionServiceClient();
+
+  @ServiceClientDescriptor(settingsClass = ProductGroupViewServiceSettings.class)
+  ProductGroupViewServiceClient createProductGroupViewServiceClient();
 
   @ServiceClientDescriptor(settingsClass = KeywordPlanServiceSettings.class)
   KeywordPlanServiceClient createKeywordPlanServiceClient();
 
-  @ServiceClientDescriptor(settingsClass = HotelPerformanceViewServiceSettings.class)
-  HotelPerformanceViewServiceClient createHotelPerformanceViewServiceClient();
+  @ServiceClientDescriptor(settingsClass = CustomInterestServiceSettings.class)
+  CustomInterestServiceClient createCustomInterestServiceClient();
 
-  @ServiceClientDescriptor(settingsClass = FeedServiceSettings.class)
-  FeedServiceClient createFeedServiceClient();
+  @ServiceClientDescriptor(settingsClass = AdGroupServiceSettings.class)
+  AdGroupServiceClient createAdGroupServiceClient();
+
+  @ServiceClientDescriptor(settingsClass = UserInterestServiceSettings.class)
+  UserInterestServiceClient createUserInterestServiceClient();
+
+  @ServiceClientDescriptor(settingsClass = AssetServiceSettings.class)
+  AssetServiceClient createAssetServiceClient();
+
+  @ServiceClientDescriptor(settingsClass = AdGroupCriterionLabelServiceSettings.class)
+  AdGroupCriterionLabelServiceClient createAdGroupCriterionLabelServiceClient();
+
+  @ServiceClientDescriptor(settingsClass = PaidOrganicSearchTermViewServiceSettings.class)
+  PaidOrganicSearchTermViewServiceClient createPaidOrganicSearchTermViewServiceClient();
+
+  @ServiceClientDescriptor(settingsClass = CustomerNegativeCriterionServiceSettings.class)
+  CustomerNegativeCriterionServiceClient createCustomerNegativeCriterionServiceClient();
+
+  @ServiceClientDescriptor(settingsClass = ConversionUploadServiceSettings.class)
+  ConversionUploadServiceClient createConversionUploadServiceClient();
+
+  @ServiceClientDescriptor(settingsClass = ShoppingPerformanceViewServiceSettings.class)
+  ShoppingPerformanceViewServiceClient createShoppingPerformanceViewServiceClient();
+
+  @ServiceClientDescriptor(settingsClass = MediaFileServiceSettings.class)
+  MediaFileServiceClient createMediaFileServiceClient();
+
+  @ServiceClientDescriptor(settingsClass = MerchantCenterLinkServiceSettings.class)
+  MerchantCenterLinkServiceClient createMerchantCenterLinkServiceClient();
+
+  @ServiceClientDescriptor(settingsClass = MobileDeviceConstantServiceSettings.class)
+  MobileDeviceConstantServiceClient createMobileDeviceConstantServiceClient();
+
+  @ServiceClientDescriptor(settingsClass = CampaignLabelServiceSettings.class)
+  CampaignLabelServiceClient createCampaignLabelServiceClient();
+
+  @ServiceClientDescriptor(settingsClass = KeywordViewServiceSettings.class)
+  KeywordViewServiceClient createKeywordViewServiceClient();
+
+  @ServiceClientDescriptor(settingsClass = CustomerClientServiceSettings.class)
+  CustomerClientServiceClient createCustomerClientServiceClient();
 
   @ServiceClientDescriptor(settingsClass = MutateJobServiceSettings.class)
   MutateJobServiceClient createMutateJobServiceClient();
@@ -63,261 +177,147 @@ public interface GoogleAdsVersion {
   @ServiceClientDescriptor(settingsClass = VideoServiceSettings.class)
   VideoServiceClient createVideoServiceClient();
 
+  @ServiceClientDescriptor(settingsClass = CampaignDraftServiceSettings.class)
+  CampaignDraftServiceClient createCampaignDraftServiceClient();
+
+  @ServiceClientDescriptor(settingsClass = ClickViewServiceSettings.class)
+  ClickViewServiceClient createClickViewServiceClient();
+
+  @ServiceClientDescriptor(settingsClass = PaymentsAccountServiceSettings.class)
+  PaymentsAccountServiceClient createPaymentsAccountServiceClient();
+
+  @ServiceClientDescriptor(settingsClass = ExtensionFeedItemServiceSettings.class)
+  ExtensionFeedItemServiceClient createExtensionFeedItemServiceClient();
+
+  @ServiceClientDescriptor(settingsClass = KeywordPlanIdeaServiceSettings.class)
+  KeywordPlanIdeaServiceClient createKeywordPlanIdeaServiceClient();
+
+  @ServiceClientDescriptor(settingsClass = AdGroupFeedServiceSettings.class)
+  AdGroupFeedServiceClient createAdGroupFeedServiceClient();
+
+  @ServiceClientDescriptor(settingsClass = SearchTermViewServiceSettings.class)
+  SearchTermViewServiceClient createSearchTermViewServiceClient();
+
+  @ServiceClientDescriptor(settingsClass = LanguageConstantServiceSettings.class)
+  LanguageConstantServiceClient createLanguageConstantServiceClient();
+
+  @ServiceClientDescriptor(settingsClass = CampaignExtensionSettingServiceSettings.class)
+  CampaignExtensionSettingServiceClient createCampaignExtensionSettingServiceClient();
+
+  @ServiceClientDescriptor(settingsClass = AccountBudgetProposalServiceSettings.class)
+  AccountBudgetProposalServiceClient createAccountBudgetProposalServiceClient();
+
   @ServiceClientDescriptor(settingsClass = CampaignCriterionSimulationServiceSettings.class)
   CampaignCriterionSimulationServiceClient createCampaignCriterionSimulationServiceClient();
 
   @ServiceClientDescriptor(settingsClass = GoogleAdsFieldServiceSettings.class)
   GoogleAdsFieldServiceClient createGoogleAdsFieldServiceClient();
 
-  @ServiceClientDescriptor(settingsClass = FeedItemTargetServiceSettings.class)
-  FeedItemTargetServiceClient createFeedItemTargetServiceClient();
+  @ServiceClientDescriptor(settingsClass = CampaignServiceSettings.class)
+  CampaignServiceClient createCampaignServiceClient();
 
-  @ServiceClientDescriptor(settingsClass = ManagedPlacementViewServiceSettings.class)
-  ManagedPlacementViewServiceClient createManagedPlacementViewServiceClient();
-
-  @ServiceClientDescriptor(settingsClass = KeywordPlanKeywordServiceSettings.class)
-  KeywordPlanKeywordServiceClient createKeywordPlanKeywordServiceClient();
-
-  @ServiceClientDescriptor(settingsClass = CampaignBudgetServiceSettings.class)
-  CampaignBudgetServiceClient createCampaignBudgetServiceClient();
-
-  @ServiceClientDescriptor(settingsClass = AdParameterServiceSettings.class)
-  AdParameterServiceClient createAdParameterServiceClient();
-
-  @ServiceClientDescriptor(settingsClass = GeoTargetConstantServiceSettings.class)
-  GeoTargetConstantServiceClient createGeoTargetConstantServiceClient();
-
-  @ServiceClientDescriptor(settingsClass = PaymentsAccountServiceSettings.class)
-  PaymentsAccountServiceClient createPaymentsAccountServiceClient();
-
-  @ServiceClientDescriptor(settingsClass = CustomerManagerLinkServiceSettings.class)
-  CustomerManagerLinkServiceClient createCustomerManagerLinkServiceClient();
-
-  @ServiceClientDescriptor(settingsClass = ConversionActionServiceSettings.class)
-  ConversionActionServiceClient createConversionActionServiceClient();
-
-  @ServiceClientDescriptor(settingsClass = AdGroupAdServiceSettings.class)
-  AdGroupAdServiceClient createAdGroupAdServiceClient();
-
-  @ServiceClientDescriptor(settingsClass = MerchantCenterLinkServiceSettings.class)
-  MerchantCenterLinkServiceClient createMerchantCenterLinkServiceClient();
-
-  @ServiceClientDescriptor(settingsClass = KeywordPlanAdGroupServiceSettings.class)
-  KeywordPlanAdGroupServiceClient createKeywordPlanAdGroupServiceClient();
-
-  @ServiceClientDescriptor(settingsClass = CampaignSharedSetServiceSettings.class)
-  CampaignSharedSetServiceClient createCampaignSharedSetServiceClient();
-
-  @ServiceClientDescriptor(settingsClass = AdGroupBidModifierServiceSettings.class)
-  AdGroupBidModifierServiceClient createAdGroupBidModifierServiceClient();
-
-  @ServiceClientDescriptor(settingsClass = CustomerLabelServiceSettings.class)
-  CustomerLabelServiceClient createCustomerLabelServiceClient();
-
-  @ServiceClientDescriptor(settingsClass = FeedPlaceholderViewServiceSettings.class)
-  FeedPlaceholderViewServiceClient createFeedPlaceholderViewServiceClient();
-
-  @ServiceClientDescriptor(settingsClass = KeywordPlanNegativeKeywordServiceSettings.class)
-  KeywordPlanNegativeKeywordServiceClient createKeywordPlanNegativeKeywordServiceClient();
-
-  @ServiceClientDescriptor(settingsClass = ConversionAdjustmentUploadServiceSettings.class)
-  ConversionAdjustmentUploadServiceClient createConversionAdjustmentUploadServiceClient();
-
-  @ServiceClientDescriptor(settingsClass = SearchTermViewServiceSettings.class)
-  SearchTermViewServiceClient createSearchTermViewServiceClient();
-
-  @ServiceClientDescriptor(settingsClass = SharedCriterionServiceSettings.class)
-  SharedCriterionServiceClient createSharedCriterionServiceClient();
-
-  @ServiceClientDescriptor(settingsClass = ProductGroupViewServiceSettings.class)
-  ProductGroupViewServiceClient createProductGroupViewServiceClient();
-
-  @ServiceClientDescriptor(settingsClass = LocationViewServiceSettings.class)
-  LocationViewServiceClient createLocationViewServiceClient();
-
-  @ServiceClientDescriptor(settingsClass = DomainCategoryServiceSettings.class)
-  DomainCategoryServiceClient createDomainCategoryServiceClient();
-
-  @ServiceClientDescriptor(settingsClass = ShoppingPerformanceViewServiceSettings.class)
-  ShoppingPerformanceViewServiceClient createShoppingPerformanceViewServiceClient();
-
-  @ServiceClientDescriptor(settingsClass = AccountBudgetServiceSettings.class)
-  AccountBudgetServiceClient createAccountBudgetServiceClient();
-
-  @ServiceClientDescriptor(settingsClass = MediaFileServiceSettings.class)
-  MediaFileServiceClient createMediaFileServiceClient();
-
-  @ServiceClientDescriptor(settingsClass = GroupPlacementViewServiceSettings.class)
-  GroupPlacementViewServiceClient createGroupPlacementViewServiceClient();
-
-  @ServiceClientDescriptor(settingsClass = AdGroupFeedServiceSettings.class)
-  AdGroupFeedServiceClient createAdGroupFeedServiceClient();
-
-  @ServiceClientDescriptor(settingsClass = AdGroupCriterionServiceSettings.class)
-  AdGroupCriterionServiceClient createAdGroupCriterionServiceClient();
-
-  @ServiceClientDescriptor(settingsClass = DetailPlacementViewServiceSettings.class)
-  DetailPlacementViewServiceClient createDetailPlacementViewServiceClient();
-
-  @ServiceClientDescriptor(settingsClass = LabelServiceSettings.class)
-  LabelServiceClient createLabelServiceClient();
-
-  @ServiceClientDescriptor(settingsClass = BiddingStrategyServiceSettings.class)
-  BiddingStrategyServiceClient createBiddingStrategyServiceClient();
-
-  @ServiceClientDescriptor(settingsClass = AdGroupServiceSettings.class)
-  AdGroupServiceClient createAdGroupServiceClient();
-
-  @ServiceClientDescriptor(settingsClass = GeographicViewServiceSettings.class)
-  GeographicViewServiceClient createGeographicViewServiceClient();
-
-  @ServiceClientDescriptor(settingsClass = OperatingSystemVersionConstantServiceSettings.class)
-  OperatingSystemVersionConstantServiceClient createOperatingSystemVersionConstantServiceClient();
-
-  @ServiceClientDescriptor(settingsClass = LanguageConstantServiceSettings.class)
-  LanguageConstantServiceClient createLanguageConstantServiceClient();
-
-  @ServiceClientDescriptor(settingsClass = DisplayKeywordViewServiceSettings.class)
-  DisplayKeywordViewServiceClient createDisplayKeywordViewServiceClient();
-
-  @ServiceClientDescriptor(settingsClass = ExtensionFeedItemServiceSettings.class)
-  ExtensionFeedItemServiceClient createExtensionFeedItemServiceClient();
-
-  @ServiceClientDescriptor(settingsClass = CustomerNegativeCriterionServiceSettings.class)
-  CustomerNegativeCriterionServiceClient createCustomerNegativeCriterionServiceClient();
-
-  @ServiceClientDescriptor(settingsClass = PaidOrganicSearchTermViewServiceSettings.class)
-  PaidOrganicSearchTermViewServiceClient createPaidOrganicSearchTermViewServiceClient();
-
-  @ServiceClientDescriptor(settingsClass = BillingSetupServiceSettings.class)
-  BillingSetupServiceClient createBillingSetupServiceClient();
-
-  @ServiceClientDescriptor(settingsClass = TopicConstantServiceSettings.class)
-  TopicConstantServiceClient createTopicConstantServiceClient();
+  @ServiceClientDescriptor(settingsClass = HotelPerformanceViewServiceSettings.class)
+  HotelPerformanceViewServiceClient createHotelPerformanceViewServiceClient();
 
   @ServiceClientDescriptor(settingsClass = ProductBiddingCategoryConstantServiceSettings.class)
   ProductBiddingCategoryConstantServiceClient createProductBiddingCategoryConstantServiceClient();
 
+  @ServiceClientDescriptor(settingsClass = KeywordPlanKeywordServiceSettings.class)
+  KeywordPlanKeywordServiceClient createKeywordPlanKeywordServiceClient();
+
   @ServiceClientDescriptor(settingsClass = ChangeStatusServiceSettings.class)
   ChangeStatusServiceClient createChangeStatusServiceClient();
 
-  @ServiceClientDescriptor(settingsClass = GenderViewServiceSettings.class)
-  GenderViewServiceClient createGenderViewServiceClient();
-
-  @ServiceClientDescriptor(settingsClass = MobileDeviceConstantServiceSettings.class)
-  MobileDeviceConstantServiceClient createMobileDeviceConstantServiceClient();
-
-  @ServiceClientDescriptor(settingsClass = CustomerExtensionSettingServiceSettings.class)
-  CustomerExtensionSettingServiceClient createCustomerExtensionSettingServiceClient();
-
-  @ServiceClientDescriptor(settingsClass = UserListServiceSettings.class)
-  UserListServiceClient createUserListServiceClient();
-
-  @ServiceClientDescriptor(settingsClass = RemarketingActionServiceSettings.class)
-  RemarketingActionServiceClient createRemarketingActionServiceClient();
-
-  @ServiceClientDescriptor(settingsClass = ParentalStatusViewServiceSettings.class)
-  ParentalStatusViewServiceClient createParentalStatusViewServiceClient();
-
-  @ServiceClientDescriptor(settingsClass = CampaignDraftServiceSettings.class)
-  CampaignDraftServiceClient createCampaignDraftServiceClient();
-
-  @ServiceClientDescriptor(settingsClass = CustomerClientServiceSettings.class)
-  CustomerClientServiceClient createCustomerClientServiceClient();
-
-  @ServiceClientDescriptor(settingsClass = KeywordPlanIdeaServiceSettings.class)
-  KeywordPlanIdeaServiceClient createKeywordPlanIdeaServiceClient();
-
-  @ServiceClientDescriptor(settingsClass = CampaignBidModifierServiceSettings.class)
-  CampaignBidModifierServiceClient createCampaignBidModifierServiceClient();
-
-  @ServiceClientDescriptor(settingsClass = GoogleAdsServiceSettings.class)
-  GoogleAdsServiceClient createGoogleAdsServiceClient();
-
-  @ServiceClientDescriptor(settingsClass = MobileAppCategoryConstantServiceSettings.class)
-  MobileAppCategoryConstantServiceClient createMobileAppCategoryConstantServiceClient();
-
-  @ServiceClientDescriptor(settingsClass = AdGroupLabelServiceSettings.class)
-  AdGroupLabelServiceClient createAdGroupLabelServiceClient();
-
-  @ServiceClientDescriptor(settingsClass = CampaignLabelServiceSettings.class)
-  CampaignLabelServiceClient createCampaignLabelServiceClient();
-
-  @ServiceClientDescriptor(settingsClass = AdScheduleViewServiceSettings.class)
-  AdScheduleViewServiceClient createAdScheduleViewServiceClient();
-
-  @ServiceClientDescriptor(settingsClass = CampaignServiceSettings.class)
-  CampaignServiceClient createCampaignServiceClient();
-
-  @ServiceClientDescriptor(settingsClass = ClickViewServiceSettings.class)
-  ClickViewServiceClient createClickViewServiceClient();
-
-  @ServiceClientDescriptor(settingsClass = CustomerFeedServiceSettings.class)
-  CustomerFeedServiceClient createCustomerFeedServiceClient();
-
-  @ServiceClientDescriptor(settingsClass = CampaignCriterionServiceSettings.class)
-  CampaignCriterionServiceClient createCampaignCriterionServiceClient();
-
-  @ServiceClientDescriptor(settingsClass = AssetServiceSettings.class)
-  AssetServiceClient createAssetServiceClient();
-
-  @ServiceClientDescriptor(settingsClass = FeedMappingServiceSettings.class)
-  FeedMappingServiceClient createFeedMappingServiceClient();
-
-  @ServiceClientDescriptor(settingsClass = AdGroupCriterionSimulationServiceSettings.class)
-  AdGroupCriterionSimulationServiceClient createAdGroupCriterionSimulationServiceClient();
-
-  @ServiceClientDescriptor(settingsClass = CarrierConstantServiceSettings.class)
-  CarrierConstantServiceClient createCarrierConstantServiceClient();
-
-  @ServiceClientDescriptor(settingsClass = CustomerClientLinkServiceSettings.class)
-  CustomerClientLinkServiceClient createCustomerClientLinkServiceClient();
-
-  @ServiceClientDescriptor(settingsClass = CustomerServiceSettings.class)
-  CustomerServiceClient createCustomerServiceClient();
-
-  @ServiceClientDescriptor(settingsClass = LandingPageViewServiceSettings.class)
-  LandingPageViewServiceClient createLandingPageViewServiceClient();
-
-  @ServiceClientDescriptor(settingsClass = CampaignExtensionSettingServiceSettings.class)
-  CampaignExtensionSettingServiceClient createCampaignExtensionSettingServiceClient();
-
-  @ServiceClientDescriptor(settingsClass = TopicViewServiceSettings.class)
-  TopicViewServiceClient createTopicViewServiceClient();
-
-  @ServiceClientDescriptor(settingsClass = KeywordViewServiceSettings.class)
-  KeywordViewServiceClient createKeywordViewServiceClient();
-
-  @ServiceClientDescriptor(settingsClass = AdGroupSimulationServiceSettings.class)
-  AdGroupSimulationServiceClient createAdGroupSimulationServiceClient();
+  @ServiceClientDescriptor(settingsClass = AdGroupExtensionSettingServiceSettings.class)
+  AdGroupExtensionSettingServiceClient createAdGroupExtensionSettingServiceClient();
 
   @ServiceClientDescriptor(settingsClass = RecommendationServiceSettings.class)
   RecommendationServiceClient createRecommendationServiceClient();
 
-  @ServiceClientDescriptor(settingsClass = CampaignAudienceViewServiceSettings.class)
-  CampaignAudienceViewServiceClient createCampaignAudienceViewServiceClient();
+  @ServiceClientDescriptor(settingsClass = TopicViewServiceSettings.class)
+  TopicViewServiceClient createTopicViewServiceClient();
+
+  @ServiceClientDescriptor(settingsClass = LandingPageViewServiceSettings.class)
+  LandingPageViewServiceClient createLandingPageViewServiceClient();
+
+  @ServiceClientDescriptor(settingsClass = CampaignSharedSetServiceSettings.class)
+  CampaignSharedSetServiceClient createCampaignSharedSetServiceClient();
+
+  @ServiceClientDescriptor(settingsClass = FeedMappingServiceSettings.class)
+  FeedMappingServiceClient createFeedMappingServiceClient();
+
+  @ServiceClientDescriptor(settingsClass = CustomerExtensionSettingServiceSettings.class)
+  CustomerExtensionSettingServiceClient createCustomerExtensionSettingServiceClient();
+
+  @ServiceClientDescriptor(settingsClass = DynamicSearchAdsSearchTermViewServiceSettings.class)
+  DynamicSearchAdsSearchTermViewServiceClient createDynamicSearchAdsSearchTermViewServiceClient();
+
+  @ServiceClientDescriptor(settingsClass = CustomerLabelServiceSettings.class)
+  CustomerLabelServiceClient createCustomerLabelServiceClient();
+
+  @ServiceClientDescriptor(settingsClass = DomainCategoryServiceSettings.class)
+  DomainCategoryServiceClient createDomainCategoryServiceClient();
 
   @ServiceClientDescriptor(settingsClass = FeedItemServiceSettings.class)
   FeedItemServiceClient createFeedItemServiceClient();
 
-  @ServiceClientDescriptor(settingsClass = KeywordPlanCampaignServiceSettings.class)
-  KeywordPlanCampaignServiceClient createKeywordPlanCampaignServiceClient();
+  @ServiceClientDescriptor(settingsClass = BillingSetupServiceSettings.class)
+  BillingSetupServiceClient createBillingSetupServiceClient();
 
-  @ServiceClientDescriptor(settingsClass = AccountBudgetProposalServiceSettings.class)
-  AccountBudgetProposalServiceClient createAccountBudgetProposalServiceClient();
+  @ServiceClientDescriptor(settingsClass = GroupPlacementViewServiceSettings.class)
+  GroupPlacementViewServiceClient createGroupPlacementViewServiceClient();
 
-  @ServiceClientDescriptor(settingsClass = AdGroupCriterionLabelServiceSettings.class)
-  AdGroupCriterionLabelServiceClient createAdGroupCriterionLabelServiceClient();
+  @ServiceClientDescriptor(settingsClass = ConversionActionServiceSettings.class)
+  ConversionActionServiceClient createConversionActionServiceClient();
 
-  @ServiceClientDescriptor(settingsClass = CampaignFeedServiceSettings.class)
-  CampaignFeedServiceClient createCampaignFeedServiceClient();
+  @ServiceClientDescriptor(settingsClass = AccountBudgetServiceSettings.class)
+  AccountBudgetServiceClient createAccountBudgetServiceClient();
 
-  @ServiceClientDescriptor(settingsClass = ConversionUploadServiceSettings.class)
-  ConversionUploadServiceClient createConversionUploadServiceClient();
+  @ServiceClientDescriptor(settingsClass = SharedSetServiceSettings.class)
+  SharedSetServiceClient createSharedSetServiceClient();
 
-  @ServiceClientDescriptor(settingsClass = UserInterestServiceSettings.class)
-  UserInterestServiceClient createUserInterestServiceClient();
+  @ServiceClientDescriptor(settingsClass = ParentalStatusViewServiceSettings.class)
+  ParentalStatusViewServiceClient createParentalStatusViewServiceClient();
 
-  @ServiceClientDescriptor(settingsClass = AgeRangeViewServiceSettings.class)
-  AgeRangeViewServiceClient createAgeRangeViewServiceClient();
+  @ServiceClientDescriptor(settingsClass = AdGroupLabelServiceSettings.class)
+  AdGroupLabelServiceClient createAdGroupLabelServiceClient();
+
+  @ServiceClientDescriptor(settingsClass = AdGroupAdLabelServiceSettings.class)
+  AdGroupAdLabelServiceClient createAdGroupAdLabelServiceClient();
+
+  @ServiceClientDescriptor(settingsClass = CustomerServiceSettings.class)
+  CustomerServiceClient createCustomerServiceClient();
+
+  @ServiceClientDescriptor(settingsClass = CustomerManagerLinkServiceSettings.class)
+  CustomerManagerLinkServiceClient createCustomerManagerLinkServiceClient();
+
+  @ServiceClientDescriptor(settingsClass = CampaignBidModifierServiceSettings.class)
+  CampaignBidModifierServiceClient createCampaignBidModifierServiceClient();
+
+  @ServiceClientDescriptor(settingsClass = OperatingSystemVersionConstantServiceSettings.class)
+  OperatingSystemVersionConstantServiceClient createOperatingSystemVersionConstantServiceClient();
+
+  @ServiceClientDescriptor(settingsClass = GeographicViewServiceSettings.class)
+  GeographicViewServiceClient createGeographicViewServiceClient();
+
+  @ServiceClientDescriptor(settingsClass = KeywordPlanNegativeKeywordServiceSettings.class)
+  KeywordPlanNegativeKeywordServiceClient createKeywordPlanNegativeKeywordServiceClient();
+
+  @ServiceClientDescriptor(settingsClass = CampaignExperimentServiceSettings.class)
+  CampaignExperimentServiceClient createCampaignExperimentServiceClient();
+
+  @ServiceClientDescriptor(settingsClass = AdGroupAdServiceSettings.class)
+  AdGroupAdServiceClient createAdGroupAdServiceClient();
+
+  @ServiceClientDescriptor(settingsClass = AdGroupBidModifierServiceSettings.class)
+  AdGroupBidModifierServiceClient createAdGroupBidModifierServiceClient();
+
+  @ServiceClientDescriptor(settingsClass = CustomerClientLinkServiceSettings.class)
+  CustomerClientLinkServiceClient createCustomerClientLinkServiceClient();
+
+  @ServiceClientDescriptor(settingsClass = AdGroupAudienceViewServiceSettings.class)
+  AdGroupAudienceViewServiceClient createAdGroupAudienceViewServiceClient();
+
+  @ServiceClientDescriptor(settingsClass = HotelGroupViewServiceSettings.class)
+  HotelGroupViewServiceClient createHotelGroupViewServiceClient();
 }

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/AccountBudgetProposalServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/AccountBudgetProposalServiceStubSettings.java
@@ -202,13 +202,13 @@ public class AccountBudgetProposalServiceStubSettings
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/AccountBudgetServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/AccountBudgetServiceStubSettings.java
@@ -183,13 +183,13 @@ public class AccountBudgetServiceStubSettings
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/AdGroupAdLabelServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/AdGroupAdLabelServiceStubSettings.java
@@ -198,13 +198,13 @@ public class AdGroupAdLabelServiceStubSettings
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/AdGroupAdServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/AdGroupAdServiceStubSettings.java
@@ -193,13 +193,13 @@ public class AdGroupAdServiceStubSettings extends StubSettings<AdGroupAdServiceS
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/AdGroupAudienceViewServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/AdGroupAudienceViewServiceStubSettings.java
@@ -185,13 +185,13 @@ public class AdGroupAudienceViewServiceStubSettings
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/AdGroupBidModifierServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/AdGroupBidModifierServiceStubSettings.java
@@ -200,13 +200,13 @@ public class AdGroupBidModifierServiceStubSettings
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/AdGroupCriterionLabelServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/AdGroupCriterionLabelServiceStubSettings.java
@@ -203,13 +203,13 @@ public class AdGroupCriterionLabelServiceStubSettings
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/AdGroupCriterionServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/AdGroupCriterionServiceStubSettings.java
@@ -199,13 +199,13 @@ public class AdGroupCriterionServiceStubSettings
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/AdGroupCriterionSimulationServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/AdGroupCriterionSimulationServiceStubSettings.java
@@ -189,13 +189,13 @@ public class AdGroupCriterionSimulationServiceStubSettings
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/AdGroupExtensionSettingServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/AdGroupExtensionSettingServiceStubSettings.java
@@ -205,13 +205,13 @@ public class AdGroupExtensionSettingServiceStubSettings
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/AdGroupFeedServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/AdGroupFeedServiceStubSettings.java
@@ -195,13 +195,13 @@ public class AdGroupFeedServiceStubSettings extends StubSettings<AdGroupFeedServ
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/AdGroupLabelServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/AdGroupLabelServiceStubSettings.java
@@ -195,13 +195,13 @@ public class AdGroupLabelServiceStubSettings extends StubSettings<AdGroupLabelSe
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/AdGroupServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/AdGroupServiceStubSettings.java
@@ -192,13 +192,13 @@ public class AdGroupServiceStubSettings extends StubSettings<AdGroupServiceStubS
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/AdGroupSimulationServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/AdGroupSimulationServiceStubSettings.java
@@ -185,13 +185,13 @@ public class AdGroupSimulationServiceStubSettings
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/AdParameterServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/AdParameterServiceStubSettings.java
@@ -195,13 +195,13 @@ public class AdParameterServiceStubSettings extends StubSettings<AdParameterServ
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/AdScheduleViewServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/AdScheduleViewServiceStubSettings.java
@@ -184,13 +184,13 @@ public class AdScheduleViewServiceStubSettings
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/AgeRangeViewServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/AgeRangeViewServiceStubSettings.java
@@ -182,13 +182,13 @@ public class AgeRangeViewServiceStubSettings extends StubSettings<AgeRangeViewSe
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/AssetServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/AssetServiceStubSettings.java
@@ -191,13 +191,13 @@ public class AssetServiceStubSettings extends StubSettings<AssetServiceStubSetti
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/BiddingStrategyServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/BiddingStrategyServiceStubSettings.java
@@ -199,13 +199,13 @@ public class BiddingStrategyServiceStubSettings
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/BillingSetupServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/BillingSetupServiceStubSettings.java
@@ -195,13 +195,13 @@ public class BillingSetupServiceStubSettings extends StubSettings<BillingSetupSe
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/CampaignAudienceViewServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/CampaignAudienceViewServiceStubSettings.java
@@ -185,13 +185,13 @@ public class CampaignAudienceViewServiceStubSettings
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/CampaignBidModifierServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/CampaignBidModifierServiceStubSettings.java
@@ -201,13 +201,13 @@ public class CampaignBidModifierServiceStubSettings
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/CampaignBudgetServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/CampaignBudgetServiceStubSettings.java
@@ -198,13 +198,13 @@ public class CampaignBudgetServiceStubSettings
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/CampaignCriterionServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/CampaignCriterionServiceStubSettings.java
@@ -199,13 +199,13 @@ public class CampaignCriterionServiceStubSettings
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/CampaignCriterionSimulationServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/CampaignCriterionSimulationServiceStubSettings.java
@@ -190,13 +190,13 @@ public class CampaignCriterionSimulationServiceStubSettings
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/CampaignDraftServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/CampaignDraftServiceStubSettings.java
@@ -330,13 +330,13 @@ public class CampaignDraftServiceStubSettings
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/CampaignExperimentServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/CampaignExperimentServiceStubSettings.java
@@ -394,13 +394,13 @@ public class CampaignExperimentServiceStubSettings
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/CampaignExtensionSettingServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/CampaignExtensionSettingServiceStubSettings.java
@@ -206,13 +206,13 @@ public class CampaignExtensionSettingServiceStubSettings
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/CampaignFeedServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/CampaignFeedServiceStubSettings.java
@@ -195,13 +195,13 @@ public class CampaignFeedServiceStubSettings extends StubSettings<CampaignFeedSe
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/CampaignLabelServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/CampaignLabelServiceStubSettings.java
@@ -197,13 +197,13 @@ public class CampaignLabelServiceStubSettings
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/CampaignServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/CampaignServiceStubSettings.java
@@ -193,13 +193,13 @@ public class CampaignServiceStubSettings extends StubSettings<CampaignServiceStu
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/CampaignSharedSetServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/CampaignSharedSetServiceStubSettings.java
@@ -199,13 +199,13 @@ public class CampaignSharedSetServiceStubSettings
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/CarrierConstantServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/CarrierConstantServiceStubSettings.java
@@ -185,13 +185,13 @@ public class CarrierConstantServiceStubSettings
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/ChangeStatusServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/ChangeStatusServiceStubSettings.java
@@ -182,13 +182,13 @@ public class ChangeStatusServiceStubSettings extends StubSettings<ChangeStatusSe
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/ClickViewServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/ClickViewServiceStubSettings.java
@@ -180,13 +180,13 @@ public class ClickViewServiceStubSettings extends StubSettings<ClickViewServiceS
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/ConversionActionServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/ConversionActionServiceStubSettings.java
@@ -199,13 +199,13 @@ public class ConversionActionServiceStubSettings
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/ConversionAdjustmentUploadServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/ConversionAdjustmentUploadServiceStubSettings.java
@@ -190,13 +190,13 @@ public class ConversionAdjustmentUploadServiceStubSettings
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/ConversionUploadServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/ConversionUploadServiceStubSettings.java
@@ -200,13 +200,13 @@ public class ConversionUploadServiceStubSettings
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/CustomInterestServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/CustomInterestServiceStubSettings.java
@@ -198,13 +198,13 @@ public class CustomInterestServiceStubSettings
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/CustomerClientLinkServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/CustomerClientLinkServiceStubSettings.java
@@ -199,13 +199,13 @@ public class CustomerClientLinkServiceStubSettings
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/CustomerClientServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/CustomerClientServiceStubSettings.java
@@ -184,13 +184,13 @@ public class CustomerClientServiceStubSettings
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/CustomerExtensionSettingServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/CustomerExtensionSettingServiceStubSettings.java
@@ -206,13 +206,13 @@ public class CustomerExtensionSettingServiceStubSettings
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/CustomerFeedServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/CustomerFeedServiceStubSettings.java
@@ -195,13 +195,13 @@ public class CustomerFeedServiceStubSettings extends StubSettings<CustomerFeedSe
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/CustomerLabelServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/CustomerLabelServiceStubSettings.java
@@ -197,13 +197,13 @@ public class CustomerLabelServiceStubSettings
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/CustomerManagerLinkServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/CustomerManagerLinkServiceStubSettings.java
@@ -200,13 +200,13 @@ public class CustomerManagerLinkServiceStubSettings
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/CustomerNegativeCriterionServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/CustomerNegativeCriterionServiceStubSettings.java
@@ -206,13 +206,13 @@ public class CustomerNegativeCriterionServiceStubSettings
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/CustomerServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/CustomerServiceStubSettings.java
@@ -220,13 +220,13 @@ public class CustomerServiceStubSettings extends StubSettings<CustomerServiceStu
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/DetailPlacementViewServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/DetailPlacementViewServiceStubSettings.java
@@ -185,13 +185,13 @@ public class DetailPlacementViewServiceStubSettings
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/DisplayKeywordViewServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/DisplayKeywordViewServiceStubSettings.java
@@ -185,13 +185,13 @@ public class DisplayKeywordViewServiceStubSettings
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/DomainCategoryServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/DomainCategoryServiceStubSettings.java
@@ -184,13 +184,13 @@ public class DomainCategoryServiceStubSettings
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/DynamicSearchAdsSearchTermViewServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/DynamicSearchAdsSearchTermViewServiceStubSettings.java
@@ -191,13 +191,13 @@ public class DynamicSearchAdsSearchTermViewServiceStubSettings
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/ExpandedLandingPageViewServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/ExpandedLandingPageViewServiceStubSettings.java
@@ -188,13 +188,13 @@ public class ExpandedLandingPageViewServiceStubSettings
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/ExtensionFeedItemServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/ExtensionFeedItemServiceStubSettings.java
@@ -199,13 +199,13 @@ public class ExtensionFeedItemServiceStubSettings
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/FeedItemServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/FeedItemServiceStubSettings.java
@@ -193,13 +193,13 @@ public class FeedItemServiceStubSettings extends StubSettings<FeedItemServiceStu
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/FeedItemTargetServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/FeedItemTargetServiceStubSettings.java
@@ -198,13 +198,13 @@ public class FeedItemTargetServiceStubSettings
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/FeedMappingServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/FeedMappingServiceStubSettings.java
@@ -195,13 +195,13 @@ public class FeedMappingServiceStubSettings extends StubSettings<FeedMappingServ
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/FeedPlaceholderViewServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/FeedPlaceholderViewServiceStubSettings.java
@@ -185,13 +185,13 @@ public class FeedPlaceholderViewServiceStubSettings
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/FeedServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/FeedServiceStubSettings.java
@@ -191,13 +191,13 @@ public class FeedServiceStubSettings extends StubSettings<FeedServiceStubSetting
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/GenderViewServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/GenderViewServiceStubSettings.java
@@ -180,13 +180,13 @@ public class GenderViewServiceStubSettings extends StubSettings<GenderViewServic
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/GeoTargetConstantServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/GeoTargetConstantServiceStubSettings.java
@@ -200,13 +200,13 @@ public class GeoTargetConstantServiceStubSettings
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/GeographicViewServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/GeographicViewServiceStubSettings.java
@@ -184,13 +184,13 @@ public class GeographicViewServiceStubSettings
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/GoogleAdsFieldServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/GoogleAdsFieldServiceStubSettings.java
@@ -275,13 +275,13 @@ public class GoogleAdsFieldServiceStubSettings
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();
@@ -324,7 +324,7 @@ public class GoogleAdsFieldServiceStubSettings
 
       builder
           .searchGoogleAdsFieldsSettings()
-          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
 
       return builder;

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/GoogleAdsServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/GoogleAdsServiceStubSettings.java
@@ -263,13 +263,13 @@ public class GoogleAdsServiceStubSettings extends StubSettings<GoogleAdsServiceS
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();
@@ -305,7 +305,7 @@ public class GoogleAdsServiceStubSettings extends StubSettings<GoogleAdsServiceS
 
       builder
           .searchSettings()
-          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
 
       builder

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/GroupPlacementViewServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/GroupPlacementViewServiceStubSettings.java
@@ -185,13 +185,13 @@ public class GroupPlacementViewServiceStubSettings
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/HotelGroupViewServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/HotelGroupViewServiceStubSettings.java
@@ -184,13 +184,13 @@ public class HotelGroupViewServiceStubSettings
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/HotelPerformanceViewServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/HotelPerformanceViewServiceStubSettings.java
@@ -185,13 +185,13 @@ public class HotelPerformanceViewServiceStubSettings
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/KeywordPlanAdGroupServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/KeywordPlanAdGroupServiceStubSettings.java
@@ -200,13 +200,13 @@ public class KeywordPlanAdGroupServiceStubSettings
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/KeywordPlanCampaignServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/KeywordPlanCampaignServiceStubSettings.java
@@ -201,13 +201,13 @@ public class KeywordPlanCampaignServiceStubSettings
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/KeywordPlanIdeaServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/KeywordPlanIdeaServiceStubSettings.java
@@ -186,13 +186,13 @@ public class KeywordPlanIdeaServiceStubSettings
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();
@@ -226,7 +226,7 @@ public class KeywordPlanIdeaServiceStubSettings
 
       builder
           .generateKeywordIdeasSettings()
-          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
 
       return builder;

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/KeywordPlanKeywordServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/KeywordPlanKeywordServiceStubSettings.java
@@ -200,13 +200,13 @@ public class KeywordPlanKeywordServiceStubSettings
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/KeywordPlanNegativeKeywordServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/KeywordPlanNegativeKeywordServiceStubSettings.java
@@ -206,13 +206,13 @@ public class KeywordPlanNegativeKeywordServiceStubSettings
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/KeywordPlanServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/KeywordPlanServiceStubSettings.java
@@ -224,13 +224,13 @@ public class KeywordPlanServiceStubSettings extends StubSettings<KeywordPlanServ
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();
@@ -284,12 +284,12 @@ public class KeywordPlanServiceStubSettings extends StubSettings<KeywordPlanServ
 
       builder
           .generateForecastMetricsSettings()
-          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
 
       builder
           .generateHistoricalMetricsSettings()
-          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
           .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
 
       return builder;

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/KeywordViewServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/KeywordViewServiceStubSettings.java
@@ -182,13 +182,13 @@ public class KeywordViewServiceStubSettings extends StubSettings<KeywordViewServ
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/LabelServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/LabelServiceStubSettings.java
@@ -191,13 +191,13 @@ public class LabelServiceStubSettings extends StubSettings<LabelServiceStubSetti
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/LandingPageViewServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/LandingPageViewServiceStubSettings.java
@@ -185,13 +185,13 @@ public class LandingPageViewServiceStubSettings
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/LanguageConstantServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/LanguageConstantServiceStubSettings.java
@@ -185,13 +185,13 @@ public class LanguageConstantServiceStubSettings
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/LocationViewServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/LocationViewServiceStubSettings.java
@@ -182,13 +182,13 @@ public class LocationViewServiceStubSettings extends StubSettings<LocationViewSe
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/ManagedPlacementViewServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/ManagedPlacementViewServiceStubSettings.java
@@ -185,13 +185,13 @@ public class ManagedPlacementViewServiceStubSettings
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/MediaFileServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/MediaFileServiceStubSettings.java
@@ -193,13 +193,13 @@ public class MediaFileServiceStubSettings extends StubSettings<MediaFileServiceS
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/MerchantCenterLinkServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/MerchantCenterLinkServiceStubSettings.java
@@ -213,13 +213,13 @@ public class MerchantCenterLinkServiceStubSettings
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/MobileAppCategoryConstantServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/MobileAppCategoryConstantServiceStubSettings.java
@@ -189,13 +189,13 @@ public class MobileAppCategoryConstantServiceStubSettings
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/MobileDeviceConstantServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/MobileDeviceConstantServiceStubSettings.java
@@ -185,13 +185,13 @@ public class MobileDeviceConstantServiceStubSettings
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/MutateJobServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/MutateJobServiceStubSettings.java
@@ -327,13 +327,13 @@ public class MutateJobServiceStubSettings extends StubSettings<MutateJobServiceS
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/OperatingSystemVersionConstantServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/OperatingSystemVersionConstantServiceStubSettings.java
@@ -191,13 +191,13 @@ public class OperatingSystemVersionConstantServiceStubSettings
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/PaidOrganicSearchTermViewServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/PaidOrganicSearchTermViewServiceStubSettings.java
@@ -189,13 +189,13 @@ public class PaidOrganicSearchTermViewServiceStubSettings
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/ParentalStatusViewServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/ParentalStatusViewServiceStubSettings.java
@@ -185,13 +185,13 @@ public class ParentalStatusViewServiceStubSettings
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/PaymentsAccountServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/PaymentsAccountServiceStubSettings.java
@@ -186,13 +186,13 @@ public class PaymentsAccountServiceStubSettings
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/ProductBiddingCategoryConstantServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/ProductBiddingCategoryConstantServiceStubSettings.java
@@ -191,13 +191,13 @@ public class ProductBiddingCategoryConstantServiceStubSettings
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/ProductGroupViewServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/ProductGroupViewServiceStubSettings.java
@@ -185,13 +185,13 @@ public class ProductGroupViewServiceStubSettings
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/RecommendationServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/RecommendationServiceStubSettings.java
@@ -211,13 +211,13 @@ public class RecommendationServiceStubSettings
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/RemarketingActionServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/RemarketingActionServiceStubSettings.java
@@ -199,13 +199,13 @@ public class RemarketingActionServiceStubSettings
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/SearchTermViewServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/SearchTermViewServiceStubSettings.java
@@ -184,13 +184,13 @@ public class SearchTermViewServiceStubSettings
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/SharedCriterionServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/SharedCriterionServiceStubSettings.java
@@ -199,13 +199,13 @@ public class SharedCriterionServiceStubSettings
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/SharedSetServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/SharedSetServiceStubSettings.java
@@ -193,13 +193,13 @@ public class SharedSetServiceStubSettings extends StubSettings<SharedSetServiceS
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/ShoppingPerformanceViewServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/ShoppingPerformanceViewServiceStubSettings.java
@@ -188,13 +188,13 @@ public class ShoppingPerformanceViewServiceStubSettings
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/TopicConstantServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/TopicConstantServiceStubSettings.java
@@ -183,13 +183,13 @@ public class TopicConstantServiceStubSettings
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/TopicViewServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/TopicViewServiceStubSettings.java
@@ -180,13 +180,13 @@ public class TopicViewServiceStubSettings extends StubSettings<TopicViewServiceS
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/UserInterestServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/UserInterestServiceStubSettings.java
@@ -182,13 +182,13 @@ public class UserInterestServiceStubSettings extends StubSettings<UserInterestSe
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/UserListServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/UserListServiceStubSettings.java
@@ -193,13 +193,13 @@ public class UserListServiceStubSettings extends StubSettings<UserListServiceStu
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();

--- a/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/VideoServiceStubSettings.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/v1/services/stub/VideoServiceStubSettings.java
@@ -180,13 +180,13 @@ public class VideoServiceStubSettings extends StubSettings<VideoServiceStubSetti
       RetrySettings settings = null;
       settings =
           RetrySettings.newBuilder()
-              .setInitialRetryDelay(Duration.ofMillis(100L))
+              .setInitialRetryDelay(Duration.ofMillis(5000L))
               .setRetryDelayMultiplier(1.3)
               .setMaxRetryDelay(Duration.ofMillis(60000L))
-              .setInitialRpcTimeout(Duration.ofMillis(20000L))
+              .setInitialRpcTimeout(Duration.ofMillis(3600000L))
               .setRpcTimeoutMultiplier(1.0)
-              .setMaxRpcTimeout(Duration.ofMillis(20000L))
-              .setTotalTimeout(Duration.ofMillis(600000L))
+              .setMaxRpcTimeout(Duration.ofMillis(3600000L))
+              .setTotalTimeout(Duration.ofMillis(3600000L))
               .build();
       definitions.put("default", settings);
       RETRY_PARAM_DEFINITIONS = definitions.build();


### PR DESCRIPTION
This change updates our client-side timeout settings to more closely match those that are defined by the server in order to prevent the client library from ending requests too soon and ultimately reducing the amount of `DEADLINE_EXCEEDED` errors that are generated.

Before this change _all_ services were configured with a *20* second timeout in the client library. The majority of services have a _server-side_ timeout of *60* seconds, and in the case of `GoogleAdsService.Search` there's a 1 hour server-side timeout. This change sets the client-side timeouts to the upper bound (1 hour) in order to prevent the client library from ending requests prematurely.

Additionally a few service methods (including `GoogleAdsService.Search`) were previously incorrectly configured to be `non_idempotent`. This means that such methods would not retry requests at all and were not using the timeout settings. With this change, `search` requests (and a few others) will properly retry if they encounter a `DEADLINE_EXCEEDED` or `UNAVAILABLE` error from the server.
