### PR TITLE
Update GetAccountChanges example

### DIFF
--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/accountmanagement/GetAccountChanges.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/accountmanagement/GetAccountChanges.java
@@ -85,13 +85,18 @@ public class GetAccountChanges {
     String query =
         "SELECT change_status.resource_name, "
             + "change_status.last_change_date_time, "
-            + "change_status.resource_type, "
-            + "change_status.campaign, "
-            + "change_status.ad_group, "
             + "change_status.resource_status, "
+            + "change_status.resource_type, "
+            + "change_status.ad_group, "
             + "change_status.ad_group_ad, "
+            + "change_status.ad_group_bid_modifier, "
             + "change_status.ad_group_criterion, "
-            + "change_status.campaign_criterion "
+            + "change_status.ad_group_feed, "
+            + "change_status.campaign, "
+            + "change_status.campaign_criterion, "
+            + "change_status.campaign_feed, "
+            + "change_status.feed, "
+            + "change_status.feed_item "
             + "FROM change_status "
             + "WHERE change_status.last_change_date_time DURING LAST_7_DAYS "
             + "ORDER BY change_status.last_change_date_time";
@@ -134,14 +139,29 @@ public class GetAccountChanges {
       case AD_GROUP_AD:
         resourceName = changeStatus.getAdGroupAd().getValue();
         break;
+      case AD_GROUP_BID_MODIFIER:
+        resourceName = changeStatus.getAdGroupBidModifier().getValue();
+        break;
       case AD_GROUP_CRITERION:
         resourceName = changeStatus.getAdGroup().getValue();
+        break;
+      case AD_GROUP_FEED:
+        resourceName = changeStatus.getAdGroupFeed().getValue();
         break;
       case CAMPAIGN:
         resourceName = changeStatus.getCampaign().getValue();
         break;
       case CAMPAIGN_CRITERION:
         resourceName = changeStatus.getCampaignCriterion().getValue();
+        break;
+      case CAMPAIGN_FEED:
+        resourceName = changeStatus.getCampaignFeed().getValue();
+        break;
+      case FEED:
+        resourceName = changeStatus.getFeed().getValue();
+        break;
+      case FEED_ITEM:
+        resourceName = changeStatus.getFeedItem().getValue();
         break;
     }
     return Optional.ofNullable(resourceName);


### PR DESCRIPTION
Bring code example up-to-date with latest `ChangeStatus` types. Coincides with content updates to [Change Status Service guide](https://developers.google.com/google-ads/api/docs/change-status): 
- Added new fields to GAQL query
- Reordered GAQL fields so common properties first, then rest alphabetical 
- Added new type values to `getResourceNameForResourceType` method
