### PR TITLE
Expose transport channel provider

### DIFF
--- a/google-ads/src/main/java/com/google/ads/googleads/lib/GoogleAdsClient.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/lib/GoogleAdsClient.java
@@ -153,7 +153,6 @@ public abstract class GoogleAdsClient extends AbstractGoogleAdsClient {
     abstract TransportChannelProvider getTransportChannelProvider();
 
     /** Sets the TransportChannelProvider to use. */
-    @VisibleForTesting
     abstract Builder setTransportChannelProvider(TransportChannelProvider transportChannelProvider);
 
     /** Returns the developer token currently configured. */


### PR DESCRIPTION
Exposes the TransportChanelProvider as package private.

This allows users who really need access to the provider to provide a custom implementation. However, it hides the method from most users who will not care. Therefore to use this method, a class needs to be added in the same package as GoogleAdsClient in order to set the TCProvider.