### PR TITLE
Fix handling of scenario with no provided geoTargetConstantId

### DIFF
--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/extensions/AddGeoTarget.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/extensions/AddGeoTarget.java
@@ -59,7 +59,7 @@ public class AddGeoTarget {
       params.feedItemId = Long.parseLong("INSERT_FEED_ID_HERE");
 
       // Optional: Specify a geoTargetConstantId.
-      params.geoTargetConstantId = GEO_TARGET_CONSTANT_ID;
+      params.geoTargetConstantId = null;
     }
 
     GoogleAdsClient googleAdsClient;
@@ -103,7 +103,11 @@ public class AddGeoTarget {
    * @param geoTargetConstantId the geo target constant ID to add to the extension feed item.
    */
   private void runExample(
-      GoogleAdsClient googleAdsClient, long customerId, long feedItemId, long geoTargetConstantId) {
+      GoogleAdsClient googleAdsClient, long customerId, long feedItemId, Long geoTargetConstantId) {
+    // Uses a default geoTargetConstantId value if none is provided.
+    geoTargetConstantId =
+        (geoTargetConstantId == null) ? GEO_TARGET_CONSTANT_ID : geoTargetConstantId;
+
     // Creates an extension feed item using the specified feed item ID and geo target constant
     // ID for targeting.
     ExtensionFeedItem extensionFeedItem =

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/extensions/AddGeoTarget.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/extensions/AddGeoTarget.java
@@ -45,7 +45,11 @@ public class AddGeoTarget {
     @Parameter(names = ArgumentNames.FEED_ITEM_ID, required = true)
     private Long feedItemId;
 
-    @Parameter(names = ArgumentNames.GEO_TARGET_CONSTANT_ID)
+    @Parameter(
+        names = ArgumentNames.GEO_TARGET_CONSTANT_ID,
+        description =
+            "The geo target constant ID to add to the extension feed item. A default value will be"
+                + " used if no value is provided.")
     private Long geoTargetConstantId;
   }
 

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/extensions/AddGeoTarget.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/extensions/AddGeoTarget.java
@@ -50,7 +50,7 @@ public class AddGeoTarget {
         description =
             "The geo target constant ID to add to the extension feed item. A default value will be"
                 + " used if no value is provided.")
-    private Long geoTargetConstantId;
+    private Long geoTargetConstantId = GEO_TARGET_CONSTANT_ID;
   }
 
   public static void main(String[] args) {
@@ -63,7 +63,7 @@ public class AddGeoTarget {
       params.feedItemId = Long.parseLong("INSERT_FEED_ID_HERE");
 
       // Optional: Specify a geoTargetConstantId.
-      params.geoTargetConstantId = null;
+      params.geoTargetConstantId = GEO_TARGET_CONSTANT_ID;
     }
 
     GoogleAdsClient googleAdsClient;
@@ -108,10 +108,6 @@ public class AddGeoTarget {
    */
   private void runExample(
       GoogleAdsClient googleAdsClient, long customerId, long feedItemId, Long geoTargetConstantId) {
-    // Uses a default geoTargetConstantId value if none is provided.
-    geoTargetConstantId =
-        (geoTargetConstantId == null) ? GEO_TARGET_CONSTANT_ID : geoTargetConstantId;
-
     // Creates an extension feed item using the specified feed item ID and geo target constant
     // ID for targeting.
     ExtensionFeedItem extensionFeedItem =


### PR DESCRIPTION
The default value of geoTargetConstantId was not being populated correctly resulting in a NullPointerError when none was provided. 