### PR TITLE
Update dependency versions for consistency

### DIFF
--- a/google-ads-examples/pom.xml
+++ b/google-ads-examples/pom.xml
@@ -67,6 +67,7 @@
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
       <version>2.11.1</version>
+      <scope>runtime</scope>
     </dependency>
     <!-- Test dependencies -->
     <dependency>

--- a/google-ads-migration-examples/pom.xml
+++ b/google-ads-migration-examples/pom.xml
@@ -77,11 +77,13 @@
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
       <version>2.11.1</version>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>log4j</groupId>
       <artifactId>log4j</artifactId>
       <version>1.2.16</version>
+      <scope>runtime</scope>
     </dependency>
     <!-- Test dependencies -->
     <dependency>

--- a/google-ads/pom.xml
+++ b/google-ads/pom.xml
@@ -33,10 +33,10 @@
   </description>
 
   <properties>
-    <auto-value.version>1.4</auto-value.version>
+    <auto-value.version>1.6.6</auto-value.version>
     <gax.version>1.50.1</gax.version>
     <grpc.version>1.25.0</grpc.version>
-    <protobuf.version>3.5.1</protobuf.version>
+    <protobuf.version>3.10.0</protobuf.version>
   </properties>
 
   <dependencies>
@@ -82,7 +82,7 @@
       <!--
         See https://github.com/grpc/grpc-java/blob/master/SECURITY.md#troubleshooting
       -->
-      <version>2.0.7.Final</version>
+      <version>2.0.26.Final</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -136,7 +136,7 @@
       <plugin>
         <groupId>com.github.os72</groupId>
         <artifactId>protoc-jar-maven-plugin</artifactId>
-        <version>3.7.0</version>
+        <version>3.11.1</version>
         <executions>
           <execution>
             <id>generate-test-protos</id>
@@ -145,7 +145,7 @@
               <goal>run</goal>
             </goals>
             <configuration>
-              <protocArtifact>com.google.protobuf:protoc:3.7.0</protocArtifact>
+              <protocArtifact>com.google.protobuf:protoc:${protobuf.version}</protocArtifact>
               <inputDirectories>
                 <include>src/test/resources/protos</include>
               </inputDirectories>

--- a/google-ads/pom.xml
+++ b/google-ads/pom.xml
@@ -34,6 +34,8 @@
 
   <properties>
     <auto-value.version>1.6.6</auto-value.version>
+    <!-- Keep all versions below consistent with the io.netty version. -->
+    <netty.version>2.0.26.Final</netty.version>
     <gax.version>1.50.1</gax.version>
     <grpc.version>1.25.0</grpc.version>
     <protobuf.version>3.10.0</protobuf.version>
@@ -51,30 +53,10 @@
       <version>${gax.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.google.api.grpc</groupId>
-      <artifactId>grpc-google-common-protos</artifactId>
-      <version>1.0.0</version>
-    </dependency>
-    <dependency>
-      <groupId>com.google.api.grpc</groupId>
-      <artifactId>proto-google-common-protos</artifactId>
-      <version>1.16.0</version>
-    </dependency>
-    <dependency>
       <groupId>com.google.auto.value</groupId>
       <artifactId>auto-value</artifactId>
       <version>${auto-value.version}</version>
       <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.protobuf</groupId>
-      <artifactId>protobuf-java</artifactId>
-      <version>${protobuf.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.grpc</groupId>
-      <artifactId>grpc-all</artifactId>
-      <version>${grpc.version}</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
@@ -82,7 +64,7 @@
       <!--
         See https://github.com/grpc/grpc-java/blob/master/SECURITY.md#troubleshooting
       -->
-      <version>2.0.26.Final</version>
+      <version>${netty.version}</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -114,6 +96,17 @@
       <artifactId>gax-grpc</artifactId>
       <classifier>testlib</classifier>
       <version>${gax.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <!--
+      Without this dependency, gax will add io.grpc:grpc-context:jar:1.22.1 to
+      the classpath instead of io.grpc:grpc-context:jar:1.25.0, and tests will
+      fail due to changes to io.grpc.Deadline.
+      -->
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-context</artifactId>
+      <version>${grpc.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
* Move to `netty-tcnative-boringssl-static` version `2.0.26.Final` and protobuf version `3.10.0` to match to match target gRPC version `1.25.0`.
* Move more recent versions of `auto-value` and `protoc-jar-maven-plugin`.
* Make log4j dependencies in examples modules have `scope` of `runtime` since they are not needed for compilation.