### PR TITLE
Remove vulnerable dependency on log4j.

### DIFF
--- a/google-ads-migration-examples/pom.xml
+++ b/google-ads-migration-examples/pom.xml
@@ -79,12 +79,6 @@
       <version>2.11.1</version>
       <scope>runtime</scope>
     </dependency>
-    <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <version>1.2.16</version>
-      <scope>runtime</scope>
-    </dependency>
     <!-- Test dependencies -->
     <dependency>
       <groupId>org.mockito</groupId>


### PR DESCRIPTION
This is highly unlikely to cause a real security threat since it's in the migration examples project. Not sure why we even added the log4j v1.x dependency there, since everywhere else we use log4j2 (which doesn't have this issue).


See details here https://github.com/advisories/GHSA-2qrg-x229-3v8q