### PR TITLE
Set a default value for `enableGeneratedCatalog`

### DIFF
--- a/google-ads/src/main/java/com/google/ads/googleads/lib/GoogleAdsClient.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/lib/GoogleAdsClient.java
@@ -67,6 +67,9 @@ public abstract class GoogleAdsClient extends AbstractGoogleAdsClient {
   /** Returns a new builder for {@link GoogleAdsClient} with only default values set. */
   public static Builder newBuilder() {
     AutoValue_GoogleAdsClient.Builder clientBuilder = new AutoValue_GoogleAdsClient.Builder();
+    // Sets the default value for enableGeneratedCatalog.
+    clientBuilder.setEnableGeneratedCatalog(false);
+    // Constructs the channel provider.
     InstantiatingGrpcChannelProvider transportChannelProvider =
         InstantiatingGrpcChannelProvider.newBuilder()
             .setInterceptorProvider(

--- a/google-ads/src/test/java/com/google/ads/googleads/lib/GoogleAdsClientTest.java
+++ b/google-ads/src/test/java/com/google/ads/googleads/lib/GoogleAdsClientTest.java
@@ -268,6 +268,24 @@ public class GoogleAdsClientTest {
     assertNull("invalid login-customer-id", client.getLoginCustomerId());
   }
 
+  /** Verifies that builder does not require enableGeneratedCatalog to be set explicitly. */
+  @Test
+  public void build_enableGeneratedCatalog_not_required() throws IOException {
+    Credentials credentials =
+        UserCredentials.newBuilder()
+            .setClientId(CLIENT_ID)
+            .setClientSecret(CLIENT_SECRET)
+            .setRefreshToken(REFRESH_TOKEN)
+            .build();
+    GoogleAdsClient client =
+        GoogleAdsClient.newBuilder()
+            .setCredentials(credentials)
+            .setDeveloperToken(DEVELOPER_TOKEN)
+            .setLoginCustomerId(LOGIN_CUSTOMER_ID)
+            .build();
+    assertGoogleAdsClient(client, LOGIN_CUSTOMER_ID, false);
+  }
+
   /** Verifies that loginCustomerId is not required. */
   @Test
   public void buildFromProperties_loginCustomerId_isOptional() {


### PR DESCRIPTION
Fixes https://github.com/googleads/google-ads-java/issues/224.

Change-Id: Ic208669d6555e1d1959597768310bb8f18cdc6ca