### PR TITLE
Ensure that tests close service clients

### DIFF
--- a/google-ads/src/test/java/com/google/ads/googleads/lib/GoogleAdsClientTest.java
+++ b/google-ads/src/test/java/com/google/ads/googleads/lib/GoogleAdsClientTest.java
@@ -292,7 +292,10 @@ public class GoogleAdsClientTest {
             .setEndpoint("fake-address")
             .build();
     mockService.addResponse(SearchGoogleAdsResponse.newBuilder().build());
-    client.getLatestVersion().createGoogleAdsServiceClient().search("123", "select blah");
+    try (GoogleAdsServiceClient googleAdsServiceClient =
+        client.getLatestVersion().createGoogleAdsServiceClient()) {
+      googleAdsServiceClient.search("123", "select blah");
+    }
     assertTrue(
         "login customer ID not found",
         localChannelProvider.isHeaderSent(
@@ -309,7 +312,10 @@ public class GoogleAdsClientTest {
             .setTransportChannelProvider(localChannelProvider)
             .build();
     mockService.addResponse(SearchGoogleAdsResponse.newBuilder().build());
-    client.getLatestVersion().createGoogleAdsServiceClient().search("123", "select blah");
+    try (GoogleAdsServiceClient googleAdsServiceClient =
+        client.getLatestVersion().createGoogleAdsServiceClient()) {
+      googleAdsServiceClient.search("123", "select blah");
+    }
     assertFalse(
         "login customer ID header should be excluded if not configured",
         localChannelProvider.isHeaderSent("login-customer-id", Pattern.compile(".*")));
@@ -332,8 +338,9 @@ public class GoogleAdsClientTest {
     trailers.put(trailerKey, failure.build().toByteArray());
     StatusException rootCause = new StatusException(Status.UNKNOWN, trailers);
     mockService.addException(new ApiException(rootCause, GrpcStatusCode.of(Code.UNKNOWN), false));
-    try {
-      client.getLatestVersion().createGoogleAdsServiceClient().search("123", "select blah");
+    try (GoogleAdsServiceClient googleAdsServiceClient =
+        client.getLatestVersion().createGoogleAdsServiceClient()) {
+      googleAdsServiceClient.search("123", "select blah");
     } catch (GoogleAdsException ex) {
       // Expected
     }

--- a/google-ads/src/test/java/com/google/ads/googleads/lib/catalog/ApiCatalogTest.java
+++ b/google-ads/src/test/java/com/google/ads/googleads/lib/catalog/ApiCatalogTest.java
@@ -155,15 +155,16 @@ public class ApiCatalogTest {
 
   /** Ensure that all services and all service clients can be instantiated. */
   @Test
-  public void createServices_createsAllServiceClients()
-      throws InvocationTargetException, IllegalAccessException {
-    GoogleAdsAllVersions versions = catalog.createAllVersionsClient(transportProvider, new FakeCredential());
+  public void createServices_createsAllServiceClients() throws Exception {
+    GoogleAdsAllVersions versions =
+        catalog.createAllVersionsClient(transportProvider, new FakeCredential());
     for (Method serviceFactoryMethod : GoogleAdsAllVersions.class.getMethods()) {
       Object factory = serviceFactoryMethod.invoke(versions);
       for (Method serviceMethod : serviceFactoryMethod.getReturnType().getMethods()) {
-        assertNotNull(
-            "Expected a valid service client for " + serviceFactoryMethod,
-            serviceMethod.invoke(factory));
+        try (AutoCloseable serviceClient = (AutoCloseable) serviceMethod.invoke(factory)) {
+          assertNotNull(
+              "Expected a valid service client for " + serviceFactoryMethod, serviceClient);
+        }
       }
     }
   }


### PR DESCRIPTION
Avoids the following SEVERE warnings in tests due to lack of cleanup of managed channels, etc.

    SEVERE: *~*~*~ Channel ManagedChannelImpl{logId=690, target=directaddress:///fake-address} was not shutdown properly!!!  ~*~*~*
        Make sure to call shutdown()/shutdownNow() and wait until awaitTermination() returns true.

Change-Id: Ia5e7cf5c866c62111db8223f747e1e75e56142dc