### PR TITLE
Use readable datetime instead of timestamp in resource names of code examples (Fix #42)

### DIFF
--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/advancedoperations/AddAdCustomizer.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/advancedoperations/AddAdCustomizer.java
@@ -14,9 +14,10 @@
 
 package com.google.ads.googleads.examples.advancedoperations;
 
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
-import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.common.ExpandedTextAdInfo;
@@ -142,7 +143,7 @@ public class AddAdCustomizer {
           "Please pass exactly two ad group IDs in the adGroupId parameter.");
     }
 
-    String feedName = "Ad Customizer example feed " + CodeSampleHelper.getPrintableDatetime();
+    String feedName = "Ad Customizer example feed " + getPrintableDatetime();
 
     // Create a feed to be used as the ad customizer.
     String adCustomizerFeedResourceName =

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/advancedoperations/AddAdCustomizer.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/advancedoperations/AddAdCustomizer.java
@@ -16,6 +16,7 @@ package com.google.ads.googleads.examples.advancedoperations;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
+import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.common.ExpandedTextAdInfo;
@@ -141,7 +142,7 @@ public class AddAdCustomizer {
           "Please pass exactly two ad group IDs in the adGroupId parameter.");
     }
 
-    String feedName = "Ad Customizer example feed " + System.currentTimeMillis();
+    String feedName = "Ad Customizer example feed " + CodeSampleHelper.getPrintableDatetime();
 
     // Create a feed to be used as the ad customizer.
     String adCustomizerFeedResourceName =

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/advancedoperations/AddAdCustomizer.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/advancedoperations/AddAdCustomizer.java
@@ -14,7 +14,7 @@
 
 package com.google.ads.googleads.examples.advancedoperations;
 
-import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getShortPrintableDatetime;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
@@ -143,7 +143,7 @@ public class AddAdCustomizer {
           "Please pass exactly two ad group IDs in the adGroupId parameter.");
     }
 
-    String feedName = "Ad Customizer example feed " + getPrintableDatetime();
+    String feedName = "Ad Customizer example feed " + getShortPrintableDatetime();
 
     // Create a feed to be used as the ad customizer.
     String adCustomizerFeedResourceName =

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/advancedoperations/AddAdCustomizer.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/advancedoperations/AddAdCustomizer.java
@@ -14,7 +14,7 @@
 
 package com.google.ads.googleads.examples.advancedoperations;
 
-import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getShortPrintableDatetime;
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getShortPrintableDateTime;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
@@ -143,7 +143,7 @@ public class AddAdCustomizer {
           "Please pass exactly two ad group IDs in the adGroupId parameter.");
     }
 
-    String feedName = "Ad Customizer example feed " + getShortPrintableDatetime();
+    String feedName = "Ad Customizer example feed " + getShortPrintableDateTime();
 
     // Create a feed to be used as the ad customizer.
     String adCustomizerFeedResourceName =

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/advancedoperations/AddAppCampaign.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/advancedoperations/AddAppCampaign.java
@@ -16,6 +16,7 @@ package com.google.ads.googleads.examples.advancedoperations;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
+import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.common.AdTextAsset;
@@ -141,7 +142,7 @@ public class AddAppCampaign {
     // Creates a campaign budget.
     CampaignBudget campaignBudget =
         CampaignBudget.newBuilder()
-            .setName("Interplanetary Cruise #" + System.currentTimeMillis())
+            .setName("Interplanetary Cruise #" + CodeSampleHelper.getPrintableDatetime())
             .setAmountMicros(50_000_000)
             .setDeliveryMethod(BudgetDeliveryMethod.STANDARD)
             // An App campaign cannot use a shared campaign budget.
@@ -180,7 +181,7 @@ public class AddAppCampaign {
     // Creates a campaign.
     Campaign campaign =
         Campaign.newBuilder()
-            .setName("Interplanetary Cruise App #" + System.currentTimeMillis())
+            .setName("Interplanetary Cruise App #" + CodeSampleHelper.getPrintableDatetime())
             .setCampaignBudget(budgetResourceName)
             // Recommendation: Set the campaign to PAUSED when creating it to prevent
             // the ads from immediately serving. Set to ENABLED once you've added
@@ -339,7 +340,7 @@ public class AddAppCampaign {
     //   2. you cannot add ad group criteria.
     AdGroup adGroup =
         AdGroup.newBuilder()
-            .setName("Earth to Mars cruises #" + System.currentTimeMillis())
+            .setName("Earth to Mars cruises #" + CodeSampleHelper.getPrintableDatetime())
             .setStatus(AdGroupStatus.ENABLED)
             .setCampaign(campaignResourceName)
             .build();

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/advancedoperations/AddAppCampaign.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/advancedoperations/AddAppCampaign.java
@@ -14,9 +14,10 @@
 
 package com.google.ads.googleads.examples.advancedoperations;
 
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
-import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.common.AdTextAsset;
@@ -142,7 +143,7 @@ public class AddAppCampaign {
     // Creates a campaign budget.
     CampaignBudget campaignBudget =
         CampaignBudget.newBuilder()
-            .setName("Interplanetary Cruise #" + CodeSampleHelper.getPrintableDatetime())
+            .setName("Interplanetary Cruise #" + getPrintableDatetime())
             .setAmountMicros(50_000_000)
             .setDeliveryMethod(BudgetDeliveryMethod.STANDARD)
             // An App campaign cannot use a shared campaign budget.
@@ -181,7 +182,7 @@ public class AddAppCampaign {
     // Creates a campaign.
     Campaign campaign =
         Campaign.newBuilder()
-            .setName("Interplanetary Cruise App #" + CodeSampleHelper.getPrintableDatetime())
+            .setName("Interplanetary Cruise App #" + getPrintableDatetime())
             .setCampaignBudget(budgetResourceName)
             // Recommendation: Set the campaign to PAUSED when creating it to prevent
             // the ads from immediately serving. Set to ENABLED once you've added
@@ -340,7 +341,7 @@ public class AddAppCampaign {
     //   2. you cannot add ad group criteria.
     AdGroup adGroup =
         AdGroup.newBuilder()
-            .setName("Earth to Mars cruises #" + CodeSampleHelper.getPrintableDatetime())
+            .setName("Earth to Mars cruises #" + getPrintableDatetime())
             .setStatus(AdGroupStatus.ENABLED)
             .setCampaign(campaignResourceName)
             .build();

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/advancedoperations/AddAppCampaign.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/advancedoperations/AddAppCampaign.java
@@ -14,7 +14,7 @@
 
 package com.google.ads.googleads.examples.advancedoperations;
 
-import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDateTime;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
@@ -143,7 +143,7 @@ public class AddAppCampaign {
     // Creates a campaign budget.
     CampaignBudget campaignBudget =
         CampaignBudget.newBuilder()
-            .setName("Interplanetary Cruise #" + getPrintableDatetime())
+            .setName("Interplanetary Cruise #" + getPrintableDateTime())
             .setAmountMicros(50_000_000)
             .setDeliveryMethod(BudgetDeliveryMethod.STANDARD)
             // An App campaign cannot use a shared campaign budget.
@@ -182,7 +182,7 @@ public class AddAppCampaign {
     // Creates a campaign.
     Campaign campaign =
         Campaign.newBuilder()
-            .setName("Interplanetary Cruise App #" + getPrintableDatetime())
+            .setName("Interplanetary Cruise App #" + getPrintableDateTime())
             .setCampaignBudget(budgetResourceName)
             // Recommendation: Set the campaign to PAUSED when creating it to prevent
             // the ads from immediately serving. Set to ENABLED once you've added
@@ -341,7 +341,7 @@ public class AddAppCampaign {
     //   2. you cannot add ad group criteria.
     AdGroup adGroup =
         AdGroup.newBuilder()
-            .setName("Earth to Mars cruises #" + getPrintableDatetime())
+            .setName("Earth to Mars cruises #" + getPrintableDateTime())
             .setStatus(AdGroupStatus.ENABLED)
             .setCampaign(campaignResourceName)
             .build();

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/advancedoperations/AddDynamicPageFeed.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/advancedoperations/AddDynamicPageFeed.java
@@ -14,9 +14,10 @@
 
 package com.google.ads.googleads.examples.advancedoperations;
 
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
-import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.lib.utils.FieldMasks;
@@ -174,7 +175,7 @@ public class AddDynamicPageFeed {
     // Creates the feed.
     Feed feed =
         Feed.newBuilder()
-            .setName("DSA Feed #" + CodeSampleHelper.getPrintableDatetime())
+            .setName("DSA Feed #" + getPrintableDatetime())
             .addAllAttributes(ImmutableList.of(urlAttribute, labelAttribute))
             .build();
 

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/advancedoperations/AddDynamicPageFeed.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/advancedoperations/AddDynamicPageFeed.java
@@ -14,7 +14,7 @@
 
 package com.google.ads.googleads.examples.advancedoperations;
 
-import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDateTime;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
@@ -175,7 +175,7 @@ public class AddDynamicPageFeed {
     // Creates the feed.
     Feed feed =
         Feed.newBuilder()
-            .setName("DSA Feed #" + getPrintableDatetime())
+            .setName("DSA Feed #" + getPrintableDateTime())
             .addAllAttributes(ImmutableList.of(urlAttribute, labelAttribute))
             .build();
 

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/advancedoperations/AddDynamicPageFeed.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/advancedoperations/AddDynamicPageFeed.java
@@ -16,6 +16,7 @@ package com.google.ads.googleads.examples.advancedoperations;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
+import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.lib.utils.FieldMasks;
@@ -173,7 +174,7 @@ public class AddDynamicPageFeed {
     // Creates the feed.
     Feed feed =
         Feed.newBuilder()
-            .setName("DSA Feed #" + System.currentTimeMillis())
+            .setName("DSA Feed #" + CodeSampleHelper.getPrintableDatetime())
             .addAllAttributes(ImmutableList.of(urlAttribute, labelAttribute))
             .build();
 

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/advancedoperations/AddDynamicSearchAds.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/advancedoperations/AddDynamicSearchAds.java
@@ -14,7 +14,7 @@
 
 package com.google.ads.googleads.examples.advancedoperations;
 
-import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDateTime;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
@@ -133,7 +133,7 @@ public class AddDynamicSearchAds {
     // Creates the budget.
     CampaignBudget campaignBudget =
         CampaignBudget.newBuilder()
-            .setName("Interplanetary Cruise Budget #" + getPrintableDatetime())
+            .setName("Interplanetary Cruise Budget #" + getPrintableDateTime())
             .setAmountMicros(3_000_000)
             .setDeliveryMethod(BudgetDeliveryMethod.STANDARD)
             .build();
@@ -170,7 +170,7 @@ public class AddDynamicSearchAds {
     // Creates the campaign.
     Campaign campaign =
         Campaign.newBuilder()
-            .setName("Interplanetary Cruise #" + getPrintableDatetime())
+            .setName("Interplanetary Cruise #" + getPrintableDateTime())
             .setAdvertisingChannelType(AdvertisingChannelType.SEARCH)
             .setStatus(CampaignStatus.PAUSED)
             .setManualCpc(ManualCpc.newBuilder().build())
@@ -218,7 +218,7 @@ public class AddDynamicSearchAds {
     // Creates the ad group.
     AdGroup adGroup =
         AdGroup.newBuilder()
-            .setName("Earth to Mars Cruises #" + getPrintableDatetime())
+            .setName("Earth to Mars Cruises #" + getPrintableDateTime())
             .setCampaign(campaignResourceName)
             .setType(AdGroupType.SEARCH_DYNAMIC_ADS)
             .setStatus(AdGroupStatus.PAUSED)

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/advancedoperations/AddDynamicSearchAds.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/advancedoperations/AddDynamicSearchAds.java
@@ -16,6 +16,7 @@ package com.google.ads.googleads.examples.advancedoperations;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
+import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.common.ExpandedDynamicSearchAdInfo;
@@ -131,7 +132,7 @@ public class AddDynamicSearchAds {
     // Creates the budget.
     CampaignBudget campaignBudget =
         CampaignBudget.newBuilder()
-            .setName("Interplanetary Cruise Budget #" + System.currentTimeMillis())
+            .setName("Interplanetary Cruise Budget #" + CodeSampleHelper.getPrintableDatetime())
             .setAmountMicros(3_000_000)
             .setDeliveryMethod(BudgetDeliveryMethod.STANDARD)
             .build();
@@ -168,7 +169,7 @@ public class AddDynamicSearchAds {
     // Creates the campaign.
     Campaign campaign =
         Campaign.newBuilder()
-            .setName("Interplanetary Cruise #" + System.currentTimeMillis())
+            .setName("Interplanetary Cruise #" + CodeSampleHelper.getPrintableDatetime())
             .setAdvertisingChannelType(AdvertisingChannelType.SEARCH)
             .setStatus(CampaignStatus.PAUSED)
             .setManualCpc(ManualCpc.newBuilder().build())
@@ -216,7 +217,7 @@ public class AddDynamicSearchAds {
     // Creates the ad group.
     AdGroup adGroup =
         AdGroup.newBuilder()
-            .setName("Earth to Mars Cruises #" + System.currentTimeMillis())
+            .setName("Earth to Mars Cruises #" + CodeSampleHelper.getPrintableDatetime())
             .setCampaign(campaignResourceName)
             .setType(AdGroupType.SEARCH_DYNAMIC_ADS)
             .setStatus(AdGroupStatus.PAUSED)

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/advancedoperations/AddDynamicSearchAds.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/advancedoperations/AddDynamicSearchAds.java
@@ -14,9 +14,10 @@
 
 package com.google.ads.googleads.examples.advancedoperations;
 
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
-import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.common.ExpandedDynamicSearchAdInfo;
@@ -132,7 +133,7 @@ public class AddDynamicSearchAds {
     // Creates the budget.
     CampaignBudget campaignBudget =
         CampaignBudget.newBuilder()
-            .setName("Interplanetary Cruise Budget #" + CodeSampleHelper.getPrintableDatetime())
+            .setName("Interplanetary Cruise Budget #" + getPrintableDatetime())
             .setAmountMicros(3_000_000)
             .setDeliveryMethod(BudgetDeliveryMethod.STANDARD)
             .build();
@@ -169,7 +170,7 @@ public class AddDynamicSearchAds {
     // Creates the campaign.
     Campaign campaign =
         Campaign.newBuilder()
-            .setName("Interplanetary Cruise #" + CodeSampleHelper.getPrintableDatetime())
+            .setName("Interplanetary Cruise #" + getPrintableDatetime())
             .setAdvertisingChannelType(AdvertisingChannelType.SEARCH)
             .setStatus(CampaignStatus.PAUSED)
             .setManualCpc(ManualCpc.newBuilder().build())
@@ -217,7 +218,7 @@ public class AddDynamicSearchAds {
     // Creates the ad group.
     AdGroup adGroup =
         AdGroup.newBuilder()
-            .setName("Earth to Mars Cruises #" + CodeSampleHelper.getPrintableDatetime())
+            .setName("Earth to Mars Cruises #" + getPrintableDatetime())
             .setCampaign(campaignResourceName)
             .setType(AdGroupType.SEARCH_DYNAMIC_ADS)
             .setStatus(AdGroupStatus.PAUSED)

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/advancedoperations/AddGmailAd.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/advancedoperations/AddGmailAd.java
@@ -16,6 +16,7 @@ package com.google.ads.googleads.examples.advancedoperations;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
+import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.common.GmailAdInfo;
@@ -214,7 +215,7 @@ public class AddGmailAd {
     // Creates the ad.
     Ad ad =
         Ad.newBuilder()
-            .setName("Gmail Ad #" + System.currentTimeMillis())
+            .setName("Gmail Ad #" + CodeSampleHelper.getPrintableDatetime())
             .addFinalUrls("http://www.example.com")
             .setGmailAd(gmailAdInfo)
             .build();

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/advancedoperations/AddGmailAd.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/advancedoperations/AddGmailAd.java
@@ -14,9 +14,10 @@
 
 package com.google.ads.googleads.examples.advancedoperations;
 
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
-import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.common.GmailAdInfo;
@@ -215,7 +216,7 @@ public class AddGmailAd {
     // Creates the ad.
     Ad ad =
         Ad.newBuilder()
-            .setName("Gmail Ad #" + CodeSampleHelper.getPrintableDatetime())
+            .setName("Gmail Ad #" + getPrintableDatetime())
             .addFinalUrls("http://www.example.com")
             .setGmailAd(gmailAdInfo)
             .build();

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/advancedoperations/AddGmailAd.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/advancedoperations/AddGmailAd.java
@@ -14,7 +14,7 @@
 
 package com.google.ads.googleads.examples.advancedoperations;
 
-import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDateTime;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
@@ -216,7 +216,7 @@ public class AddGmailAd {
     // Creates the ad.
     Ad ad =
         Ad.newBuilder()
-            .setName("Gmail Ad #" + getPrintableDatetime())
+            .setName("Gmail Ad #" + getPrintableDateTime())
             .addFinalUrls("http://www.example.com")
             .setGmailAd(gmailAdInfo)
             .build();

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/advancedoperations/AddLocalCampaign.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/advancedoperations/AddLocalCampaign.java
@@ -16,6 +16,7 @@ package com.google.ads.googleads.examples.advancedoperations;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
+import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.common.AdImageAsset;
@@ -146,7 +147,7 @@ public class AddLocalCampaign {
     CampaignBudget budget =
         CampaignBudget.newBuilder()
             .setAmountMicros(50000000)
-            .setName("Interplanetary Cruise Budget #" + System.currentTimeMillis())
+            .setName("Interplanetary Cruise Budget #" + CodeSampleHelper.getPrintableDatetime())
             .setDeliveryMethod(BudgetDeliveryMethod.STANDARD)
             // A Local campaign cannot use a shared campaign budget.
             .setExplicitlyShared(false)
@@ -177,7 +178,7 @@ public class AddLocalCampaign {
     // Creates a Campaign object.
     Campaign campaign =
         Campaign.newBuilder()
-            .setName("Interplanetary Cruise Budget #" + System.currentTimeMillis())
+            .setName("Interplanetary Cruise Budget #" + CodeSampleHelper.getPrintableDatetime())
             .setCampaignBudget(budgetResourceName)
             // Recommendation: Set the campaign to PAUSED when creating it to prevent the ads from
             // immediately serving. Set to ENABLED once you've added targeting and the ads are ready
@@ -241,7 +242,7 @@ public class AddLocalCampaign {
     //   2. you cannot add ad group criteria.
     AdGroup adGroup =
         AdGroup.newBuilder()
-            .setName("Earth to Mars Cruises #" + System.currentTimeMillis())
+            .setName("Earth to Mars Cruises #" + CodeSampleHelper.getPrintableDatetime())
             .setStatus(AdGroupStatus.ENABLED)
             .setCampaign(campaignResourceName)
             .build();

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/advancedoperations/AddLocalCampaign.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/advancedoperations/AddLocalCampaign.java
@@ -14,7 +14,7 @@
 
 package com.google.ads.googleads.examples.advancedoperations;
 
-import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDateTime;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
@@ -148,7 +148,7 @@ public class AddLocalCampaign {
     CampaignBudget budget =
         CampaignBudget.newBuilder()
             .setAmountMicros(50000000)
-            .setName("Interplanetary Cruise Budget #" + getPrintableDatetime())
+            .setName("Interplanetary Cruise Budget #" + getPrintableDateTime())
             .setDeliveryMethod(BudgetDeliveryMethod.STANDARD)
             // A Local campaign cannot use a shared campaign budget.
             .setExplicitlyShared(false)
@@ -179,7 +179,7 @@ public class AddLocalCampaign {
     // Creates a Campaign object.
     Campaign campaign =
         Campaign.newBuilder()
-            .setName("Interplanetary Cruise Budget #" + getPrintableDatetime())
+            .setName("Interplanetary Cruise Budget #" + getPrintableDateTime())
             .setCampaignBudget(budgetResourceName)
             // Recommendation: Set the campaign to PAUSED when creating it to prevent the ads from
             // immediately serving. Set to ENABLED once you've added targeting and the ads are ready
@@ -243,7 +243,7 @@ public class AddLocalCampaign {
     //   2. you cannot add ad group criteria.
     AdGroup adGroup =
         AdGroup.newBuilder()
-            .setName("Earth to Mars Cruises #" + getPrintableDatetime())
+            .setName("Earth to Mars Cruises #" + getPrintableDateTime())
             .setStatus(AdGroupStatus.ENABLED)
             .setCampaign(campaignResourceName)
             .build();

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/advancedoperations/AddLocalCampaign.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/advancedoperations/AddLocalCampaign.java
@@ -14,9 +14,10 @@
 
 package com.google.ads.googleads.examples.advancedoperations;
 
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
-import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.common.AdImageAsset;
@@ -147,7 +148,7 @@ public class AddLocalCampaign {
     CampaignBudget budget =
         CampaignBudget.newBuilder()
             .setAmountMicros(50000000)
-            .setName("Interplanetary Cruise Budget #" + CodeSampleHelper.getPrintableDatetime())
+            .setName("Interplanetary Cruise Budget #" + getPrintableDatetime())
             .setDeliveryMethod(BudgetDeliveryMethod.STANDARD)
             // A Local campaign cannot use a shared campaign budget.
             .setExplicitlyShared(false)
@@ -178,7 +179,7 @@ public class AddLocalCampaign {
     // Creates a Campaign object.
     Campaign campaign =
         Campaign.newBuilder()
-            .setName("Interplanetary Cruise Budget #" + CodeSampleHelper.getPrintableDatetime())
+            .setName("Interplanetary Cruise Budget #" + getPrintableDatetime())
             .setCampaignBudget(budgetResourceName)
             // Recommendation: Set the campaign to PAUSED when creating it to prevent the ads from
             // immediately serving. Set to ENABLED once you've added targeting and the ads are ready
@@ -242,7 +243,7 @@ public class AddLocalCampaign {
     //   2. you cannot add ad group criteria.
     AdGroup adGroup =
         AdGroup.newBuilder()
-            .setName("Earth to Mars Cruises #" + CodeSampleHelper.getPrintableDatetime())
+            .setName("Earth to Mars Cruises #" + getPrintableDatetime())
             .setStatus(AdGroupStatus.ENABLED)
             .setCampaign(campaignResourceName)
             .build();

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/advancedoperations/AddSmartDisplayAd.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/advancedoperations/AddSmartDisplayAd.java
@@ -16,6 +16,7 @@ package com.google.ads.googleads.examples.advancedoperations;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
+import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.common.AdImageAsset;
@@ -180,7 +181,7 @@ public class AddSmartDisplayAd {
     // Creates the budget.
     CampaignBudget campaignBudget =
         CampaignBudget.newBuilder()
-            .setName("Interplanetary Cruise Budget #" + System.currentTimeMillis())
+            .setName("Interplanetary Cruise Budget #" + CodeSampleHelper.getPrintableDatetime())
             .setAmountMicros(5_000_000)
             .setDeliveryMethod(BudgetDeliveryMethod.STANDARD)
             .build();
@@ -218,7 +219,7 @@ public class AddSmartDisplayAd {
     // Creates the campaign.
     Campaign campaign =
         Campaign.newBuilder()
-            .setName("Smart Display Campaign #" + System.currentTimeMillis())
+            .setName("Smart Display Campaign #" + CodeSampleHelper.getPrintableDatetime())
             // Smart Display campaign requires the advertising channel type as 'DISPLAY'.
             .setAdvertisingChannelType(AdvertisingChannelType.DISPLAY)
             // Smart Display campaign requires the advertising channel sub type as
@@ -267,7 +268,7 @@ public class AddSmartDisplayAd {
     // Creates the ad group.
     AdGroup adGroup =
         AdGroup.newBuilder()
-            .setName("Earth to Mars Cruises #" + System.currentTimeMillis())
+            .setName("Earth to Mars Cruises #" + CodeSampleHelper.getPrintableDatetime())
             .setCampaign(campaignResourceName)
             .setStatus(AdGroupStatus.PAUSED)
             .build();

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/advancedoperations/AddSmartDisplayAd.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/advancedoperations/AddSmartDisplayAd.java
@@ -14,7 +14,7 @@
 
 package com.google.ads.googleads.examples.advancedoperations;
 
-import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDateTime;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
@@ -182,7 +182,7 @@ public class AddSmartDisplayAd {
     // Creates the budget.
     CampaignBudget campaignBudget =
         CampaignBudget.newBuilder()
-            .setName("Interplanetary Cruise Budget #" + getPrintableDatetime())
+            .setName("Interplanetary Cruise Budget #" + getPrintableDateTime())
             .setAmountMicros(5_000_000)
             .setDeliveryMethod(BudgetDeliveryMethod.STANDARD)
             .build();
@@ -220,7 +220,7 @@ public class AddSmartDisplayAd {
     // Creates the campaign.
     Campaign campaign =
         Campaign.newBuilder()
-            .setName("Smart Display Campaign #" + getPrintableDatetime())
+            .setName("Smart Display Campaign #" + getPrintableDateTime())
             // Smart Display campaign requires the advertising channel type as 'DISPLAY'.
             .setAdvertisingChannelType(AdvertisingChannelType.DISPLAY)
             // Smart Display campaign requires the advertising channel sub type as
@@ -269,7 +269,7 @@ public class AddSmartDisplayAd {
     // Creates the ad group.
     AdGroup adGroup =
         AdGroup.newBuilder()
-            .setName("Earth to Mars Cruises #" + getPrintableDatetime())
+            .setName("Earth to Mars Cruises #" + getPrintableDateTime())
             .setCampaign(campaignResourceName)
             .setStatus(AdGroupStatus.PAUSED)
             .build();

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/advancedoperations/AddSmartDisplayAd.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/advancedoperations/AddSmartDisplayAd.java
@@ -14,9 +14,10 @@
 
 package com.google.ads.googleads.examples.advancedoperations;
 
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
-import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.common.AdImageAsset;
@@ -181,7 +182,7 @@ public class AddSmartDisplayAd {
     // Creates the budget.
     CampaignBudget campaignBudget =
         CampaignBudget.newBuilder()
-            .setName("Interplanetary Cruise Budget #" + CodeSampleHelper.getPrintableDatetime())
+            .setName("Interplanetary Cruise Budget #" + getPrintableDatetime())
             .setAmountMicros(5_000_000)
             .setDeliveryMethod(BudgetDeliveryMethod.STANDARD)
             .build();
@@ -219,7 +220,7 @@ public class AddSmartDisplayAd {
     // Creates the campaign.
     Campaign campaign =
         Campaign.newBuilder()
-            .setName("Smart Display Campaign #" + CodeSampleHelper.getPrintableDatetime())
+            .setName("Smart Display Campaign #" + getPrintableDatetime())
             // Smart Display campaign requires the advertising channel type as 'DISPLAY'.
             .setAdvertisingChannelType(AdvertisingChannelType.DISPLAY)
             // Smart Display campaign requires the advertising channel sub type as
@@ -268,7 +269,7 @@ public class AddSmartDisplayAd {
     // Creates the ad group.
     AdGroup adGroup =
         AdGroup.newBuilder()
-            .setName("Earth to Mars Cruises #" + CodeSampleHelper.getPrintableDatetime())
+            .setName("Earth to Mars Cruises #" + getPrintableDatetime())
             .setCampaign(campaignResourceName)
             .setStatus(AdGroupStatus.PAUSED)
             .build();

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/advancedoperations/CreateAndAttachSharedKeywordSet.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/advancedoperations/CreateAndAttachSharedKeywordSet.java
@@ -14,7 +14,7 @@
 
 package com.google.ads.googleads.examples.advancedoperations;
 
-import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDateTime;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
@@ -115,7 +115,7 @@ public class CreateAndAttachSharedKeywordSet {
     // Creates shared negative keyword set.
     SharedSet sharedSet =
         SharedSet.newBuilder()
-            .setName("API Negative keyword list - " + getPrintableDatetime())
+            .setName("API Negative keyword list - " + getPrintableDateTime())
             .setType(SharedSetType.NEGATIVE_KEYWORDS)
             .build();
 

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/advancedoperations/CreateAndAttachSharedKeywordSet.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/advancedoperations/CreateAndAttachSharedKeywordSet.java
@@ -16,6 +16,7 @@ package com.google.ads.googleads.examples.advancedoperations;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
+import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.common.KeywordInfo;
@@ -113,7 +114,7 @@ public class CreateAndAttachSharedKeywordSet {
     // Creates shared negative keyword set.
     SharedSet sharedSet =
         SharedSet.newBuilder()
-            .setName("API Negative keyword list - " + System.currentTimeMillis())
+            .setName("API Negative keyword list - " + CodeSampleHelper.getPrintableDatetime())
             .setType(SharedSetType.NEGATIVE_KEYWORDS)
             .build();
 

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/advancedoperations/CreateAndAttachSharedKeywordSet.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/advancedoperations/CreateAndAttachSharedKeywordSet.java
@@ -14,9 +14,10 @@
 
 package com.google.ads.googleads.examples.advancedoperations;
 
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
-import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.common.KeywordInfo;
@@ -114,7 +115,7 @@ public class CreateAndAttachSharedKeywordSet {
     // Creates shared negative keyword set.
     SharedSet sharedSet =
         SharedSet.newBuilder()
-            .setName("API Negative keyword list - " + CodeSampleHelper.getPrintableDatetime())
+            .setName("API Negative keyword list - " + getPrintableDatetime())
             .setType(SharedSetType.NEGATIVE_KEYWORDS)
             .build();
 

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/advancedoperations/UsePortfolioBiddingStrategy.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/advancedoperations/UsePortfolioBiddingStrategy.java
@@ -16,6 +16,7 @@ package com.google.ads.googleads.examples.advancedoperations;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
+import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.common.TargetSpend;
@@ -139,7 +140,7 @@ public class UsePortfolioBiddingStrategy {
       TargetSpend targetSpend = TargetSpend.newBuilder().setCpcBidCeilingMicros(2_000_000L).build();
       BiddingStrategy portfolioBiddingStrategy =
           BiddingStrategy.newBuilder()
-              .setName("Maximize Clicks #" + System.currentTimeMillis())
+              .setName("Maximize Clicks #" + CodeSampleHelper.getPrintableDatetime())
               .setTargetSpend(targetSpend)
               .build();
       // Constructs an operation that will create a portfolio bidding strategy.
@@ -175,7 +176,7 @@ public class UsePortfolioBiddingStrategy {
       // Creates a shared budget.
       CampaignBudget budget =
           CampaignBudget.newBuilder()
-              .setName("Shared Interplanetary Budget #" + System.currentTimeMillis())
+              .setName("Shared Interplanetary Budget #" + CodeSampleHelper.getPrintableDatetime())
               .setAmountMicros(50_000_000L)
               .setDeliveryMethod(BudgetDeliveryMethod.STANDARD)
               .setExplicitlyShared(true)
@@ -225,7 +226,7 @@ public class UsePortfolioBiddingStrategy {
       // [START UsePortfolioBiddingStrategy_2]
       Campaign campaign =
           Campaign.newBuilder()
-              .setName("Interplanetary Cruise #" + System.currentTimeMillis())
+              .setName("Interplanetary Cruise #" + CodeSampleHelper.getPrintableDatetime())
               .setStatus(CampaignStatus.PAUSED)
               .setCampaignBudget(campaignBudgetResourceName)
               .setBiddingStrategy(biddingStrategyResourceName)

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/advancedoperations/UsePortfolioBiddingStrategy.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/advancedoperations/UsePortfolioBiddingStrategy.java
@@ -14,9 +14,10 @@
 
 package com.google.ads.googleads.examples.advancedoperations;
 
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
-import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.common.TargetSpend;
@@ -140,7 +141,7 @@ public class UsePortfolioBiddingStrategy {
       TargetSpend targetSpend = TargetSpend.newBuilder().setCpcBidCeilingMicros(2_000_000L).build();
       BiddingStrategy portfolioBiddingStrategy =
           BiddingStrategy.newBuilder()
-              .setName("Maximize Clicks #" + CodeSampleHelper.getPrintableDatetime())
+              .setName("Maximize Clicks #" + getPrintableDatetime())
               .setTargetSpend(targetSpend)
               .build();
       // Constructs an operation that will create a portfolio bidding strategy.
@@ -176,7 +177,7 @@ public class UsePortfolioBiddingStrategy {
       // Creates a shared budget.
       CampaignBudget budget =
           CampaignBudget.newBuilder()
-              .setName("Shared Interplanetary Budget #" + CodeSampleHelper.getPrintableDatetime())
+              .setName("Shared Interplanetary Budget #" + getPrintableDatetime())
               .setAmountMicros(50_000_000L)
               .setDeliveryMethod(BudgetDeliveryMethod.STANDARD)
               .setExplicitlyShared(true)
@@ -226,7 +227,7 @@ public class UsePortfolioBiddingStrategy {
       // [START UsePortfolioBiddingStrategy_2]
       Campaign campaign =
           Campaign.newBuilder()
-              .setName("Interplanetary Cruise #" + CodeSampleHelper.getPrintableDatetime())
+              .setName("Interplanetary Cruise #" + getPrintableDatetime())
               .setStatus(CampaignStatus.PAUSED)
               .setCampaignBudget(campaignBudgetResourceName)
               .setBiddingStrategy(biddingStrategyResourceName)

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/advancedoperations/UsePortfolioBiddingStrategy.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/advancedoperations/UsePortfolioBiddingStrategy.java
@@ -14,7 +14,7 @@
 
 package com.google.ads.googleads.examples.advancedoperations;
 
-import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDateTime;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
@@ -141,7 +141,7 @@ public class UsePortfolioBiddingStrategy {
       TargetSpend targetSpend = TargetSpend.newBuilder().setCpcBidCeilingMicros(2_000_000L).build();
       BiddingStrategy portfolioBiddingStrategy =
           BiddingStrategy.newBuilder()
-              .setName("Maximize Clicks #" + getPrintableDatetime())
+              .setName("Maximize Clicks #" + getPrintableDateTime())
               .setTargetSpend(targetSpend)
               .build();
       // Constructs an operation that will create a portfolio bidding strategy.
@@ -177,7 +177,7 @@ public class UsePortfolioBiddingStrategy {
       // Creates a shared budget.
       CampaignBudget budget =
           CampaignBudget.newBuilder()
-              .setName("Shared Interplanetary Budget #" + getPrintableDatetime())
+              .setName("Shared Interplanetary Budget #" + getPrintableDateTime())
               .setAmountMicros(50_000_000L)
               .setDeliveryMethod(BudgetDeliveryMethod.STANDARD)
               .setExplicitlyShared(true)
@@ -227,7 +227,7 @@ public class UsePortfolioBiddingStrategy {
       // [START UsePortfolioBiddingStrategy_2]
       Campaign campaign =
           Campaign.newBuilder()
-              .setName("Interplanetary Cruise #" + getPrintableDatetime())
+              .setName("Interplanetary Cruise #" + getPrintableDateTime())
               .setStatus(CampaignStatus.PAUSED)
               .setCampaignBudget(campaignBudgetResourceName)
               .setBiddingStrategy(biddingStrategyResourceName)

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/basicoperations/AddAdGroups.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/basicoperations/AddAdGroups.java
@@ -14,9 +14,10 @@
 
 package com.google.ads.googleads.examples.basicoperations;
 
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
-import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.enums.AdGroupStatusEnum.AdGroupStatus;
@@ -100,7 +101,7 @@ public class AddAdGroups {
     // Creates an ad group, setting an optional CPC value.
     AdGroup adGroup1 =
         AdGroup.newBuilder()
-            .setName("Earth to Mars Cruises #" + CodeSampleHelper.getPrintableDatetime())
+            .setName("Earth to Mars Cruises #" + getPrintableDatetime())
             .setStatus(AdGroupStatus.ENABLED)
             .setCampaign(campaignResourceName)
             .setType(AdGroupType.SEARCH_STANDARD)
@@ -110,7 +111,7 @@ public class AddAdGroups {
     // You may add as many additional ad groups as you need.
     AdGroup adGroup2 =
         AdGroup.newBuilder()
-            .setName("Earth to Venus Cruises #" + CodeSampleHelper.getPrintableDatetime())
+            .setName("Earth to Venus Cruises #" + getPrintableDatetime())
             .setStatus(AdGroupStatus.ENABLED)
             .setCampaign(campaignResourceName)
             .setType(AdGroupType.SEARCH_STANDARD)

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/basicoperations/AddAdGroups.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/basicoperations/AddAdGroups.java
@@ -14,7 +14,7 @@
 
 package com.google.ads.googleads.examples.basicoperations;
 
-import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDateTime;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
@@ -101,7 +101,7 @@ public class AddAdGroups {
     // Creates an ad group, setting an optional CPC value.
     AdGroup adGroup1 =
         AdGroup.newBuilder()
-            .setName("Earth to Mars Cruises #" + getPrintableDatetime())
+            .setName("Earth to Mars Cruises #" + getPrintableDateTime())
             .setStatus(AdGroupStatus.ENABLED)
             .setCampaign(campaignResourceName)
             .setType(AdGroupType.SEARCH_STANDARD)
@@ -111,7 +111,7 @@ public class AddAdGroups {
     // You may add as many additional ad groups as you need.
     AdGroup adGroup2 =
         AdGroup.newBuilder()
-            .setName("Earth to Venus Cruises #" + getPrintableDatetime())
+            .setName("Earth to Venus Cruises #" + getPrintableDateTime())
             .setStatus(AdGroupStatus.ENABLED)
             .setCampaign(campaignResourceName)
             .setType(AdGroupType.SEARCH_STANDARD)

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/basicoperations/AddAdGroups.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/basicoperations/AddAdGroups.java
@@ -16,6 +16,7 @@ package com.google.ads.googleads.examples.basicoperations;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
+import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.enums.AdGroupStatusEnum.AdGroupStatus;
@@ -99,7 +100,7 @@ public class AddAdGroups {
     // Creates an ad group, setting an optional CPC value.
     AdGroup adGroup1 =
         AdGroup.newBuilder()
-            .setName("Earth to Mars Cruises #" + System.currentTimeMillis())
+            .setName("Earth to Mars Cruises #" + CodeSampleHelper.getPrintableDatetime())
             .setStatus(AdGroupStatus.ENABLED)
             .setCampaign(campaignResourceName)
             .setType(AdGroupType.SEARCH_STANDARD)
@@ -109,7 +110,7 @@ public class AddAdGroups {
     // You may add as many additional ad groups as you need.
     AdGroup adGroup2 =
         AdGroup.newBuilder()
-            .setName("Earth to Venus Cruises #" + System.currentTimeMillis())
+            .setName("Earth to Venus Cruises #" + CodeSampleHelper.getPrintableDatetime())
             .setStatus(AdGroupStatus.ENABLED)
             .setCampaign(campaignResourceName)
             .setType(AdGroupType.SEARCH_STANDARD)

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/basicoperations/AddCampaigns.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/basicoperations/AddCampaigns.java
@@ -14,9 +14,10 @@
 
 package com.google.ads.googleads.examples.basicoperations;
 
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
-import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.common.ManualCpc;
@@ -105,7 +106,7 @@ public class AddCampaigns {
   private static String addCampaignBudget(GoogleAdsClient googleAdsClient, long customerId) {
     CampaignBudget budget =
         CampaignBudget.newBuilder()
-            .setName("Interplanetary Cruise Budget #" + CodeSampleHelper.getPrintableDatetime())
+            .setName("Interplanetary Cruise Budget #" + getPrintableDatetime())
             .setDeliveryMethod(BudgetDeliveryMethod.STANDARD)
             .setAmountMicros(500_000)
             .build();
@@ -152,7 +153,7 @@ public class AddCampaigns {
       // Creates the campaign.
       Campaign campaign =
           Campaign.newBuilder()
-              .setName("Interplanetary Cruise #" + CodeSampleHelper.getPrintableDatetime())
+              .setName("Interplanetary Cruise #" + getPrintableDatetime())
               .setAdvertisingChannelType(AdvertisingChannelType.SEARCH)
               // Recommendation: Set the campaign to PAUSED when creating it to prevent
               // the ads from immediately serving. Set to ENABLED once you've added

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/basicoperations/AddCampaigns.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/basicoperations/AddCampaigns.java
@@ -16,6 +16,7 @@ package com.google.ads.googleads.examples.basicoperations;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
+import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.common.ManualCpc;
@@ -104,7 +105,7 @@ public class AddCampaigns {
   private static String addCampaignBudget(GoogleAdsClient googleAdsClient, long customerId) {
     CampaignBudget budget =
         CampaignBudget.newBuilder()
-            .setName("Interplanetary Cruise Budget #" + System.currentTimeMillis())
+            .setName("Interplanetary Cruise Budget #" + CodeSampleHelper.getPrintableDatetime())
             .setDeliveryMethod(BudgetDeliveryMethod.STANDARD)
             .setAmountMicros(500_000)
             .build();
@@ -151,7 +152,7 @@ public class AddCampaigns {
       // Creates the campaign.
       Campaign campaign =
           Campaign.newBuilder()
-              .setName("Interplanetary Cruise #" + System.currentTimeMillis())
+              .setName("Interplanetary Cruise #" + CodeSampleHelper.getPrintableDatetime())
               .setAdvertisingChannelType(AdvertisingChannelType.SEARCH)
               // Recommendation: Set the campaign to PAUSED when creating it to prevent
               // the ads from immediately serving. Set to ENABLED once you've added

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/basicoperations/AddCampaigns.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/basicoperations/AddCampaigns.java
@@ -14,7 +14,7 @@
 
 package com.google.ads.googleads.examples.basicoperations;
 
-import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDateTime;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
@@ -106,7 +106,7 @@ public class AddCampaigns {
   private static String addCampaignBudget(GoogleAdsClient googleAdsClient, long customerId) {
     CampaignBudget budget =
         CampaignBudget.newBuilder()
-            .setName("Interplanetary Cruise Budget #" + getPrintableDatetime())
+            .setName("Interplanetary Cruise Budget #" + getPrintableDateTime())
             .setDeliveryMethod(BudgetDeliveryMethod.STANDARD)
             .setAmountMicros(500_000)
             .build();
@@ -153,7 +153,7 @@ public class AddCampaigns {
       // Creates the campaign.
       Campaign campaign =
           Campaign.newBuilder()
-              .setName("Interplanetary Cruise #" + getPrintableDatetime())
+              .setName("Interplanetary Cruise #" + getPrintableDateTime())
               .setAdvertisingChannelType(AdvertisingChannelType.SEARCH)
               // Recommendation: Set the campaign to PAUSED when creating it to prevent
               // the ads from immediately serving. Set to ENABLED once you've added

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/basicoperations/AddResponsiveSearchAd.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/basicoperations/AddResponsiveSearchAd.java
@@ -16,6 +16,7 @@ package com.google.ads.googleads.examples.basicoperations;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
+import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.common.AdTextAsset;
@@ -103,7 +104,7 @@ public class AddResponsiveSearchAd {
     // perform best will be used more often.
     AdTextAsset pinnedHeadline =
         AdTextAsset.newBuilder()
-            .setText("Cruise to Mars #" + System.currentTimeMillis())
+            .setText("Cruise to Mars #" + CodeSampleHelper.getPrintableDatetime())
             .setPinnedField(ServedAssetFieldType.HEADLINE_1)
             .build();
 

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/basicoperations/AddResponsiveSearchAd.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/basicoperations/AddResponsiveSearchAd.java
@@ -14,7 +14,7 @@
 
 package com.google.ads.googleads.examples.basicoperations;
 
-import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getShortPrintableDatetime;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
@@ -105,7 +105,7 @@ public class AddResponsiveSearchAd {
     // perform best will be used more often.
     AdTextAsset pinnedHeadline =
         AdTextAsset.newBuilder()
-            .setText("Cruise to Mars #" + getPrintableDatetime())
+            .setText("Cruise to Mars #" + getShortPrintableDatetime())
             .setPinnedField(ServedAssetFieldType.HEADLINE_1)
             .build();
 

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/basicoperations/AddResponsiveSearchAd.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/basicoperations/AddResponsiveSearchAd.java
@@ -14,7 +14,7 @@
 
 package com.google.ads.googleads.examples.basicoperations;
 
-import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getShortPrintableDatetime;
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getShortPrintableDateTime;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
@@ -105,7 +105,7 @@ public class AddResponsiveSearchAd {
     // perform best will be used more often.
     AdTextAsset pinnedHeadline =
         AdTextAsset.newBuilder()
-            .setText("Cruise to Mars #" + getShortPrintableDatetime())
+            .setText("Cruise to Mars #" + getShortPrintableDateTime())
             .setPinnedField(ServedAssetFieldType.HEADLINE_1)
             .build();
 

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/basicoperations/AddResponsiveSearchAd.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/basicoperations/AddResponsiveSearchAd.java
@@ -14,9 +14,10 @@
 
 package com.google.ads.googleads.examples.basicoperations;
 
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
-import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.common.AdTextAsset;
@@ -104,7 +105,7 @@ public class AddResponsiveSearchAd {
     // perform best will be used more often.
     AdTextAsset pinnedHeadline =
         AdTextAsset.newBuilder()
-            .setText("Cruise to Mars #" + CodeSampleHelper.getPrintableDatetime())
+            .setText("Cruise to Mars #" + getPrintableDatetime())
             .setPinnedField(ServedAssetFieldType.HEADLINE_1)
             .build();
 

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/basicoperations/PauseAd.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/basicoperations/PauseAd.java
@@ -14,21 +14,38 @@
 
 package com.google.ads.googleads.examples.basicoperations;
 
+import com.beust.jcommander.Parameter;
+import com.google.ads.googleads.examples.utils.ArgumentNames;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.lib.utils.FieldMasks;
-import com.google.ads.googleads.v6.common.ManualCpc;
+import com.google.ads.googleads.v6.enums.AdGroupAdStatusEnum.AdGroupAdStatus;
 import com.google.ads.googleads.v6.errors.GoogleAdsError;
 import com.google.ads.googleads.v6.errors.GoogleAdsException;
-import com.google.ads.googleads.v6.resources.Campaign;
-import com.google.protobuf.FieldMask;
+import com.google.ads.googleads.v6.resources.AdGroupAd;
+import com.google.ads.googleads.v6.services.AdGroupAdOperation;
+import com.google.ads.googleads.v6.services.AdGroupAdServiceClient;
+import com.google.ads.googleads.v6.services.MutateAdGroupAdResult;
+import com.google.ads.googleads.v6.services.MutateAdGroupAdsResponse;
+import com.google.ads.googleads.v6.utils.ResourceNames;
+import com.google.common.collect.ImmutableList;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 
 /** Changes the status of a given ad to {@code PAUSED}. */
 public class PauseAd {
 
-  private static class PauseAdParams extends CodeSampleParams {}
+  private static class PauseAdParams extends CodeSampleParams {
+
+    @Parameter(names = ArgumentNames.CUSTOMER_ID, required = true)
+    private Long customerId;
+
+    @Parameter(names = ArgumentNames.AD_GROUP_ID, required = true)
+    private Long adGroupId;
+
+    @Parameter(names = ArgumentNames.AD_ID, required = true)
+    private Long adId;
+  }
 
   public static void main(String[] args) {
     PauseAdParams params = new PauseAdParams();
@@ -36,6 +53,9 @@ public class PauseAd {
 
       // Either pass the required parameters for this example on the command line, or insert them
       // into the code here. See the parameter class definition above for descriptions.
+      params.customerId = Long.parseLong("INSERT_CUSTOMER_ID_HERE");
+      params.adGroupId = Long.parseLong("INSERT_AD_GROUP_ID_HERE");
+      params.adId = Long.parseLong("INSERT_AD_ID_HERE");
     }
 
     GoogleAdsClient googleAdsClient = null;
@@ -51,7 +71,7 @@ public class PauseAd {
     }
 
     try {
-      new PauseAd().runExample(googleAdsClient);
+      new PauseAd().runExample(googleAdsClient, params.customerId, params.adGroupId, params.adId);
     } catch (GoogleAdsException gae) {
       // GoogleAdsException is the base class for most exceptions thrown by an API request.
       // Instances of this exception have a message and a GoogleAdsFailure that contains a
@@ -72,40 +92,36 @@ public class PauseAd {
    * Runs the example.
    *
    * @param googleAdsClient the Google Ads API client.
+   * @param customerId the client customer ID.
+   * @param adGroupId the ad group ID.
+   * @param adId the ID of the ad to pause.
    * @throws GoogleAdsException if an API request failed with one or more service errors.
    */
-  private void runExample(GoogleAdsClient googleAdsClient) {
+  private void runExample(
+      GoogleAdsClient googleAdsClient, long customerId, long adGroupId, long adId) {
 
-    // String adGroupAdResourceName = ResourceNames.adGroupAd(customerId, adGroupId, adId);
-    //
-    // // Creates an ad representation with its status set to PAUSED.
-    // AdGroupAd adGroupAd =
-    //     AdGroupAd.newBuilder()
-    //         .setResourceName(adGroupAdResourceName)
-    //         .setStatus(AdGroupAdStatus.PAUSED)
-    //         .build();
-    //
-    // AdGroupAdOperation op =
-    //     AdGroupAdOperation.newBuilder()
-    //         .setUpdate(adGroupAd)
-    //         .setUpdateMask(FieldMasks.allSetFieldsOf(adGroupAd))
-    //         .build();
-    //
-    // try (AdGroupAdServiceClient adGroupAdServiceClient =
-    //     googleAdsClient.getLatestVersion().createAdGroupAdServiceClient()) {
-    //   MutateAdGroupAdsResponse response =
-    //       adGroupAdServiceClient.mutateAdGroupAds(Long.toString(customerId),
-    // ImmutableList.of(op));
-    //   for (MutateAdGroupAdResult result : response.getResultsList()) {
-    //     System.out.printf("Ad with resource name '%s' is paused.%n", result.getResourceName());
-    //   }
-    // }
+    String adGroupAdResourceName = ResourceNames.adGroupAd(customerId, adGroupId, adId);
 
-    Campaign campaign =
-        Campaign.newBuilder()
-            .setManualCpc(ManualCpc.newBuilder().setEnhancedCpcEnabled(false).build())
+    // Creates an ad representation with its status set to PAUSED.
+    AdGroupAd adGroupAd =
+        AdGroupAd.newBuilder()
+            .setResourceName(adGroupAdResourceName)
+            .setStatus(AdGroupAdStatus.PAUSED)
             .build();
-    FieldMask fieldMask = FieldMasks.allSetFieldsOf(campaign);
-    System.out.println(fieldMask.toString());
+
+    AdGroupAdOperation op =
+        AdGroupAdOperation.newBuilder()
+            .setUpdate(adGroupAd)
+            .setUpdateMask(FieldMasks.allSetFieldsOf(adGroupAd))
+            .build();
+
+    try (AdGroupAdServiceClient adGroupAdServiceClient =
+        googleAdsClient.getLatestVersion().createAdGroupAdServiceClient()) {
+      MutateAdGroupAdsResponse response =
+          adGroupAdServiceClient.mutateAdGroupAds(Long.toString(customerId), ImmutableList.of(op));
+      for (MutateAdGroupAdResult result : response.getResultsList()) {
+        System.out.printf("Ad with resource name '%s' is paused.%n", result.getResourceName());
+      }
+    }
   }
 }

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/basicoperations/PauseAd.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/basicoperations/PauseAd.java
@@ -14,38 +14,21 @@
 
 package com.google.ads.googleads.examples.basicoperations;
 
-import com.beust.jcommander.Parameter;
-import com.google.ads.googleads.examples.utils.ArgumentNames;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.lib.utils.FieldMasks;
-import com.google.ads.googleads.v6.enums.AdGroupAdStatusEnum.AdGroupAdStatus;
+import com.google.ads.googleads.v6.common.ManualCpc;
 import com.google.ads.googleads.v6.errors.GoogleAdsError;
 import com.google.ads.googleads.v6.errors.GoogleAdsException;
-import com.google.ads.googleads.v6.resources.AdGroupAd;
-import com.google.ads.googleads.v6.services.AdGroupAdOperation;
-import com.google.ads.googleads.v6.services.AdGroupAdServiceClient;
-import com.google.ads.googleads.v6.services.MutateAdGroupAdResult;
-import com.google.ads.googleads.v6.services.MutateAdGroupAdsResponse;
-import com.google.ads.googleads.v6.utils.ResourceNames;
-import com.google.common.collect.ImmutableList;
+import com.google.ads.googleads.v6.resources.Campaign;
+import com.google.protobuf.FieldMask;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 
 /** Changes the status of a given ad to {@code PAUSED}. */
 public class PauseAd {
 
-  private static class PauseAdParams extends CodeSampleParams {
-
-    @Parameter(names = ArgumentNames.CUSTOMER_ID, required = true)
-    private Long customerId;
-
-    @Parameter(names = ArgumentNames.AD_GROUP_ID, required = true)
-    private Long adGroupId;
-
-    @Parameter(names = ArgumentNames.AD_ID, required = true)
-    private Long adId;
-  }
+  private static class PauseAdParams extends CodeSampleParams {}
 
   public static void main(String[] args) {
     PauseAdParams params = new PauseAdParams();
@@ -53,9 +36,6 @@ public class PauseAd {
 
       // Either pass the required parameters for this example on the command line, or insert them
       // into the code here. See the parameter class definition above for descriptions.
-      params.customerId = Long.parseLong("INSERT_CUSTOMER_ID_HERE");
-      params.adGroupId = Long.parseLong("INSERT_AD_GROUP_ID_HERE");
-      params.adId = Long.parseLong("INSERT_AD_ID_HERE");
     }
 
     GoogleAdsClient googleAdsClient = null;
@@ -71,7 +51,7 @@ public class PauseAd {
     }
 
     try {
-      new PauseAd().runExample(googleAdsClient, params.customerId, params.adGroupId, params.adId);
+      new PauseAd().runExample(googleAdsClient);
     } catch (GoogleAdsException gae) {
       // GoogleAdsException is the base class for most exceptions thrown by an API request.
       // Instances of this exception have a message and a GoogleAdsFailure that contains a
@@ -92,36 +72,40 @@ public class PauseAd {
    * Runs the example.
    *
    * @param googleAdsClient the Google Ads API client.
-   * @param customerId the client customer ID.
-   * @param adGroupId the ad group ID.
-   * @param adId the ID of the ad to pause.
    * @throws GoogleAdsException if an API request failed with one or more service errors.
    */
-  private void runExample(
-      GoogleAdsClient googleAdsClient, long customerId, long adGroupId, long adId) {
+  private void runExample(GoogleAdsClient googleAdsClient) {
 
-    String adGroupAdResourceName = ResourceNames.adGroupAd(customerId, adGroupId, adId);
+    // String adGroupAdResourceName = ResourceNames.adGroupAd(customerId, adGroupId, adId);
+    //
+    // // Creates an ad representation with its status set to PAUSED.
+    // AdGroupAd adGroupAd =
+    //     AdGroupAd.newBuilder()
+    //         .setResourceName(adGroupAdResourceName)
+    //         .setStatus(AdGroupAdStatus.PAUSED)
+    //         .build();
+    //
+    // AdGroupAdOperation op =
+    //     AdGroupAdOperation.newBuilder()
+    //         .setUpdate(adGroupAd)
+    //         .setUpdateMask(FieldMasks.allSetFieldsOf(adGroupAd))
+    //         .build();
+    //
+    // try (AdGroupAdServiceClient adGroupAdServiceClient =
+    //     googleAdsClient.getLatestVersion().createAdGroupAdServiceClient()) {
+    //   MutateAdGroupAdsResponse response =
+    //       adGroupAdServiceClient.mutateAdGroupAds(Long.toString(customerId),
+    // ImmutableList.of(op));
+    //   for (MutateAdGroupAdResult result : response.getResultsList()) {
+    //     System.out.printf("Ad with resource name '%s' is paused.%n", result.getResourceName());
+    //   }
+    // }
 
-    // Creates an ad representation with its status set to PAUSED.
-    AdGroupAd adGroupAd =
-        AdGroupAd.newBuilder()
-            .setResourceName(adGroupAdResourceName)
-            .setStatus(AdGroupAdStatus.PAUSED)
+    Campaign campaign =
+        Campaign.newBuilder()
+            .setManualCpc(ManualCpc.newBuilder().setEnhancedCpcEnabled(false).build())
             .build();
-
-    AdGroupAdOperation op =
-        AdGroupAdOperation.newBuilder()
-            .setUpdate(adGroupAd)
-            .setUpdateMask(FieldMasks.allSetFieldsOf(adGroupAd))
-            .build();
-
-    try (AdGroupAdServiceClient adGroupAdServiceClient =
-        googleAdsClient.getLatestVersion().createAdGroupAdServiceClient()) {
-      MutateAdGroupAdsResponse response =
-          adGroupAdServiceClient.mutateAdGroupAds(Long.toString(customerId), ImmutableList.of(op));
-      for (MutateAdGroupAdResult result : response.getResultsList()) {
-        System.out.printf("Ad with resource name '%s' is paused.%n", result.getResourceName());
-      }
-    }
+    FieldMask fieldMask = FieldMasks.allSetFieldsOf(campaign);
+    System.out.println(fieldMask.toString());
   }
 }

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/basicoperations/UpdateExpandedTextAd.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/basicoperations/UpdateExpandedTextAd.java
@@ -13,7 +13,7 @@
 // limitations under the License.
 package com.google.ads.googleads.examples.basicoperations;
 
-import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getShortPrintableDatetime;
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getShortPrintableDateTime;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
@@ -107,7 +107,7 @@ public class UpdateExpandedTextAd {
     // Sets the expanded text ad properties to update on the ad.
     adBuilder
         .getExpandedTextAdBuilder()
-        .setHeadlinePart1("Cruise to Pluto #" + getShortPrintableDatetime())
+        .setHeadlinePart1("Cruise to Pluto #" + getShortPrintableDateTime())
         .setHeadlinePart2("Tickets on sale now")
         .setDescription("Best space cruise ever.");
 

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/basicoperations/UpdateExpandedTextAd.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/basicoperations/UpdateExpandedTextAd.java
@@ -13,7 +13,7 @@
 // limitations under the License.
 package com.google.ads.googleads.examples.basicoperations;
 
-import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getShortPrintableDatetime;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
@@ -107,7 +107,7 @@ public class UpdateExpandedTextAd {
     // Sets the expanded text ad properties to update on the ad.
     adBuilder
         .getExpandedTextAdBuilder()
-        .setHeadlinePart1("Cruise to Pluto #" + getPrintableDatetime())
+        .setHeadlinePart1("Cruise to Pluto #" + getShortPrintableDatetime())
         .setHeadlinePart2("Tickets on sale now")
         .setDescription("Best space cruise ever.");
 

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/basicoperations/UpdateExpandedTextAd.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/basicoperations/UpdateExpandedTextAd.java
@@ -15,6 +15,7 @@ package com.google.ads.googleads.examples.basicoperations;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
+import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.lib.utils.FieldMasks;
@@ -105,7 +106,7 @@ public class UpdateExpandedTextAd {
     // Sets the expanded text ad properties to update on the ad.
     adBuilder
         .getExpandedTextAdBuilder()
-        .setHeadlinePart1("Cruise to Pluto #" + System.currentTimeMillis())
+        .setHeadlinePart1("Cruise to Pluto #" + CodeSampleHelper.getPrintableDatetime())
         .setHeadlinePart2("Tickets on sale now")
         .setDescription("Best space cruise ever.");
 

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/basicoperations/UpdateExpandedTextAd.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/basicoperations/UpdateExpandedTextAd.java
@@ -13,9 +13,10 @@
 // limitations under the License.
 package com.google.ads.googleads.examples.basicoperations;
 
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
-import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.lib.utils.FieldMasks;
@@ -106,7 +107,7 @@ public class UpdateExpandedTextAd {
     // Sets the expanded text ad properties to update on the ad.
     adBuilder
         .getExpandedTextAdBuilder()
-        .setHeadlinePart1("Cruise to Pluto #" + CodeSampleHelper.getPrintableDatetime())
+        .setHeadlinePart1("Cruise to Pluto #" + getPrintableDatetime())
         .setHeadlinePart2("Tickets on sale now")
         .setDescription("Best space cruise ever.");
 

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/billing/AddBillingSetup.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/billing/AddBillingSetup.java
@@ -14,7 +14,7 @@
 
 package com.google.ads.googleads.examples.billing;
 
-import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDateTime;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
@@ -180,7 +180,7 @@ public class AddBillingSetup {
       // about payments profiles.
       billingSetupBuilder.setPaymentsAccountInfo(
           PaymentsAccountInfo.newBuilder()
-              .setPaymentsAccountName("Payments Account #" + getPrintableDatetime())
+              .setPaymentsAccountName("Payments Account #" + getPrintableDateTime())
               .setPaymentsProfileId(paymentsProfileId)
               .build());
     } else {

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/billing/AddBillingSetup.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/billing/AddBillingSetup.java
@@ -14,9 +14,10 @@
 
 package com.google.ads.googleads.examples.billing;
 
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
-import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.errors.GoogleAdsError;
@@ -179,8 +180,7 @@ public class AddBillingSetup {
       // about payments profiles.
       billingSetupBuilder.setPaymentsAccountInfo(
           PaymentsAccountInfo.newBuilder()
-              .setPaymentsAccountName(
-                  "Payments Account #" + CodeSampleHelper.getPrintableDatetime())
+              .setPaymentsAccountName("Payments Account #" + getPrintableDatetime())
               .setPaymentsProfileId(paymentsProfileId)
               .build());
     } else {

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/billing/AddBillingSetup.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/billing/AddBillingSetup.java
@@ -16,6 +16,7 @@ package com.google.ads.googleads.examples.billing;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
+import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.errors.GoogleAdsError;
@@ -178,7 +179,7 @@ public class AddBillingSetup {
       // about payments profiles.
       billingSetupBuilder.setPaymentsAccountInfo(
           PaymentsAccountInfo.newBuilder()
-              .setPaymentsAccountName("Payments Account #" + System.currentTimeMillis())
+              .setPaymentsAccountName("Payments Account #" + CodeSampleHelper.getPrintableDatetime())
               .setPaymentsProfileId(paymentsProfileId)
               .build());
     } else {

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/billing/AddBillingSetup.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/billing/AddBillingSetup.java
@@ -179,7 +179,8 @@ public class AddBillingSetup {
       // about payments profiles.
       billingSetupBuilder.setPaymentsAccountInfo(
           PaymentsAccountInfo.newBuilder()
-              .setPaymentsAccountName("Payments Account #" + CodeSampleHelper.getPrintableDatetime())
+              .setPaymentsAccountName(
+                  "Payments Account #" + CodeSampleHelper.getPrintableDatetime())
               .setPaymentsProfileId(paymentsProfileId)
               .build());
     } else {

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/campaignmanagement/AddCampaignDraft.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/campaignmanagement/AddCampaignDraft.java
@@ -14,7 +14,7 @@
 
 package com.google.ads.googleads.examples.campaignmanagement;
 
-import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDateTime;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
@@ -99,7 +99,7 @@ public class AddCampaignDraft {
     CampaignDraft draft =
         CampaignDraft.newBuilder()
             .setBaseCampaign(ResourceNames.campaign(customerId, baseCampaignId))
-            .setName("Campaign Draft #" + getPrintableDatetime())
+            .setName("Campaign Draft #" + getPrintableDateTime())
             .build();
 
     // Creates an operation to create the draft campaign.

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/campaignmanagement/AddCampaignDraft.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/campaignmanagement/AddCampaignDraft.java
@@ -14,9 +14,10 @@
 
 package com.google.ads.googleads.examples.campaignmanagement;
 
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
-import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.errors.GoogleAdsError;
@@ -98,7 +99,7 @@ public class AddCampaignDraft {
     CampaignDraft draft =
         CampaignDraft.newBuilder()
             .setBaseCampaign(ResourceNames.campaign(customerId, baseCampaignId))
-            .setName("Campaign Draft #" + CodeSampleHelper.getPrintableDatetime())
+            .setName("Campaign Draft #" + getPrintableDatetime())
             .build();
 
     // Creates an operation to create the draft campaign.

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/campaignmanagement/AddCampaignDraft.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/campaignmanagement/AddCampaignDraft.java
@@ -16,6 +16,7 @@ package com.google.ads.googleads.examples.campaignmanagement;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
+import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.errors.GoogleAdsError;
@@ -97,7 +98,7 @@ public class AddCampaignDraft {
     CampaignDraft draft =
         CampaignDraft.newBuilder()
             .setBaseCampaign(ResourceNames.campaign(customerId, baseCampaignId))
-            .setName("Campaign Draft #" + System.currentTimeMillis())
+            .setName("Campaign Draft #" + CodeSampleHelper.getPrintableDatetime())
             .build();
 
     // Creates an operation to create the draft campaign.

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/campaignmanagement/AddCompleteCampaignsUsingBatchJob.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/campaignmanagement/AddCompleteCampaignsUsingBatchJob.java
@@ -14,7 +14,7 @@
 
 package com.google.ads.googleads.examples.campaignmanagement;
 
-import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDateTime;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
@@ -341,7 +341,7 @@ public class AddCompleteCampaignsUsingBatchJob {
         CampaignBudget.newBuilder()
             // Creates a resource name using the temporary ID.
             .setResourceName(ResourceNames.campaignBudget(customerId, getNextTemporaryId()))
-            .setName("Interplanetary Cruise Budget #" + getPrintableDatetime())
+            .setName("Interplanetary Cruise Budget #" + getPrintableDateTime())
             .setDeliveryMethod(BudgetDeliveryMethod.STANDARD)
             .setAmountMicros(5_000_000)
             .build();
@@ -369,7 +369,7 @@ public class AddCompleteCampaignsUsingBatchJob {
           Campaign.newBuilder()
               // Creates a resource name using the temporary ID.
               .setResourceName(ResourceNames.campaign(customerId, campaignId))
-              .setName("Mutate job campaign #" + getPrintableDatetime() + "." + campaignId)
+              .setName("Mutate job campaign #" + getPrintableDateTime() + "." + campaignId)
               .setAdvertisingChannelType(AdvertisingChannelType.SEARCH)
               // Recommendation: Set the campaign to PAUSED when creating it to prevent
               // the ads from immediately serving. Set to ENABLED once you've added
@@ -440,7 +440,7 @@ public class AddCompleteCampaignsUsingBatchJob {
             AdGroup.newBuilder()
                 // Creates a resource name using the temporary ID.
                 .setResourceName(ResourceNames.adGroup(customerId, adGroupId))
-                .setName("Mutate job ad group #" + getPrintableDatetime() + "." + adGroupId)
+                .setName("Mutate job ad group #" + getPrintableDateTime() + "." + adGroupId)
                 .setCampaign(campaignOperation.getCreate().getResourceName())
                 .setType(AdGroupType.SEARCH_STANDARD)
                 .setCpcBidMicros(10_000_000)
@@ -516,7 +516,7 @@ public class AddCompleteCampaignsUsingBatchJob {
                       // Sets the expanded text ad info on an ad.
                       .setExpandedTextAd(
                           ExpandedTextAdInfo.newBuilder()
-                              .setHeadlinePart1("Cruise to Mars #" + getPrintableDatetime())
+                              .setHeadlinePart1("Cruise to Mars #" + getPrintableDateTime())
                               .setHeadlinePart2("Best Space Cruise Line")
                               .setDescription("Buy your tickets now!")
                               .build())

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/campaignmanagement/AddCompleteCampaignsUsingBatchJob.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/campaignmanagement/AddCompleteCampaignsUsingBatchJob.java
@@ -14,9 +14,10 @@
 
 package com.google.ads.googleads.examples.campaignmanagement;
 
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
-import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.common.ExpandedTextAdInfo;
@@ -340,7 +341,7 @@ public class AddCompleteCampaignsUsingBatchJob {
         CampaignBudget.newBuilder()
             // Creates a resource name using the temporary ID.
             .setResourceName(ResourceNames.campaignBudget(customerId, getNextTemporaryId()))
-            .setName("Interplanetary Cruise Budget #" + CodeSampleHelper.getPrintableDatetime())
+            .setName("Interplanetary Cruise Budget #" + getPrintableDatetime())
             .setDeliveryMethod(BudgetDeliveryMethod.STANDARD)
             .setAmountMicros(5_000_000)
             .build();
@@ -368,11 +369,7 @@ public class AddCompleteCampaignsUsingBatchJob {
           Campaign.newBuilder()
               // Creates a resource name using the temporary ID.
               .setResourceName(ResourceNames.campaign(customerId, campaignId))
-              .setName(
-                  "Mutate job campaign #"
-                      + CodeSampleHelper.getPrintableDatetime()
-                      + "."
-                      + campaignId)
+              .setName("Mutate job campaign #" + getPrintableDatetime() + "." + campaignId)
               .setAdvertisingChannelType(AdvertisingChannelType.SEARCH)
               // Recommendation: Set the campaign to PAUSED when creating it to prevent
               // the ads from immediately serving. Set to ENABLED once you've added
@@ -443,11 +440,7 @@ public class AddCompleteCampaignsUsingBatchJob {
             AdGroup.newBuilder()
                 // Creates a resource name using the temporary ID.
                 .setResourceName(ResourceNames.adGroup(customerId, adGroupId))
-                .setName(
-                    "Mutate job ad group #"
-                        + CodeSampleHelper.getPrintableDatetime()
-                        + "."
-                        + adGroupId)
+                .setName("Mutate job ad group #" + getPrintableDatetime() + "." + adGroupId)
                 .setCampaign(campaignOperation.getCreate().getResourceName())
                 .setType(AdGroupType.SEARCH_STANDARD)
                 .setCpcBidMicros(10_000_000)
@@ -523,8 +516,7 @@ public class AddCompleteCampaignsUsingBatchJob {
                       // Sets the expanded text ad info on an ad.
                       .setExpandedTextAd(
                           ExpandedTextAdInfo.newBuilder()
-                              .setHeadlinePart1(
-                                  "Cruise to Mars #" + CodeSampleHelper.getPrintableDatetime())
+                              .setHeadlinePart1("Cruise to Mars #" + getPrintableDatetime())
                               .setHeadlinePart2("Best Space Cruise Line")
                               .setDescription("Buy your tickets now!")
                               .build())

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/campaignmanagement/AddCompleteCampaignsUsingBatchJob.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/campaignmanagement/AddCompleteCampaignsUsingBatchJob.java
@@ -16,6 +16,7 @@ package com.google.ads.googleads.examples.campaignmanagement;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
+import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.common.ExpandedTextAdInfo;
@@ -339,7 +340,7 @@ public class AddCompleteCampaignsUsingBatchJob {
         CampaignBudget.newBuilder()
             // Creates a resource name using the temporary ID.
             .setResourceName(ResourceNames.campaignBudget(customerId, getNextTemporaryId()))
-            .setName("Interplanetary Cruise Budget #" + System.currentTimeMillis())
+            .setName("Interplanetary Cruise Budget #" + CodeSampleHelper.getPrintableDatetime())
             .setDeliveryMethod(BudgetDeliveryMethod.STANDARD)
             .setAmountMicros(5_000_000)
             .build();
@@ -367,7 +368,7 @@ public class AddCompleteCampaignsUsingBatchJob {
           Campaign.newBuilder()
               // Creates a resource name using the temporary ID.
               .setResourceName(ResourceNames.campaign(customerId, campaignId))
-              .setName("Mutate job campaign #" + System.currentTimeMillis() + "." + campaignId)
+              .setName("Mutate job campaign #" + CodeSampleHelper.getPrintableDatetime() + "." + campaignId)
               .setAdvertisingChannelType(AdvertisingChannelType.SEARCH)
               // Recommendation: Set the campaign to PAUSED when creating it to prevent
               // the ads from immediately serving. Set to ENABLED once you've added
@@ -438,7 +439,7 @@ public class AddCompleteCampaignsUsingBatchJob {
             AdGroup.newBuilder()
                 // Creates a resource name using the temporary ID.
                 .setResourceName(ResourceNames.adGroup(customerId, adGroupId))
-                .setName("Mutate job ad group #" + System.currentTimeMillis() + "." + adGroupId)
+                .setName("Mutate job ad group #" + CodeSampleHelper.getPrintableDatetime() + "." + adGroupId)
                 .setCampaign(campaignOperation.getCreate().getResourceName())
                 .setType(AdGroupType.SEARCH_STANDARD)
                 .setCpcBidMicros(10_000_000)
@@ -514,7 +515,7 @@ public class AddCompleteCampaignsUsingBatchJob {
                       // Sets the expanded text ad info on an ad.
                       .setExpandedTextAd(
                           ExpandedTextAdInfo.newBuilder()
-                              .setHeadlinePart1("Cruise to Mars #" + System.currentTimeMillis())
+                              .setHeadlinePart1("Cruise to Mars #" + CodeSampleHelper.getPrintableDatetime())
                               .setHeadlinePart2("Best Space Cruise Line")
                               .setDescription("Buy your tickets now!")
                               .build())

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/campaignmanagement/AddCompleteCampaignsUsingBatchJob.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/campaignmanagement/AddCompleteCampaignsUsingBatchJob.java
@@ -368,7 +368,11 @@ public class AddCompleteCampaignsUsingBatchJob {
           Campaign.newBuilder()
               // Creates a resource name using the temporary ID.
               .setResourceName(ResourceNames.campaign(customerId, campaignId))
-              .setName("Mutate job campaign #" + CodeSampleHelper.getPrintableDatetime() + "." + campaignId)
+              .setName(
+                  "Mutate job campaign #"
+                      + CodeSampleHelper.getPrintableDatetime()
+                      + "."
+                      + campaignId)
               .setAdvertisingChannelType(AdvertisingChannelType.SEARCH)
               // Recommendation: Set the campaign to PAUSED when creating it to prevent
               // the ads from immediately serving. Set to ENABLED once you've added
@@ -439,7 +443,11 @@ public class AddCompleteCampaignsUsingBatchJob {
             AdGroup.newBuilder()
                 // Creates a resource name using the temporary ID.
                 .setResourceName(ResourceNames.adGroup(customerId, adGroupId))
-                .setName("Mutate job ad group #" + CodeSampleHelper.getPrintableDatetime() + "." + adGroupId)
+                .setName(
+                    "Mutate job ad group #"
+                        + CodeSampleHelper.getPrintableDatetime()
+                        + "."
+                        + adGroupId)
                 .setCampaign(campaignOperation.getCreate().getResourceName())
                 .setType(AdGroupType.SEARCH_STANDARD)
                 .setCpcBidMicros(10_000_000)
@@ -515,7 +523,8 @@ public class AddCompleteCampaignsUsingBatchJob {
                       // Sets the expanded text ad info on an ad.
                       .setExpandedTextAd(
                           ExpandedTextAdInfo.newBuilder()
-                              .setHeadlinePart1("Cruise to Mars #" + CodeSampleHelper.getPrintableDatetime())
+                              .setHeadlinePart1(
+                                  "Cruise to Mars #" + CodeSampleHelper.getPrintableDatetime())
                               .setHeadlinePart2("Best Space Cruise Line")
                               .setDescription("Buy your tickets now!")
                               .build())

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/campaignmanagement/CreateCampaignExperiment.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/campaignmanagement/CreateCampaignExperiment.java
@@ -14,7 +14,7 @@
 
 package com.google.ads.googleads.examples.campaignmanagement;
 
-import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDateTime;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
@@ -133,7 +133,7 @@ public class CreateCampaignExperiment {
     CampaignExperiment experiment =
         CampaignExperiment.newBuilder()
             .setCampaignDraft(ResourceNames.campaignDraft(customerId, baseCampaignId, draftId))
-            .setName("Campaign experiment #" + getPrintableDatetime())
+            .setName("Campaign experiment #" + getPrintableDateTime())
             .setTrafficSplitPercent(50)
             .setTrafficSplitType(CampaignExperimentTrafficSplitType.RANDOM_QUERY)
             .build();

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/campaignmanagement/CreateCampaignExperiment.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/campaignmanagement/CreateCampaignExperiment.java
@@ -16,6 +16,7 @@ package com.google.ads.googleads.examples.campaignmanagement;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
+import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.enums.CampaignExperimentTrafficSplitTypeEnum.CampaignExperimentTrafficSplitType;
@@ -131,7 +132,7 @@ public class CreateCampaignExperiment {
     CampaignExperiment experiment =
         CampaignExperiment.newBuilder()
             .setCampaignDraft(ResourceNames.campaignDraft(customerId, baseCampaignId, draftId))
-            .setName("Campaign experiment #" + System.currentTimeMillis())
+            .setName("Campaign experiment #" + CodeSampleHelper.getPrintableDatetime())
             .setTrafficSplitPercent(50)
             .setTrafficSplitType(CampaignExperimentTrafficSplitType.RANDOM_QUERY)
             .build();

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/campaignmanagement/CreateCampaignExperiment.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/campaignmanagement/CreateCampaignExperiment.java
@@ -14,9 +14,10 @@
 
 package com.google.ads.googleads.examples.campaignmanagement;
 
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
-import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.enums.CampaignExperimentTrafficSplitTypeEnum.CampaignExperimentTrafficSplitType;
@@ -132,7 +133,7 @@ public class CreateCampaignExperiment {
     CampaignExperiment experiment =
         CampaignExperiment.newBuilder()
             .setCampaignDraft(ResourceNames.campaignDraft(customerId, baseCampaignId, draftId))
-            .setName("Campaign experiment #" + CodeSampleHelper.getPrintableDatetime())
+            .setName("Campaign experiment #" + getPrintableDatetime())
             .setTrafficSplitPercent(50)
             .setTrafficSplitType(CampaignExperimentTrafficSplitType.RANDOM_QUERY)
             .build();

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/campaignmanagement/GraduateCampaignExperiment.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/campaignmanagement/GraduateCampaignExperiment.java
@@ -16,6 +16,7 @@ package com.google.ads.googleads.examples.campaignmanagement;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
+import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.enums.BudgetDeliveryMethodEnum.BudgetDeliveryMethod;
@@ -98,7 +99,7 @@ public class GraduateCampaignExperiment {
     // after it is made independent by graduation.
     CampaignBudget budget =
         CampaignBudget.newBuilder()
-            .setName("Budget #" + System.currentTimeMillis())
+            .setName("Budget #" + CodeSampleHelper.getPrintableDatetime())
             .setAmountMicros(50_000_000)
             .setDeliveryMethod(BudgetDeliveryMethod.STANDARD)
             .build();

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/campaignmanagement/GraduateCampaignExperiment.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/campaignmanagement/GraduateCampaignExperiment.java
@@ -14,9 +14,10 @@
 
 package com.google.ads.googleads.examples.campaignmanagement;
 
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
-import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.enums.BudgetDeliveryMethodEnum.BudgetDeliveryMethod;
@@ -99,7 +100,7 @@ public class GraduateCampaignExperiment {
     // after it is made independent by graduation.
     CampaignBudget budget =
         CampaignBudget.newBuilder()
-            .setName("Budget #" + CodeSampleHelper.getPrintableDatetime())
+            .setName("Budget #" + getPrintableDatetime())
             .setAmountMicros(50_000_000)
             .setDeliveryMethod(BudgetDeliveryMethod.STANDARD)
             .build();

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/campaignmanagement/GraduateCampaignExperiment.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/campaignmanagement/GraduateCampaignExperiment.java
@@ -14,7 +14,7 @@
 
 package com.google.ads.googleads.examples.campaignmanagement;
 
-import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDateTime;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
@@ -100,7 +100,7 @@ public class GraduateCampaignExperiment {
     // after it is made independent by graduation.
     CampaignBudget budget =
         CampaignBudget.newBuilder()
-            .setName("Budget #" + getPrintableDatetime())
+            .setName("Budget #" + getPrintableDateTime())
             .setAmountMicros(50_000_000)
             .setDeliveryMethod(BudgetDeliveryMethod.STANDARD)
             .build();

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/errorhandling/HandleExpandedTextAdPolicyViolations.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/errorhandling/HandleExpandedTextAdPolicyViolations.java
@@ -14,7 +14,7 @@
 
 package com.google.ads.googleads.examples.errorhandling;
 
-import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getShortPrintableDatetime;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
@@ -113,7 +113,7 @@ public class HandleExpandedTextAdPolicyViolations {
         .addFinalUrls("http://www.example.com")
         // Adds an expanded text ad.
         .getExpandedTextAdBuilder()
-        .setHeadlinePart1("Cruise to Mars #" + getPrintableDatetime())
+        .setHeadlinePart1("Cruise to Mars #" + getShortPrintableDatetime())
         .setHeadlinePart2("Best Space Cruise Line")
         // Adds a description with too much punctuation. This will fail policy.
         .setDescription("Buy your tickets now!!!!!!!");

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/errorhandling/HandleExpandedTextAdPolicyViolations.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/errorhandling/HandleExpandedTextAdPolicyViolations.java
@@ -16,6 +16,7 @@ package com.google.ads.googleads.examples.errorhandling;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
+import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.common.PolicyTopicEntry;
@@ -111,7 +112,7 @@ public class HandleExpandedTextAdPolicyViolations {
         .addFinalUrls("http://www.example.com")
         // Adds an expanded text ad.
         .getExpandedTextAdBuilder()
-        .setHeadlinePart1("Cruise to Mars #" + System.currentTimeMillis())
+        .setHeadlinePart1("Cruise to Mars #" + CodeSampleHelper.getPrintableDatetime())
         .setHeadlinePart2("Best Space Cruise Line")
         // Adds a description with too much punctuation. This will fail policy.
         .setDescription("Buy your tickets now!!!!!!!");

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/errorhandling/HandleExpandedTextAdPolicyViolations.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/errorhandling/HandleExpandedTextAdPolicyViolations.java
@@ -14,7 +14,7 @@
 
 package com.google.ads.googleads.examples.errorhandling;
 
-import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getShortPrintableDatetime;
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getShortPrintableDateTime;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
@@ -113,7 +113,7 @@ public class HandleExpandedTextAdPolicyViolations {
         .addFinalUrls("http://www.example.com")
         // Adds an expanded text ad.
         .getExpandedTextAdBuilder()
-        .setHeadlinePart1("Cruise to Mars #" + getShortPrintableDatetime())
+        .setHeadlinePart1("Cruise to Mars #" + getShortPrintableDateTime())
         .setHeadlinePart2("Best Space Cruise Line")
         // Adds a description with too much punctuation. This will fail policy.
         .setDescription("Buy your tickets now!!!!!!!");

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/errorhandling/HandleExpandedTextAdPolicyViolations.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/errorhandling/HandleExpandedTextAdPolicyViolations.java
@@ -14,9 +14,10 @@
 
 package com.google.ads.googleads.examples.errorhandling;
 
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
-import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.common.PolicyTopicEntry;
@@ -112,7 +113,7 @@ public class HandleExpandedTextAdPolicyViolations {
         .addFinalUrls("http://www.example.com")
         // Adds an expanded text ad.
         .getExpandedTextAdBuilder()
-        .setHeadlinePart1("Cruise to Mars #" + CodeSampleHelper.getPrintableDatetime())
+        .setHeadlinePart1("Cruise to Mars #" + getPrintableDatetime())
         .setHeadlinePart2("Best Space Cruise Line")
         // Adds a description with too much punctuation. This will fail policy.
         .setDescription("Buy your tickets now!!!!!!!");

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/errorhandling/HandlePartialFailure.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/errorhandling/HandlePartialFailure.java
@@ -14,7 +14,7 @@
 
 package com.google.ads.googleads.examples.errorhandling;
 
-import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDateTime;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
@@ -123,13 +123,13 @@ public class HandlePartialFailure {
     AdGroup group1 =
         AdGroup.newBuilder()
             .setCampaign(ResourceNames.campaign(customerId, campaignId))
-            .setName("Valid AdGroup: " + getPrintableDatetime())
+            .setName("Valid AdGroup: " + getPrintableDateTime())
             .build();
     // This AdGroup will always fail - campaign ID 0 in resource names is never valid.
     AdGroup group2 =
         AdGroup.newBuilder()
             .setCampaign(ResourceNames.campaign(customerId, 0L))
-            .setName("Broken AdGroup: " + getPrintableDatetime())
+            .setName("Broken AdGroup: " + getPrintableDateTime())
             .build();
     // This AdGroup will always fail - duplicate ad group names are not allowed.
     AdGroup group3 =

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/errorhandling/HandlePartialFailure.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/errorhandling/HandlePartialFailure.java
@@ -14,9 +14,10 @@
 
 package com.google.ads.googleads.examples.errorhandling;
 
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
-import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.errors.GoogleAdsError;
@@ -122,13 +123,13 @@ public class HandlePartialFailure {
     AdGroup group1 =
         AdGroup.newBuilder()
             .setCampaign(ResourceNames.campaign(customerId, campaignId))
-            .setName("Valid AdGroup: " + CodeSampleHelper.getPrintableDatetime())
+            .setName("Valid AdGroup: " + getPrintableDatetime())
             .build();
     // This AdGroup will always fail - campaign ID 0 in resource names is never valid.
     AdGroup group2 =
         AdGroup.newBuilder()
             .setCampaign(ResourceNames.campaign(customerId, 0L))
-            .setName("Broken AdGroup: " + CodeSampleHelper.getPrintableDatetime())
+            .setName("Broken AdGroup: " + getPrintableDatetime())
             .build();
     // This AdGroup will always fail - duplicate ad group names are not allowed.
     AdGroup group3 =

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/errorhandling/HandlePartialFailure.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/errorhandling/HandlePartialFailure.java
@@ -16,6 +16,7 @@ package com.google.ads.googleads.examples.errorhandling;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
+import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.errors.GoogleAdsError;
@@ -121,13 +122,13 @@ public class HandlePartialFailure {
     AdGroup group1 =
         AdGroup.newBuilder()
             .setCampaign(ResourceNames.campaign(customerId, campaignId))
-            .setName("Valid AdGroup: " + System.currentTimeMillis())
+            .setName("Valid AdGroup: " + CodeSampleHelper.getPrintableDatetime())
             .build();
     // This AdGroup will always fail - campaign ID 0 in resource names is never valid.
     AdGroup group2 =
         AdGroup.newBuilder()
             .setCampaign(ResourceNames.campaign(customerId, 0L))
-            .setName("Broken AdGroup: " + System.currentTimeMillis())
+            .setName("Broken AdGroup: " + CodeSampleHelper.getPrintableDatetime())
             .build();
     // This AdGroup will always fail - duplicate ad group names are not allowed.
     AdGroup group3 =

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/extensions/AddAffiliateLocationExtensions.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/extensions/AddAffiliateLocationExtensions.java
@@ -14,9 +14,10 @@
 
 package com.google.ads.googleads.examples.extensions;
 
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
-import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.common.MatchingFunction;
@@ -150,8 +151,7 @@ public class AddAffiliateLocationExtensions {
     // them automatically because this will be a system generated feed.
     Feed feed =
         Feed.newBuilder()
-            .setName(
-                "Affiliate Location Extension feed #" + CodeSampleHelper.getPrintableDatetime())
+            .setName("Affiliate Location Extension feed #" + getPrintableDatetime())
             .setAffiliateLocationFeedData(
                 AffiliateLocationFeedData.newBuilder()
                     .addChainIds(chainId)

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/extensions/AddAffiliateLocationExtensions.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/extensions/AddAffiliateLocationExtensions.java
@@ -14,7 +14,7 @@
 
 package com.google.ads.googleads.examples.extensions;
 
-import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDateTime;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
@@ -151,7 +151,7 @@ public class AddAffiliateLocationExtensions {
     // them automatically because this will be a system generated feed.
     Feed feed =
         Feed.newBuilder()
-            .setName("Affiliate Location Extension feed #" + getPrintableDatetime())
+            .setName("Affiliate Location Extension feed #" + getPrintableDateTime())
             .setAffiliateLocationFeedData(
                 AffiliateLocationFeedData.newBuilder()
                     .addChainIds(chainId)

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/extensions/AddAffiliateLocationExtensions.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/extensions/AddAffiliateLocationExtensions.java
@@ -150,7 +150,8 @@ public class AddAffiliateLocationExtensions {
     // them automatically because this will be a system generated feed.
     Feed feed =
         Feed.newBuilder()
-            .setName("Affiliate Location Extension feed #" + CodeSampleHelper.getPrintableDatetime())
+            .setName(
+                "Affiliate Location Extension feed #" + CodeSampleHelper.getPrintableDatetime())
             .setAffiliateLocationFeedData(
                 AffiliateLocationFeedData.newBuilder()
                     .addChainIds(chainId)

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/extensions/AddAffiliateLocationExtensions.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/extensions/AddAffiliateLocationExtensions.java
@@ -16,6 +16,7 @@ package com.google.ads.googleads.examples.extensions;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
+import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.common.MatchingFunction;
@@ -149,7 +150,7 @@ public class AddAffiliateLocationExtensions {
     // them automatically because this will be a system generated feed.
     Feed feed =
         Feed.newBuilder()
-            .setName("Affiliate Location Extension feed #" + System.currentTimeMillis())
+            .setName("Affiliate Location Extension feed #" + CodeSampleHelper.getPrintableDatetime())
             .setAffiliateLocationFeedData(
                 AffiliateLocationFeedData.newBuilder()
                     .addChainIds(chainId)

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/extensions/AddGoogleMyBusinessLocationExtensions.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/extensions/AddGoogleMyBusinessLocationExtensions.java
@@ -14,7 +14,7 @@
 
 package com.google.ads.googleads.examples.extensions;
 
-import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDateTime;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
@@ -167,7 +167,7 @@ public class AddGoogleMyBusinessLocationExtensions {
     // feed.
     Feed.Builder gmbFeed =
         Feed.newBuilder()
-            .setName("Google My Business feed #" + getPrintableDatetime())
+            .setName("Google My Business feed #" + getPrintableDateTime())
             // Configures the location feed populated from Google My Business Locations.
             .setPlacesLocationFeedData(placesLocationFeedData)
             // Since this feed's feed items will be managed by Google,

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/extensions/AddGoogleMyBusinessLocationExtensions.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/extensions/AddGoogleMyBusinessLocationExtensions.java
@@ -14,9 +14,10 @@
 
 package com.google.ads.googleads.examples.extensions;
 
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
-import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.common.MatchingFunction;
@@ -166,7 +167,7 @@ public class AddGoogleMyBusinessLocationExtensions {
     // feed.
     Feed.Builder gmbFeed =
         Feed.newBuilder()
-            .setName("Google My Business feed #" + CodeSampleHelper.getPrintableDatetime())
+            .setName("Google My Business feed #" + getPrintableDatetime())
             // Configures the location feed populated from Google My Business Locations.
             .setPlacesLocationFeedData(placesLocationFeedData)
             // Since this feed's feed items will be managed by Google,

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/extensions/AddGoogleMyBusinessLocationExtensions.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/extensions/AddGoogleMyBusinessLocationExtensions.java
@@ -16,6 +16,7 @@ package com.google.ads.googleads.examples.extensions;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
+import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.common.MatchingFunction;
@@ -165,7 +166,7 @@ public class AddGoogleMyBusinessLocationExtensions {
     // feed.
     Feed.Builder gmbFeed =
         Feed.newBuilder()
-            .setName("Google My Business feed #" + System.currentTimeMillis())
+            .setName("Google My Business feed #" + CodeSampleHelper.getPrintableDatetime())
             // Configures the location feed populated from Google My Business Locations.
             .setPlacesLocationFeedData(placesLocationFeedData)
             // Since this feed's feed items will be managed by Google,

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/extensions/AddLeadFormExtension.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/extensions/AddLeadFormExtension.java
@@ -16,6 +16,7 @@ package com.google.ads.googleads.examples.extensions;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
+import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.common.LeadFormAsset;
@@ -123,7 +124,7 @@ public class AddLeadFormExtension {
     // Creates the lead form asset.
     Asset leadFormAsset =
         Asset.newBuilder()
-            .setName("Interplanetary Cruise #" + System.currentTimeMillis() + " Lead Form")
+            .setName("Interplanetary Cruise #" + CodeSampleHelper.getPrintableDatetime() + " Lead Form")
             .setLeadFormAsset(
                 LeadFormAsset.newBuilder()
                     // Specify the details of the extension that the users will see.

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/extensions/AddLeadFormExtension.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/extensions/AddLeadFormExtension.java
@@ -14,9 +14,10 @@
 
 package com.google.ads.googleads.examples.extensions;
 
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
-import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.common.LeadFormAsset;
@@ -123,8 +124,7 @@ public class AddLeadFormExtension {
     // Creates the lead form asset.
     Asset leadFormAsset =
         Asset.newBuilder()
-            .setName(
-                "Interplanetary Cruise #" + CodeSampleHelper.getPrintableDatetime() + " Lead Form")
+            .setName("Interplanetary Cruise #" + getPrintableDatetime() + " Lead Form")
             .setLeadFormAsset(
                 LeadFormAsset.newBuilder()
                     // Specify the details of the extension that the users will see.

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/extensions/AddLeadFormExtension.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/extensions/AddLeadFormExtension.java
@@ -14,7 +14,7 @@
 
 package com.google.ads.googleads.examples.extensions;
 
-import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDateTime;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
@@ -124,7 +124,7 @@ public class AddLeadFormExtension {
     // Creates the lead form asset.
     Asset leadFormAsset =
         Asset.newBuilder()
-            .setName("Interplanetary Cruise #" + getPrintableDatetime() + " Lead Form")
+            .setName("Interplanetary Cruise #" + getPrintableDateTime() + " Lead Form")
             .setLeadFormAsset(
                 LeadFormAsset.newBuilder()
                     // Specify the details of the extension that the users will see.

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/extensions/AddLeadFormExtension.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/extensions/AddLeadFormExtension.java
@@ -25,7 +25,6 @@ import com.google.ads.googleads.v6.common.LeadFormField;
 import com.google.ads.googleads.v6.common.LeadFormSingleChoiceAnswers;
 import com.google.ads.googleads.v6.common.WebhookDelivery;
 import com.google.ads.googleads.v6.enums.AssetFieldTypeEnum.AssetFieldType;
-import com.google.ads.googleads.v6.enums.AssetLinkStatusEnum.AssetLinkStatus;
 import com.google.ads.googleads.v6.enums.LeadFormCallToActionTypeEnum.LeadFormCallToActionType;
 import com.google.ads.googleads.v6.enums.LeadFormFieldUserInputTypeEnum.LeadFormFieldUserInputType;
 import com.google.ads.googleads.v6.enums.LeadFormPostSubmitCallToActionTypeEnum.LeadFormPostSubmitCallToActionType;
@@ -124,7 +123,8 @@ public class AddLeadFormExtension {
     // Creates the lead form asset.
     Asset leadFormAsset =
         Asset.newBuilder()
-            .setName("Interplanetary Cruise #" + CodeSampleHelper.getPrintableDatetime() + " Lead Form")
+            .setName(
+                "Interplanetary Cruise #" + CodeSampleHelper.getPrintableDatetime() + " Lead Form")
             .setLeadFormAsset(
                 LeadFormAsset.newBuilder()
                     // Specify the details of the extension that the users will see.
@@ -165,7 +165,7 @@ public class AddLeadFormExtension {
 
                     // Optional: You can also specify a background image asset.
                     // To upload an asset, see Misc/UploadImageAsset.java.
-                    //.setBackgroundImageAsset("INSERT_IMAGE_ASSET_HERE")
+                    // .setBackgroundImageAsset("INSERT_IMAGE_ASSET_HERE")
 
                     // Optional: Define the response page after the user signs up on the form.
                     .setPostSubmitHeadline("Thanks for signing up!")

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/extensions/AddSitelinksUsingFeeds.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/extensions/AddSitelinksUsingFeeds.java
@@ -16,6 +16,7 @@ package com.google.ads.googleads.examples.extensions;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
+import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.common.MatchingFunction;
@@ -160,7 +161,7 @@ public class AddSitelinksUsingFeeds {
     // Creates the feed.
     Feed feed =
         Feed.newBuilder()
-            .setName("Sitelinks Feed #" + System.currentTimeMillis())
+            .setName("Sitelinks Feed #" + CodeSampleHelper.getPrintableDatetime())
             .setOrigin(FeedOrigin.USER)
             // Specifies the column name and data type. This is just raw data at this point
             // and not yet linked to any particular purpose. The names are used to help us

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/extensions/AddSitelinksUsingFeeds.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/extensions/AddSitelinksUsingFeeds.java
@@ -14,9 +14,10 @@
 
 package com.google.ads.googleads.examples.extensions;
 
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
-import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.common.MatchingFunction;
@@ -161,7 +162,7 @@ public class AddSitelinksUsingFeeds {
     // Creates the feed.
     Feed feed =
         Feed.newBuilder()
-            .setName("Sitelinks Feed #" + CodeSampleHelper.getPrintableDatetime())
+            .setName("Sitelinks Feed #" + getPrintableDatetime())
             .setOrigin(FeedOrigin.USER)
             // Specifies the column name and data type. This is just raw data at this point
             // and not yet linked to any particular purpose. The names are used to help us

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/extensions/AddSitelinksUsingFeeds.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/extensions/AddSitelinksUsingFeeds.java
@@ -14,7 +14,7 @@
 
 package com.google.ads.googleads.examples.extensions;
 
-import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDateTime;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
@@ -162,7 +162,7 @@ public class AddSitelinksUsingFeeds {
     // Creates the feed.
     Feed feed =
         Feed.newBuilder()
-            .setName("Sitelinks Feed #" + getPrintableDatetime())
+            .setName("Sitelinks Feed #" + getPrintableDateTime())
             .setOrigin(FeedOrigin.USER)
             // Specifies the column name and data type. This is just raw data at this point
             // and not yet linked to any particular purpose. The names are used to help us

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/extensions/UpdateSitelink.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/extensions/UpdateSitelink.java
@@ -32,9 +32,7 @@ import com.google.common.collect.ImmutableList;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 
-/**
- * Updates a sitelink extension feed item {@code SitelinkFeedItem} with the specified link text.
- */
+/** Updates a sitelink extension feed item {@code SitelinkFeedItem} with the specified link text. */
 public class UpdateSitelink {
 
   private static class UpdateSitelinkParams extends CodeSampleParams {

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/feeds/CreateFeedItemSet.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/feeds/CreateFeedItemSet.java
@@ -14,9 +14,10 @@
 
 package com.google.ads.googleads.examples.feeds;
 
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
-import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.errors.GoogleAdsError;
@@ -98,7 +99,7 @@ public class CreateFeedItemSet {
     FeedItemSet.Builder feedItemSetBuilder =
         FeedItemSet.newBuilder()
             .setFeed(ResourceNames.feed(customerId, feedId))
-            .setDisplayName("Feed Item Set #" + CodeSampleHelper.getPrintableDatetime());
+            .setDisplayName("Feed Item Set #" + getPrintableDatetime());
 
     // A feed item set can be created as a dynamic set by setting an optional filter field
     // below. If your feed is a location extension, uncomment the code that calls

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/feeds/CreateFeedItemSet.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/feeds/CreateFeedItemSet.java
@@ -14,7 +14,7 @@
 
 package com.google.ads.googleads.examples.feeds;
 
-import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDateTime;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
@@ -99,7 +99,7 @@ public class CreateFeedItemSet {
     FeedItemSet.Builder feedItemSetBuilder =
         FeedItemSet.newBuilder()
             .setFeed(ResourceNames.feed(customerId, feedId))
-            .setDisplayName("Feed Item Set #" + getPrintableDatetime());
+            .setDisplayName("Feed Item Set #" + getPrintableDateTime());
 
     // A feed item set can be created as a dynamic set by setting an optional filter field
     // below. If your feed is a location extension, uncomment the code that calls

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/feeds/CreateFeedItemSet.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/feeds/CreateFeedItemSet.java
@@ -16,6 +16,7 @@ package com.google.ads.googleads.examples.feeds;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
+import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.errors.GoogleAdsError;
@@ -97,7 +98,7 @@ public class CreateFeedItemSet {
     FeedItemSet.Builder feedItemSetBuilder =
         FeedItemSet.newBuilder()
             .setFeed(ResourceNames.feed(customerId, feedId))
-            .setDisplayName("Feed Item Set #" + System.currentTimeMillis());
+            .setDisplayName("Feed Item Set #" + CodeSampleHelper.getPrintableDatetime());
 
     // A feed item set can be created as a dynamic set by setting an optional filter field
     // below. If your feed is a location extension, uncomment the code that calls

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/hotelads/AddHotelAd.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/hotelads/AddHotelAd.java
@@ -14,7 +14,7 @@
 
 package com.google.ads.googleads.examples.hotelads;
 
-import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDateTime;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
@@ -170,7 +170,7 @@ public class AddHotelAd {
   private String addCampaignBudget(GoogleAdsClient googleAdsClient, long customerId) {
     CampaignBudget budget =
         CampaignBudget.newBuilder()
-            .setName("Interplanetary Cruise Budget #" + getPrintableDatetime())
+            .setName("Interplanetary Cruise Budget #" + getPrintableDateTime())
             .setDeliveryMethod(BudgetDeliveryMethod.STANDARD)
             .setAmountMicros(5_000_000)
             .build();
@@ -220,7 +220,7 @@ public class AddHotelAd {
     // Creates the campaign.
     Campaign campaign =
         Campaign.newBuilder()
-            .setName("Interplanetary Cruise #" + getPrintableDatetime())
+            .setName("Interplanetary Cruise #" + getPrintableDateTime())
             // Configures settings related to hotel campaigns including advertising channel type
             // and hotel setting info.
             .setAdvertisingChannelType(AdvertisingChannelType.HOTEL)
@@ -272,7 +272,7 @@ public class AddHotelAd {
     // Creates an ad group.
     AdGroup adGroup =
         AdGroup.newBuilder()
-            .setName("Earth to Mars Cruises #" + getPrintableDatetime())
+            .setName("Earth to Mars Cruises #" + getPrintableDateTime())
             .setCampaign(campaignResourceName)
             // Sets the ad group type to HOTEL_ADS. This cannot be set to other types.
             .setType(AdGroupType.HOTEL_ADS)

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/hotelads/AddHotelAd.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/hotelads/AddHotelAd.java
@@ -14,9 +14,10 @@
 
 package com.google.ads.googleads.examples.hotelads;
 
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
-import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.common.HotelAdInfo;
@@ -169,7 +170,7 @@ public class AddHotelAd {
   private String addCampaignBudget(GoogleAdsClient googleAdsClient, long customerId) {
     CampaignBudget budget =
         CampaignBudget.newBuilder()
-            .setName("Interplanetary Cruise Budget #" + CodeSampleHelper.getPrintableDatetime())
+            .setName("Interplanetary Cruise Budget #" + getPrintableDatetime())
             .setDeliveryMethod(BudgetDeliveryMethod.STANDARD)
             .setAmountMicros(5_000_000)
             .build();
@@ -219,7 +220,7 @@ public class AddHotelAd {
     // Creates the campaign.
     Campaign campaign =
         Campaign.newBuilder()
-            .setName("Interplanetary Cruise #" + CodeSampleHelper.getPrintableDatetime())
+            .setName("Interplanetary Cruise #" + getPrintableDatetime())
             // Configures settings related to hotel campaigns including advertising channel type
             // and hotel setting info.
             .setAdvertisingChannelType(AdvertisingChannelType.HOTEL)
@@ -271,7 +272,7 @@ public class AddHotelAd {
     // Creates an ad group.
     AdGroup adGroup =
         AdGroup.newBuilder()
-            .setName("Earth to Mars Cruises #" + CodeSampleHelper.getPrintableDatetime())
+            .setName("Earth to Mars Cruises #" + getPrintableDatetime())
             .setCampaign(campaignResourceName)
             // Sets the ad group type to HOTEL_ADS. This cannot be set to other types.
             .setType(AdGroupType.HOTEL_ADS)

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/hotelads/AddHotelAd.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/hotelads/AddHotelAd.java
@@ -16,6 +16,7 @@ package com.google.ads.googleads.examples.hotelads;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
+import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.common.HotelAdInfo;
@@ -168,7 +169,7 @@ public class AddHotelAd {
   private String addCampaignBudget(GoogleAdsClient googleAdsClient, long customerId) {
     CampaignBudget budget =
         CampaignBudget.newBuilder()
-            .setName("Interplanetary Cruise Budget #" + System.currentTimeMillis())
+            .setName("Interplanetary Cruise Budget #" + CodeSampleHelper.getPrintableDatetime())
             .setDeliveryMethod(BudgetDeliveryMethod.STANDARD)
             .setAmountMicros(5_000_000)
             .build();
@@ -218,7 +219,7 @@ public class AddHotelAd {
     // Creates the campaign.
     Campaign campaign =
         Campaign.newBuilder()
-            .setName("Interplanetary Cruise #" + System.currentTimeMillis())
+            .setName("Interplanetary Cruise #" + CodeSampleHelper.getPrintableDatetime())
             // Configures settings related to hotel campaigns including advertising channel type
             // and hotel setting info.
             .setAdvertisingChannelType(AdvertisingChannelType.HOTEL)
@@ -270,7 +271,7 @@ public class AddHotelAd {
     // Creates an ad group.
     AdGroup adGroup =
         AdGroup.newBuilder()
-            .setName("Earth to Mars Cruises #" + System.currentTimeMillis())
+            .setName("Earth to Mars Cruises #" + CodeSampleHelper.getPrintableDatetime())
             .setCampaign(campaignResourceName)
             // Sets the ad group type to HOTEL_ADS. This cannot be set to other types.
             .setType(AdGroupType.HOTEL_ADS)

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/misc/UploadImageAsset.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/misc/UploadImageAsset.java
@@ -104,7 +104,7 @@ public class UploadImageAsset {
             // If you specify the name field, then both the asset name and the image being
             // uploaded should be unique, and should not match another ACTIVE asset in this
             // customer account.
-            // .setName("Jupiter Trip # " + getPrintableDatetime())
+            // .setName("Jupiter Trip # " + getPrintableDateTime())
             .setType(AssetType.IMAGE)
             .setImageAsset(imageAsset)
             .build();

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/misc/UploadImageAsset.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/misc/UploadImageAsset.java
@@ -104,7 +104,7 @@ public class UploadImageAsset {
             // If you specify the name field, then both the asset name and the image being
             // uploaded should be unique, and should not match another ACTIVE asset in this
             // customer account.
-            // .setName("Jupiter Trip # " + System.currentTimeMillis())
+            // .setName("Jupiter Trip # " + CodeSampleHelper.getPrintableDatetime())
             .setType(AssetType.IMAGE)
             .setImageAsset(imageAsset)
             .build();

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/misc/UploadImageAsset.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/misc/UploadImageAsset.java
@@ -104,7 +104,7 @@ public class UploadImageAsset {
             // If you specify the name field, then both the asset name and the image being
             // uploaded should be unique, and should not match another ACTIVE asset in this
             // customer account.
-            // .setName("Jupiter Trip # " + CodeSampleHelper.getPrintableDatetime())
+            // .setName("Jupiter Trip # " + getPrintableDatetime())
             .setType(AssetType.IMAGE)
             .setImageAsset(imageAsset)
             .build();

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/planning/AddKeywordPlan.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/planning/AddKeywordPlan.java
@@ -16,6 +16,7 @@ package com.google.ads.googleads.examples.planning;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
+import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.enums.KeywordMatchTypeEnum.KeywordMatchType;
@@ -130,7 +131,7 @@ public class AddKeywordPlan {
   private static String createKeywordPlan(GoogleAdsClient googleAdsClient, Long customerId) {
     KeywordPlan plan =
         KeywordPlan.newBuilder()
-            .setName("Keyword plan for traffic estimate #" + System.currentTimeMillis())
+            .setName("Keyword plan for traffic estimate #" + CodeSampleHelper.getPrintableDatetime())
             .setForecastPeriod(
                 KeywordPlanForecastPeriod.newBuilder()
                     .setDateInterval(KeywordPlanForecastInterval.NEXT_QUARTER)
@@ -164,7 +165,7 @@ public class AddKeywordPlan {
     // Creates a keyword plan campaign.
     KeywordPlanCampaign.Builder campaign =
         KeywordPlanCampaign.newBuilder()
-            .setName("Keyword plan campaign #" + System.currentTimeMillis())
+            .setName("Keyword plan campaign #" + CodeSampleHelper.getPrintableDatetime())
             .setCpcBidMicros(1_000_000L)
             .setKeywordPlanNetwork(KeywordPlanNetwork.GOOGLE_SEARCH)
             .setKeywordPlan(keywordPlanResource);
@@ -212,7 +213,7 @@ public class AddKeywordPlan {
     KeywordPlanAdGroup.Builder adGroup =
         KeywordPlanAdGroup.newBuilder()
             .setKeywordPlanCampaign(planCampaignResource)
-            .setName("Keyword plan ad group #" + System.currentTimeMillis())
+            .setName("Keyword plan ad group #" + CodeSampleHelper.getPrintableDatetime())
             .setCpcBidMicros(2_500_000L);
 
     KeywordPlanAdGroupOperation op =

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/planning/AddKeywordPlan.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/planning/AddKeywordPlan.java
@@ -131,7 +131,8 @@ public class AddKeywordPlan {
   private static String createKeywordPlan(GoogleAdsClient googleAdsClient, Long customerId) {
     KeywordPlan plan =
         KeywordPlan.newBuilder()
-            .setName("Keyword plan for traffic estimate #" + CodeSampleHelper.getPrintableDatetime())
+            .setName(
+                "Keyword plan for traffic estimate #" + CodeSampleHelper.getPrintableDatetime())
             .setForecastPeriod(
                 KeywordPlanForecastPeriod.newBuilder()
                     .setDateInterval(KeywordPlanForecastInterval.NEXT_QUARTER)

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/planning/AddKeywordPlan.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/planning/AddKeywordPlan.java
@@ -14,7 +14,7 @@
 
 package com.google.ads.googleads.examples.planning;
 
-import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDateTime;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
@@ -132,7 +132,7 @@ public class AddKeywordPlan {
   private static String createKeywordPlan(GoogleAdsClient googleAdsClient, Long customerId) {
     KeywordPlan plan =
         KeywordPlan.newBuilder()
-            .setName("Keyword plan for traffic estimate #" + getPrintableDatetime())
+            .setName("Keyword plan for traffic estimate #" + getPrintableDateTime())
             .setForecastPeriod(
                 KeywordPlanForecastPeriod.newBuilder()
                     .setDateInterval(KeywordPlanForecastInterval.NEXT_QUARTER)
@@ -166,7 +166,7 @@ public class AddKeywordPlan {
     // Creates a keyword plan campaign.
     KeywordPlanCampaign.Builder campaign =
         KeywordPlanCampaign.newBuilder()
-            .setName("Keyword plan campaign #" + getPrintableDatetime())
+            .setName("Keyword plan campaign #" + getPrintableDateTime())
             .setCpcBidMicros(1_000_000L)
             .setKeywordPlanNetwork(KeywordPlanNetwork.GOOGLE_SEARCH)
             .setKeywordPlan(keywordPlanResource);
@@ -214,7 +214,7 @@ public class AddKeywordPlan {
     KeywordPlanAdGroup.Builder adGroup =
         KeywordPlanAdGroup.newBuilder()
             .setKeywordPlanCampaign(planCampaignResource)
-            .setName("Keyword plan ad group #" + getPrintableDatetime())
+            .setName("Keyword plan ad group #" + getPrintableDateTime())
             .setCpcBidMicros(2_500_000L);
 
     KeywordPlanAdGroupOperation op =

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/planning/AddKeywordPlan.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/planning/AddKeywordPlan.java
@@ -14,9 +14,10 @@
 
 package com.google.ads.googleads.examples.planning;
 
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
-import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.enums.KeywordMatchTypeEnum.KeywordMatchType;
@@ -131,8 +132,7 @@ public class AddKeywordPlan {
   private static String createKeywordPlan(GoogleAdsClient googleAdsClient, Long customerId) {
     KeywordPlan plan =
         KeywordPlan.newBuilder()
-            .setName(
-                "Keyword plan for traffic estimate #" + CodeSampleHelper.getPrintableDatetime())
+            .setName("Keyword plan for traffic estimate #" + getPrintableDatetime())
             .setForecastPeriod(
                 KeywordPlanForecastPeriod.newBuilder()
                     .setDateInterval(KeywordPlanForecastInterval.NEXT_QUARTER)
@@ -166,7 +166,7 @@ public class AddKeywordPlan {
     // Creates a keyword plan campaign.
     KeywordPlanCampaign.Builder campaign =
         KeywordPlanCampaign.newBuilder()
-            .setName("Keyword plan campaign #" + CodeSampleHelper.getPrintableDatetime())
+            .setName("Keyword plan campaign #" + getPrintableDatetime())
             .setCpcBidMicros(1_000_000L)
             .setKeywordPlanNetwork(KeywordPlanNetwork.GOOGLE_SEARCH)
             .setKeywordPlan(keywordPlanResource);
@@ -214,7 +214,7 @@ public class AddKeywordPlan {
     KeywordPlanAdGroup.Builder adGroup =
         KeywordPlanAdGroup.newBuilder()
             .setKeywordPlanCampaign(planCampaignResource)
-            .setName("Keyword plan ad group #" + CodeSampleHelper.getPrintableDatetime())
+            .setName("Keyword plan ad group #" + getPrintableDatetime())
             .setCpcBidMicros(2_500_000L);
 
     KeywordPlanAdGroupOperation op =

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/AddCombinedRuleUserList.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/AddCombinedRuleUserList.java
@@ -14,7 +14,7 @@
 
 package com.google.ads.googleads.examples.remarketing;
 
-import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDateTime;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
@@ -166,7 +166,7 @@ public class AddCombinedRuleUserList {
         UserList.newBuilder()
             .setName(
                 "All visitors to http://example.com/example1 AND http://example.com/example2 #"
-                    + getPrintableDatetime())
+                    + getPrintableDateTime())
             .setDescription(
                 "Visitors of both http://example.com/example1 AND http://example.com/example2")
             .setMembershipStatus(UserListMembershipStatus.OPEN)

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/AddCombinedRuleUserList.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/AddCombinedRuleUserList.java
@@ -14,9 +14,10 @@
 
 package com.google.ads.googleads.examples.remarketing;
 
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
-import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.common.CombinedRuleUserListInfo;
@@ -165,7 +166,7 @@ public class AddCombinedRuleUserList {
         UserList.newBuilder()
             .setName(
                 "All visitors to http://example.com/example1 AND http://example.com/example2 #"
-                    + CodeSampleHelper.getPrintableDatetime())
+                    + getPrintableDatetime())
             .setDescription(
                 "Visitors of both http://example.com/example1 AND http://example.com/example2")
             .setMembershipStatus(UserListMembershipStatus.OPEN)

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/AddCombinedRuleUserList.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/AddCombinedRuleUserList.java
@@ -16,6 +16,7 @@ package com.google.ads.googleads.examples.remarketing;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
+import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.common.CombinedRuleUserListInfo;
@@ -164,7 +165,7 @@ public class AddCombinedRuleUserList {
         UserList.newBuilder()
             .setName(
                 "All visitors to http://example.com/example1 AND http://example.com/example2 #"
-                    + System.currentTimeMillis())
+                    + CodeSampleHelper.getPrintableDatetime())
             .setDescription(
                 "Visitors of both http://example.com/example1 AND http://example.com/example2")
             .setMembershipStatus(UserListMembershipStatus.OPEN)

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/AddConversionAction.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/AddConversionAction.java
@@ -14,7 +14,7 @@
 
 package com.google.ads.googleads.examples.remarketing;
 
-import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDateTime;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
@@ -96,7 +96,7 @@ public class AddConversionAction {
     // Creates a ConversionAction.
     ConversionAction conversionAction =
         ConversionAction.newBuilder()
-            .setName("Earth to Mars Cruises Conversion #" + getPrintableDatetime())
+            .setName("Earth to Mars Cruises Conversion #" + getPrintableDateTime())
             .setCategory(ConversionActionCategory.DEFAULT)
             .setType(ConversionActionType.WEBPAGE)
             .setStatus(ConversionActionStatus.ENABLED)

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/AddConversionAction.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/AddConversionAction.java
@@ -16,6 +16,7 @@ package com.google.ads.googleads.examples.remarketing;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
+import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.enums.ConversionActionCategoryEnum.ConversionActionCategory;
@@ -94,7 +95,7 @@ public class AddConversionAction {
     // Creates a ConversionAction.
     ConversionAction conversionAction =
         ConversionAction.newBuilder()
-            .setName("Earth to Mars Cruises Conversion #" + System.currentTimeMillis())
+            .setName("Earth to Mars Cruises Conversion #" + CodeSampleHelper.getPrintableDatetime())
             .setCategory(ConversionActionCategory.DEFAULT)
             .setType(ConversionActionType.WEBPAGE)
             .setStatus(ConversionActionStatus.ENABLED)

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/AddConversionAction.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/AddConversionAction.java
@@ -14,9 +14,10 @@
 
 package com.google.ads.googleads.examples.remarketing;
 
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
-import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.enums.ConversionActionCategoryEnum.ConversionActionCategory;
@@ -95,7 +96,7 @@ public class AddConversionAction {
     // Creates a ConversionAction.
     ConversionAction conversionAction =
         ConversionAction.newBuilder()
-            .setName("Earth to Mars Cruises Conversion #" + CodeSampleHelper.getPrintableDatetime())
+            .setName("Earth to Mars Cruises Conversion #" + getPrintableDatetime())
             .setCategory(ConversionActionCategory.DEFAULT)
             .setType(ConversionActionType.WEBPAGE)
             .setStatus(ConversionActionStatus.ENABLED)

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/AddConversionBasedUserList.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/AddConversionBasedUserList.java
@@ -14,9 +14,10 @@
 
 package com.google.ads.googleads.examples.remarketing;
 
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
-import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.common.BasicUserListInfo;
@@ -120,7 +121,7 @@ public class AddConversionBasedUserList {
     // Creates the basic user list.
     UserList basicUserList =
         UserList.newBuilder()
-            .setName("Example BasicUserList #" + CodeSampleHelper.getPrintableDatetime())
+            .setName("Example BasicUserList #" + getPrintableDatetime())
             .setDescription("A list of people who have triggered one or more conversion actions")
             .setMembershipLifeSpan(365)
             .setBasicUserList(basicUserListInfo)

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/AddConversionBasedUserList.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/AddConversionBasedUserList.java
@@ -16,6 +16,7 @@ package com.google.ads.googleads.examples.remarketing;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
+import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.common.BasicUserListInfo;
@@ -119,7 +120,7 @@ public class AddConversionBasedUserList {
     // Creates the basic user list.
     UserList basicUserList =
         UserList.newBuilder()
-            .setName("Example BasicUserList #" + System.currentTimeMillis())
+            .setName("Example BasicUserList #" + CodeSampleHelper.getPrintableDatetime())
             .setDescription("A list of people who have triggered one or more conversion actions")
             .setMembershipLifeSpan(365)
             .setBasicUserList(basicUserListInfo)

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/AddConversionBasedUserList.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/AddConversionBasedUserList.java
@@ -14,7 +14,7 @@
 
 package com.google.ads.googleads.examples.remarketing;
 
-import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDateTime;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
@@ -121,7 +121,7 @@ public class AddConversionBasedUserList {
     // Creates the basic user list.
     UserList basicUserList =
         UserList.newBuilder()
-            .setName("Example BasicUserList #" + getPrintableDatetime())
+            .setName("Example BasicUserList #" + getPrintableDateTime())
             .setDescription("A list of people who have triggered one or more conversion actions")
             .setMembershipLifeSpan(365)
             .setBasicUserList(basicUserListInfo)

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/AddCustomerMatchUserList.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/AddCustomerMatchUserList.java
@@ -14,9 +14,10 @@
 
 package com.google.ads.googleads.examples.remarketing;
 
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
-import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.common.CrmBasedUserListInfo;
@@ -142,7 +143,7 @@ public class AddCustomerMatchUserList {
     // Creates the new user list.
     UserList userList =
         UserList.newBuilder()
-            .setName("Customer Match list #" + CodeSampleHelper.getPrintableDatetime())
+            .setName("Customer Match list #" + getPrintableDatetime())
             .setDescription("A list of customers that originated from email addresses")
             // Customer Match user lists can use a membership life span of 10,000 to indicate
             // unlimited; otherwise normal values apply.

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/AddCustomerMatchUserList.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/AddCustomerMatchUserList.java
@@ -14,7 +14,7 @@
 
 package com.google.ads.googleads.examples.remarketing;
 
-import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDateTime;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
@@ -143,7 +143,7 @@ public class AddCustomerMatchUserList {
     // Creates the new user list.
     UserList userList =
         UserList.newBuilder()
-            .setName("Customer Match list #" + getPrintableDatetime())
+            .setName("Customer Match list #" + getPrintableDateTime())
             .setDescription("A list of customers that originated from email addresses")
             // Customer Match user lists can use a membership life span of 10,000 to indicate
             // unlimited; otherwise normal values apply.

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/AddCustomerMatchUserList.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/AddCustomerMatchUserList.java
@@ -16,6 +16,7 @@ package com.google.ads.googleads.examples.remarketing;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
+import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.common.CrmBasedUserListInfo;
@@ -141,7 +142,7 @@ public class AddCustomerMatchUserList {
     // Creates the new user list.
     UserList userList =
         UserList.newBuilder()
-            .setName("Customer Match list #" + System.currentTimeMillis())
+            .setName("Customer Match list #" + CodeSampleHelper.getPrintableDatetime())
             .setDescription("A list of customers that originated from email addresses")
             // Customer Match user lists can use a membership life span of 10,000 to indicate
             // unlimited; otherwise normal values apply.

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/AddExpressionRuleUserList.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/AddExpressionRuleUserList.java
@@ -14,7 +14,7 @@
 
 package com.google.ads.googleads.examples.remarketing;
 
-import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDateTime;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
@@ -157,7 +157,7 @@ public class AddExpressionRuleUserList {
         UserList.newBuilder()
             .setName(
                 "All visitors to example.com/section1 AND example.com/section2 #"
-                    + getPrintableDatetime())
+                    + getPrintableDateTime())
             .setDescription("Visitors of both example.com/section1 AND example.com/section2")
             .setMembershipStatus(UserListMembershipStatus.OPEN)
             .setMembershipLifeSpan(365)

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/AddExpressionRuleUserList.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/AddExpressionRuleUserList.java
@@ -14,9 +14,10 @@
 
 package com.google.ads.googleads.examples.remarketing;
 
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
-import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.common.ExpressionRuleUserListInfo;
@@ -156,7 +157,7 @@ public class AddExpressionRuleUserList {
         UserList.newBuilder()
             .setName(
                 "All visitors to example.com/section1 AND example.com/section2 #"
-                    + CodeSampleHelper.getPrintableDatetime())
+                    + getPrintableDatetime())
             .setDescription("Visitors of both example.com/section1 AND example.com/section2")
             .setMembershipStatus(UserListMembershipStatus.OPEN)
             .setMembershipLifeSpan(365)

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/AddExpressionRuleUserList.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/AddExpressionRuleUserList.java
@@ -16,6 +16,7 @@ package com.google.ads.googleads.examples.remarketing;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
+import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.common.ExpressionRuleUserListInfo;
@@ -155,7 +156,7 @@ public class AddExpressionRuleUserList {
         UserList.newBuilder()
             .setName(
                 "All visitors to example.com/section1 AND example.com/section2 #"
-                    + System.currentTimeMillis())
+                    + CodeSampleHelper.getPrintableDatetime())
             .setDescription("Visitors of both example.com/section1 AND example.com/section2")
             .setMembershipStatus(UserListMembershipStatus.OPEN)
             .setMembershipLifeSpan(365)

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/AddFlightsFeed.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/AddFlightsFeed.java
@@ -16,6 +16,7 @@ package com.google.ads.googleads.examples.remarketing;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
+import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.enums.FeedAttributeTypeEnum.FeedAttributeType;
@@ -162,7 +163,7 @@ public class AddFlightsFeed {
     // Creates the feed.
     Feed feed =
         Feed.newBuilder()
-            .setName("Flights Feed #" + System.currentTimeMillis())
+            .setName("Flights Feed #" + CodeSampleHelper.getPrintableDatetime())
             .addAttributes(flightDescriptionAttribute)
             .addAttributes(destinationIdAttribute)
             .addAttributes(flightPriceAttribute)

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/AddFlightsFeed.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/AddFlightsFeed.java
@@ -14,7 +14,7 @@
 
 package com.google.ads.googleads.examples.remarketing;
 
-import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDateTime;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
@@ -164,7 +164,7 @@ public class AddFlightsFeed {
     // Creates the feed.
     Feed feed =
         Feed.newBuilder()
-            .setName("Flights Feed #" + getPrintableDatetime())
+            .setName("Flights Feed #" + getPrintableDateTime())
             .addAttributes(flightDescriptionAttribute)
             .addAttributes(destinationIdAttribute)
             .addAttributes(flightPriceAttribute)

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/AddFlightsFeed.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/AddFlightsFeed.java
@@ -14,9 +14,10 @@
 
 package com.google.ads.googleads.examples.remarketing;
 
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
-import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.enums.FeedAttributeTypeEnum.FeedAttributeType;
@@ -163,7 +164,7 @@ public class AddFlightsFeed {
     // Creates the feed.
     Feed feed =
         Feed.newBuilder()
-            .setName("Flights Feed #" + CodeSampleHelper.getPrintableDatetime())
+            .setName("Flights Feed #" + getPrintableDatetime())
             .addAttributes(flightDescriptionAttribute)
             .addAttributes(destinationIdAttribute)
             .addAttributes(flightPriceAttribute)

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/AddLogicalUserList.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/AddLogicalUserList.java
@@ -14,7 +14,7 @@
 
 package com.google.ads.googleads.examples.remarketing;
 
-import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDateTime;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
@@ -131,7 +131,7 @@ public class AddLogicalUserList {
     // Creates the new combination user list.
     UserList userList =
         UserList.newBuilder()
-            .setName("My combination list of other user lists #" + getPrintableDatetime())
+            .setName("My combination list of other user lists #" + getPrintableDateTime())
             .setLogicalUserList(
                 LogicalUserListInfo.newBuilder().addRules(userListLogicalRuleInfo).build())
             .build();

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/AddLogicalUserList.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/AddLogicalUserList.java
@@ -16,6 +16,7 @@ package com.google.ads.googleads.examples.remarketing;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
+import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.common.LogicalUserListInfo;
@@ -129,7 +130,7 @@ public class AddLogicalUserList {
     // Creates the new combination user list.
     UserList userList =
         UserList.newBuilder()
-            .setName("My combination list of other user lists #" + System.currentTimeMillis())
+            .setName("My combination list of other user lists #" + CodeSampleHelper.getPrintableDatetime())
             .setLogicalUserList(
                 LogicalUserListInfo.newBuilder().addRules(userListLogicalRuleInfo).build())
             .build();

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/AddLogicalUserList.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/AddLogicalUserList.java
@@ -130,7 +130,9 @@ public class AddLogicalUserList {
     // Creates the new combination user list.
     UserList userList =
         UserList.newBuilder()
-            .setName("My combination list of other user lists #" + CodeSampleHelper.getPrintableDatetime())
+            .setName(
+                "My combination list of other user lists #"
+                    + CodeSampleHelper.getPrintableDatetime())
             .setLogicalUserList(
                 LogicalUserListInfo.newBuilder().addRules(userListLogicalRuleInfo).build())
             .build();

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/AddLogicalUserList.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/AddLogicalUserList.java
@@ -14,9 +14,10 @@
 
 package com.google.ads.googleads.examples.remarketing;
 
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
-import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.common.LogicalUserListInfo;
@@ -130,9 +131,7 @@ public class AddLogicalUserList {
     // Creates the new combination user list.
     UserList userList =
         UserList.newBuilder()
-            .setName(
-                "My combination list of other user lists #"
-                    + CodeSampleHelper.getPrintableDatetime())
+            .setName("My combination list of other user lists #" + getPrintableDatetime())
             .setLogicalUserList(
                 LogicalUserListInfo.newBuilder().addRules(userListLogicalRuleInfo).build())
             .build();

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/AddMerchantCenterDynamicRemarketingCampaign.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/AddMerchantCenterDynamicRemarketingCampaign.java
@@ -16,6 +16,7 @@ package com.google.ads.googleads.examples.remarketing;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
+import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.common.AdImageAsset;
@@ -170,7 +171,7 @@ public class AddMerchantCenterDynamicRemarketingCampaign {
     // Creates the campaign.
     Campaign campaign =
         Campaign.newBuilder()
-            .setName("Shopping campaign #" + System.currentTimeMillis())
+            .setName("Shopping campaign #" + CodeSampleHelper.getPrintableDatetime())
             // Dynamic remarketing campaigns are only available on the Google Display Network.
             .setAdvertisingChannelType(AdvertisingChannelType.DISPLAY)
             .setStatus(CampaignStatus.PAUSED)

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/AddMerchantCenterDynamicRemarketingCampaign.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/AddMerchantCenterDynamicRemarketingCampaign.java
@@ -14,9 +14,10 @@
 
 package com.google.ads.googleads.examples.remarketing;
 
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
-import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.common.AdImageAsset;
@@ -171,7 +172,7 @@ public class AddMerchantCenterDynamicRemarketingCampaign {
     // Creates the campaign.
     Campaign campaign =
         Campaign.newBuilder()
-            .setName("Shopping campaign #" + CodeSampleHelper.getPrintableDatetime())
+            .setName("Shopping campaign #" + getPrintableDatetime())
             // Dynamic remarketing campaigns are only available on the Google Display Network.
             .setAdvertisingChannelType(AdvertisingChannelType.DISPLAY)
             .setStatus(CampaignStatus.PAUSED)

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/AddMerchantCenterDynamicRemarketingCampaign.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/AddMerchantCenterDynamicRemarketingCampaign.java
@@ -14,7 +14,7 @@
 
 package com.google.ads.googleads.examples.remarketing;
 
-import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDateTime;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
@@ -172,7 +172,7 @@ public class AddMerchantCenterDynamicRemarketingCampaign {
     // Creates the campaign.
     Campaign campaign =
         Campaign.newBuilder()
-            .setName("Shopping campaign #" + getPrintableDatetime())
+            .setName("Shopping campaign #" + getPrintableDateTime())
             // Dynamic remarketing campaigns are only available on the Google Display Network.
             .setAdvertisingChannelType(AdvertisingChannelType.DISPLAY)
             .setStatus(CampaignStatus.PAUSED)

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/AddRealEstateFeed.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/AddRealEstateFeed.java
@@ -16,6 +16,7 @@ package com.google.ads.googleads.examples.remarketing;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
+import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.enums.FeedAttributeTypeEnum.FeedAttributeType;
@@ -161,7 +162,7 @@ public class AddRealEstateFeed {
     // Creates the feed.
     Feed feed =
         Feed.newBuilder()
-            .setName("Real Estate Feed #" + System.currentTimeMillis())
+            .setName("Real Estate Feed #" + CodeSampleHelper.getPrintableDatetime())
             .addAttributes(listingIdAttribute)
             .addAttributes(listingNameAttribute)
             .addAttributes(finalUrlsAttribute)

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/AddRealEstateFeed.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/AddRealEstateFeed.java
@@ -14,9 +14,10 @@
 
 package com.google.ads.googleads.examples.remarketing;
 
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
-import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.enums.FeedAttributeTypeEnum.FeedAttributeType;
@@ -162,7 +163,7 @@ public class AddRealEstateFeed {
     // Creates the feed.
     Feed feed =
         Feed.newBuilder()
-            .setName("Real Estate Feed #" + CodeSampleHelper.getPrintableDatetime())
+            .setName("Real Estate Feed #" + getPrintableDatetime())
             .addAttributes(listingIdAttribute)
             .addAttributes(listingNameAttribute)
             .addAttributes(finalUrlsAttribute)

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/AddRealEstateFeed.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/AddRealEstateFeed.java
@@ -14,7 +14,7 @@
 
 package com.google.ads.googleads.examples.remarketing;
 
-import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDateTime;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
@@ -163,7 +163,7 @@ public class AddRealEstateFeed {
     // Creates the feed.
     Feed feed =
         Feed.newBuilder()
-            .setName("Real Estate Feed #" + getPrintableDatetime())
+            .setName("Real Estate Feed #" + getPrintableDateTime())
             .addAttributes(listingIdAttribute)
             .addAttributes(listingNameAttribute)
             .addAttributes(finalUrlsAttribute)

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/AddRemarketingAction.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/AddRemarketingAction.java
@@ -16,6 +16,7 @@ package com.google.ads.googleads.examples.remarketing;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
+import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.common.TagSnippet;
@@ -93,7 +94,7 @@ public class AddRemarketingAction {
     // Creates a remarketing action with the specified name.
     RemarketingAction remarketingAction =
         RemarketingAction.newBuilder()
-            .setName("Remarketing action #" + System.currentTimeMillis())
+            .setName("Remarketing action #" + CodeSampleHelper.getPrintableDatetime())
             .build();
 
     // Creates a remarketing action operation.

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/AddRemarketingAction.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/AddRemarketingAction.java
@@ -14,9 +14,10 @@
 
 package com.google.ads.googleads.examples.remarketing;
 
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
-import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.common.TagSnippet;
@@ -94,7 +95,7 @@ public class AddRemarketingAction {
     // Creates a remarketing action with the specified name.
     RemarketingAction remarketingAction =
         RemarketingAction.newBuilder()
-            .setName("Remarketing action #" + CodeSampleHelper.getPrintableDatetime())
+            .setName("Remarketing action #" + getPrintableDatetime())
             .build();
 
     // Creates a remarketing action operation.

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/AddRemarketingAction.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/AddRemarketingAction.java
@@ -14,7 +14,7 @@
 
 package com.google.ads.googleads.examples.remarketing;
 
-import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDateTime;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
@@ -95,7 +95,7 @@ public class AddRemarketingAction {
     // Creates a remarketing action with the specified name.
     RemarketingAction remarketingAction =
         RemarketingAction.newBuilder()
-            .setName("Remarketing action #" + getPrintableDatetime())
+            .setName("Remarketing action #" + getPrintableDateTime())
             .build();
 
     // Creates a remarketing action operation.

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/SetupAdvancedRemarketing.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/SetupAdvancedRemarketing.java
@@ -14,9 +14,10 @@
 
 package com.google.ads.googleads.examples.remarketing;
 
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
-import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.common.ExpressionRuleUserListInfo;
@@ -212,7 +213,7 @@ public class SetupAdvancedRemarketing {
     // Creates a user list.
     UserList userList =
         UserList.newBuilder()
-            .setName("My expression rule user list #" + CodeSampleHelper.getPrintableDatetime())
+            .setName("My expression rule user list #" + getPrintableDatetime())
             .setDescription(
                 "Users who checked out in November or December OR visited the checkout page"
                     + " with more than one item in their cart")

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/SetupAdvancedRemarketing.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/SetupAdvancedRemarketing.java
@@ -16,6 +16,7 @@ package com.google.ads.googleads.examples.remarketing;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
+import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.common.ExpressionRuleUserListInfo;
@@ -211,7 +212,7 @@ public class SetupAdvancedRemarketing {
     // Creates a user list.
     UserList userList =
         UserList.newBuilder()
-            .setName("My expression rule user list #" + System.currentTimeMillis())
+            .setName("My expression rule user list #" + CodeSampleHelper.getPrintableDatetime())
             .setDescription(
                 "Users who checked out in November or December OR visited the checkout page"
                     + " with more than one item in their cart")

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/SetupAdvancedRemarketing.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/SetupAdvancedRemarketing.java
@@ -14,7 +14,7 @@
 
 package com.google.ads.googleads.examples.remarketing;
 
-import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDateTime;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
@@ -213,7 +213,7 @@ public class SetupAdvancedRemarketing {
     // Creates a user list.
     UserList userList =
         UserList.newBuilder()
-            .setName("My expression rule user list #" + getPrintableDatetime())
+            .setName("My expression rule user list #" + getPrintableDateTime())
             .setDescription(
                 "Users who checked out in November or December OR visited the checkout page"
                     + " with more than one item in their cart")

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/SetupRemarketing.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/SetupRemarketing.java
@@ -14,7 +14,7 @@
 
 package com.google.ads.googleads.examples.remarketing;
 
-import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDateTime;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
@@ -203,7 +203,7 @@ public class SetupRemarketing {
     // Creates the user list.
     UserList userList =
         UserList.newBuilder()
-            .setName("All visitors to example.com" + getPrintableDatetime())
+            .setName("All visitors to example.com" + getPrintableDateTime())
             .setDescription("Any visitor to any page of example.com")
             .setMembershipStatus(UserListMembershipStatus.OPEN)
             .setMembershipLifeSpan(365)

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/SetupRemarketing.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/SetupRemarketing.java
@@ -16,6 +16,7 @@ package com.google.ads.googleads.examples.remarketing;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
+import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.lib.utils.FieldMasks;
@@ -201,7 +202,7 @@ public class SetupRemarketing {
     // Creates the user list.
     UserList userList =
         UserList.newBuilder()
-            .setName("All visitors to example.com" + System.currentTimeMillis())
+            .setName("All visitors to example.com" + CodeSampleHelper.getPrintableDatetime())
             .setDescription("Any visitor to any page of example.com")
             .setMembershipStatus(UserListMembershipStatus.OPEN)
             .setMembershipLifeSpan(365)

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/SetupRemarketing.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/remarketing/SetupRemarketing.java
@@ -14,9 +14,10 @@
 
 package com.google.ads.googleads.examples.remarketing;
 
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
-import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.lib.utils.FieldMasks;
@@ -202,7 +203,7 @@ public class SetupRemarketing {
     // Creates the user list.
     UserList userList =
         UserList.newBuilder()
-            .setName("All visitors to example.com" + CodeSampleHelper.getPrintableDatetime())
+            .setName("All visitors to example.com" + getPrintableDatetime())
             .setDescription("Any visitor to any page of example.com")
             .setMembershipStatus(UserListMembershipStatus.OPEN)
             .setMembershipLifeSpan(365)

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/shoppingads/AddShoppingProductAd.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/shoppingads/AddShoppingProductAd.java
@@ -16,6 +16,7 @@ package com.google.ads.googleads.examples.shoppingads;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
+import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.common.ListingGroupInfo;
@@ -177,7 +178,7 @@ public class AddShoppingProductAd {
   private String addCampaignBudget(GoogleAdsClient googleAdsClient, long customerId) {
     CampaignBudget budget =
         CampaignBudget.newBuilder()
-            .setName("Interplanetary Cruise Budget #" + System.currentTimeMillis())
+            .setName("Interplanetary Cruise Budget #" + CodeSampleHelper.getPrintableDatetime())
             .setDeliveryMethod(BudgetDeliveryMethod.STANDARD)
             .setAmountMicros(5_000_000L)
             .build();
@@ -228,7 +229,7 @@ public class AddShoppingProductAd {
     // Create the standard shopping campaign.
     Campaign campaign =
         Campaign.newBuilder()
-            .setName("Interplanetary Cruise #" + System.currentTimeMillis())
+            .setName("Interplanetary Cruise #" + CodeSampleHelper.getPrintableDatetime())
             // Configures settings related to shopping campaigns including advertising channel type
             // and shopping setting.
             .setAdvertisingChannelType(AdvertisingChannelType.SHOPPING)
@@ -280,7 +281,7 @@ public class AddShoppingProductAd {
     // Creates an ad group.
     AdGroup adGroup =
         AdGroup.newBuilder()
-            .setName("Earth to Mars Cruises #" + System.currentTimeMillis())
+            .setName("Earth to Mars Cruises #" + CodeSampleHelper.getPrintableDatetime())
             .setCampaign(campaignResourceName)
             // Sets the ad group type to SHOPPING_PRODUCT_ADS. This is the only value possible for
             // ad groups that contain shopping product ads.

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/shoppingads/AddShoppingProductAd.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/shoppingads/AddShoppingProductAd.java
@@ -14,9 +14,10 @@
 
 package com.google.ads.googleads.examples.shoppingads;
 
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
-import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.common.ListingGroupInfo;
@@ -178,7 +179,7 @@ public class AddShoppingProductAd {
   private String addCampaignBudget(GoogleAdsClient googleAdsClient, long customerId) {
     CampaignBudget budget =
         CampaignBudget.newBuilder()
-            .setName("Interplanetary Cruise Budget #" + CodeSampleHelper.getPrintableDatetime())
+            .setName("Interplanetary Cruise Budget #" + getPrintableDatetime())
             .setDeliveryMethod(BudgetDeliveryMethod.STANDARD)
             .setAmountMicros(5_000_000L)
             .build();
@@ -229,7 +230,7 @@ public class AddShoppingProductAd {
     // Create the standard shopping campaign.
     Campaign campaign =
         Campaign.newBuilder()
-            .setName("Interplanetary Cruise #" + CodeSampleHelper.getPrintableDatetime())
+            .setName("Interplanetary Cruise #" + getPrintableDatetime())
             // Configures settings related to shopping campaigns including advertising channel type
             // and shopping setting.
             .setAdvertisingChannelType(AdvertisingChannelType.SHOPPING)
@@ -281,7 +282,7 @@ public class AddShoppingProductAd {
     // Creates an ad group.
     AdGroup adGroup =
         AdGroup.newBuilder()
-            .setName("Earth to Mars Cruises #" + CodeSampleHelper.getPrintableDatetime())
+            .setName("Earth to Mars Cruises #" + getPrintableDatetime())
             .setCampaign(campaignResourceName)
             // Sets the ad group type to SHOPPING_PRODUCT_ADS. This is the only value possible for
             // ad groups that contain shopping product ads.

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/shoppingads/AddShoppingProductAd.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/shoppingads/AddShoppingProductAd.java
@@ -14,7 +14,7 @@
 
 package com.google.ads.googleads.examples.shoppingads;
 
-import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDateTime;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
@@ -179,7 +179,7 @@ public class AddShoppingProductAd {
   private String addCampaignBudget(GoogleAdsClient googleAdsClient, long customerId) {
     CampaignBudget budget =
         CampaignBudget.newBuilder()
-            .setName("Interplanetary Cruise Budget #" + getPrintableDatetime())
+            .setName("Interplanetary Cruise Budget #" + getPrintableDateTime())
             .setDeliveryMethod(BudgetDeliveryMethod.STANDARD)
             .setAmountMicros(5_000_000L)
             .build();
@@ -230,7 +230,7 @@ public class AddShoppingProductAd {
     // Create the standard shopping campaign.
     Campaign campaign =
         Campaign.newBuilder()
-            .setName("Interplanetary Cruise #" + getPrintableDatetime())
+            .setName("Interplanetary Cruise #" + getPrintableDateTime())
             // Configures settings related to shopping campaigns including advertising channel type
             // and shopping setting.
             .setAdvertisingChannelType(AdvertisingChannelType.SHOPPING)
@@ -282,7 +282,7 @@ public class AddShoppingProductAd {
     // Creates an ad group.
     AdGroup adGroup =
         AdGroup.newBuilder()
-            .setName("Earth to Mars Cruises #" + getPrintableDatetime())
+            .setName("Earth to Mars Cruises #" + getPrintableDateTime())
             .setCampaign(campaignResourceName)
             // Sets the ad group type to SHOPPING_PRODUCT_ADS. This is the only value possible for
             // ad groups that contain shopping product ads.

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/shoppingads/AddShoppingSmartAd.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/shoppingads/AddShoppingSmartAd.java
@@ -16,6 +16,7 @@ package com.google.ads.googleads.examples.shoppingads;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
+import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.common.ListingGroupInfo;
@@ -178,7 +179,7 @@ public class AddShoppingSmartAd {
   private String addCampaignBudget(GoogleAdsClient googleAdsClient, long customerId) {
     CampaignBudget budget =
         CampaignBudget.newBuilder()
-            .setName("Interplanetary Cruise Budget #" + System.currentTimeMillis())
+            .setName("Interplanetary Cruise Budget #" + CodeSampleHelper.getPrintableDatetime())
             .setDeliveryMethod(BudgetDeliveryMethod.STANDARD)
             // The budget is specified in the local currency of the account.
             // The amount should be specified in micros, where one million is equivalent to one
@@ -232,7 +233,7 @@ public class AddShoppingSmartAd {
     // Creates the campaign.
     Campaign campaign =
         Campaign.newBuilder()
-            .setName("Interplanetary Cruise #" + System.currentTimeMillis())
+            .setName("Interplanetary Cruise #" + CodeSampleHelper.getPrintableDatetime())
             // Configures settings related to shopping campaigns including advertising channel type,
             // advertising sub-type and shopping setting.
             .setAdvertisingChannelType(AdvertisingChannelType.SHOPPING)
@@ -292,7 +293,7 @@ public class AddShoppingSmartAd {
     // Creates an ad group.
     AdGroup adGroup =
         AdGroup.newBuilder()
-            .setName("Earth to Mars Cruises #" + System.currentTimeMillis())
+            .setName("Earth to Mars Cruises #" + CodeSampleHelper.getPrintableDatetime())
             .setCampaign(campaignResourceName)
             // Sets the ad group type to SHOPPING_SMART_ADS. This cannot be set to other types.
             .setType(AdGroupType.SHOPPING_SMART_ADS)

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/shoppingads/AddShoppingSmartAd.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/shoppingads/AddShoppingSmartAd.java
@@ -14,9 +14,10 @@
 
 package com.google.ads.googleads.examples.shoppingads;
 
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
-import com.google.ads.googleads.examples.utils.CodeSampleHelper;
 import com.google.ads.googleads.examples.utils.CodeSampleParams;
 import com.google.ads.googleads.lib.GoogleAdsClient;
 import com.google.ads.googleads.v6.common.ListingGroupInfo;
@@ -179,7 +180,7 @@ public class AddShoppingSmartAd {
   private String addCampaignBudget(GoogleAdsClient googleAdsClient, long customerId) {
     CampaignBudget budget =
         CampaignBudget.newBuilder()
-            .setName("Interplanetary Cruise Budget #" + CodeSampleHelper.getPrintableDatetime())
+            .setName("Interplanetary Cruise Budget #" + getPrintableDatetime())
             .setDeliveryMethod(BudgetDeliveryMethod.STANDARD)
             // The budget is specified in the local currency of the account.
             // The amount should be specified in micros, where one million is equivalent to one
@@ -233,7 +234,7 @@ public class AddShoppingSmartAd {
     // Creates the campaign.
     Campaign campaign =
         Campaign.newBuilder()
-            .setName("Interplanetary Cruise #" + CodeSampleHelper.getPrintableDatetime())
+            .setName("Interplanetary Cruise #" + getPrintableDatetime())
             // Configures settings related to shopping campaigns including advertising channel type,
             // advertising sub-type and shopping setting.
             .setAdvertisingChannelType(AdvertisingChannelType.SHOPPING)
@@ -293,7 +294,7 @@ public class AddShoppingSmartAd {
     // Creates an ad group.
     AdGroup adGroup =
         AdGroup.newBuilder()
-            .setName("Earth to Mars Cruises #" + CodeSampleHelper.getPrintableDatetime())
+            .setName("Earth to Mars Cruises #" + getPrintableDatetime())
             .setCampaign(campaignResourceName)
             // Sets the ad group type to SHOPPING_SMART_ADS. This cannot be set to other types.
             .setType(AdGroupType.SHOPPING_SMART_ADS)

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/shoppingads/AddShoppingSmartAd.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/shoppingads/AddShoppingSmartAd.java
@@ -14,7 +14,7 @@
 
 package com.google.ads.googleads.examples.shoppingads;
 
-import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDatetime;
+import static com.google.ads.googleads.examples.utils.CodeSampleHelper.getPrintableDateTime;
 
 import com.beust.jcommander.Parameter;
 import com.google.ads.googleads.examples.utils.ArgumentNames;
@@ -180,7 +180,7 @@ public class AddShoppingSmartAd {
   private String addCampaignBudget(GoogleAdsClient googleAdsClient, long customerId) {
     CampaignBudget budget =
         CampaignBudget.newBuilder()
-            .setName("Interplanetary Cruise Budget #" + getPrintableDatetime())
+            .setName("Interplanetary Cruise Budget #" + getPrintableDateTime())
             .setDeliveryMethod(BudgetDeliveryMethod.STANDARD)
             // The budget is specified in the local currency of the account.
             // The amount should be specified in micros, where one million is equivalent to one
@@ -234,7 +234,7 @@ public class AddShoppingSmartAd {
     // Creates the campaign.
     Campaign campaign =
         Campaign.newBuilder()
-            .setName("Interplanetary Cruise #" + getPrintableDatetime())
+            .setName("Interplanetary Cruise #" + getPrintableDateTime())
             // Configures settings related to shopping campaigns including advertising channel type,
             // advertising sub-type and shopping setting.
             .setAdvertisingChannelType(AdvertisingChannelType.SHOPPING)
@@ -294,7 +294,7 @@ public class AddShoppingSmartAd {
     // Creates an ad group.
     AdGroup adGroup =
         AdGroup.newBuilder()
-            .setName("Earth to Mars Cruises #" + getPrintableDatetime())
+            .setName("Earth to Mars Cruises #" + getPrintableDateTime())
             .setCampaign(campaignResourceName)
             // Sets the ad group type to SHOPPING_SMART_ADS. This cannot be set to other types.
             .setType(AdGroupType.SHOPPING_SMART_ADS)

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/utils/CodeSampleHelper.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/utils/CodeSampleHelper.java
@@ -26,7 +26,7 @@ public abstract class CodeSampleHelper {
 
   /** The shorter date format used for printing. */
   private static final DateTimeFormatter shortFormat =
-      DateTimeFormatter.ofPattern("yyMMddHHmmssSSS");
+      DateTimeFormatter.ofPattern("MMddHHmmssSSS");
 
   /**
    * Generates a printable string for the current date and time in local time zone.

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/utils/CodeSampleHelper.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/utils/CodeSampleHelper.java
@@ -14,11 +14,15 @@
 
 package com.google.ads.googleads.examples.utils;
 
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 
 /** A helper class for all code examples. */
 public abstract class CodeSampleHelper {
+
+  /** The date format used for printing. */
+  private static final DateTimeFormatter format =
+      DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZZ");
 
   /**
    * Generates a printable string for the current date and time in local time zone.
@@ -26,6 +30,6 @@ public abstract class CodeSampleHelper {
    * @return the result string.
    */
   public static String getPrintableDatetime() {
-    return new DateTime().toString("yyyy-MM-dd'T'HH:mm:ss.SSSZZ");
+    return ZonedDateTime.now().format(format);
   }
 }

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/utils/CodeSampleHelper.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/utils/CodeSampleHelper.java
@@ -22,6 +22,7 @@ public abstract class CodeSampleHelper {
 
   /**
    * Generates a printable string for the current date and time in UTC time zone.
+   *
    * @return the result string.
    */
   public static String getPrintableDatetime() {

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/utils/CodeSampleHelper.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/utils/CodeSampleHelper.java
@@ -24,6 +24,10 @@ public abstract class CodeSampleHelper {
   private static final DateTimeFormatter format =
       DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZZ");
 
+  /** The shorter date format used for printing. */
+  private static final DateTimeFormatter shortFormat =
+      DateTimeFormatter.ofPattern("yyMMddHHmmssSSS");
+
   /**
    * Generates a printable string for the current date and time in local time zone.
    *
@@ -31,5 +35,14 @@ public abstract class CodeSampleHelper {
    */
   public static String getPrintableDatetime() {
     return ZonedDateTime.now().format(format);
+  }
+
+  /**
+   * Generates a short printable string for the current date and time in local time zone.
+   *
+   * @return the result string.
+   */
+  public static String getShortPrintableDatetime() {
+    return ZonedDateTime.now().format(shortFormat);
   }
 }

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/utils/CodeSampleHelper.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/utils/CodeSampleHelper.java
@@ -21,7 +21,7 @@ import org.joda.time.DateTimeZone;
 public abstract class CodeSampleHelper {
 
   /**
-   * Generates a printable string for the current date and time in UTC time zone.
+   * Generates a printable string for the current date and time in local time zone.
    *
    * @return the result string.
    */

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/utils/CodeSampleHelper.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/utils/CodeSampleHelper.java
@@ -26,6 +26,6 @@ public abstract class CodeSampleHelper {
    * @return the result string.
    */
   public static String getPrintableDatetime() {
-    return new DateTime(DateTimeZone.UTC).toString("yyyyMMdd_HH:mm:ss.SSS") + "_UTC";
+    return new DateTime().toString("yyyy-MM-dd'T'HH:mm:ss.SSSZZ");
   }
 }

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/utils/CodeSampleHelper.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/utils/CodeSampleHelper.java
@@ -1,0 +1,30 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.ads.googleads.examples.utils;
+
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+
+/** A helper class for all code examples. */
+public abstract class CodeSampleHelper {
+
+  /**
+   * Generates a printable string for the current date and time in UTC time zone.
+   * @return the result string.
+   */
+  public static String getPrintableDatetime() {
+    return new DateTime(DateTimeZone.UTC).toString("yyyyMMdd_HH:mm:ss.SSS") + "_UTC";
+  }
+}

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/utils/CodeSampleHelper.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/utils/CodeSampleHelper.java
@@ -33,7 +33,7 @@ public abstract class CodeSampleHelper {
    *
    * @return the result string.
    */
-  public static String getPrintableDatetime() {
+  public static String getPrintableDateTime() {
     return ZonedDateTime.now().format(format);
   }
 
@@ -42,7 +42,7 @@ public abstract class CodeSampleHelper {
    *
    * @return the result string.
    */
-  public static String getShortPrintableDatetime() {
+  public static String getShortPrintableDateTime() {
     return ZonedDateTime.now().format(shortFormat);
   }
 }


### PR DESCRIPTION
This uses the same granularity as before (milliseconds) to avoid any regression related to concurrent name conflicts.

Two formats are introduced:

1. Default: a resource name typically looks like the following `Interplanetary Cruise #2020-12-09T14:27:32.388-05:00`.
1. Short: for the resources that requires a short name, a resource name typically looks like the following `Feed name  1209142732388`.