### PR TITLE
Adding comment for ad group ad status

### DIFF
--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/hotelads/AddHotelAd.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/hotelads/AddHotelAd.java
@@ -313,6 +313,9 @@ public class AddHotelAd {
         AdGroupAd.newBuilder()
             // Sets the ad to the ad created above.
             .setAd(ad)
+            // Set the ad group ad to enabled.  Setting this to paused will cause an error
+            // for hotel campaigns.  For hotels pausing should happen at either the ad group or
+            // campaign level.
             .setStatus(AdGroupAdStatus.ENABLED)
             // Sets the ad group.
             .setAdGroup(StringValue.of(adGroupResourceName))


### PR DESCRIPTION
- Adding comment about why ad group ad should be enabled for hotels, originally brought up in https://github.com/googleads/google-ads-dotnet/pull/123#discussion_r352711245