### PR TITLE
Add `.run` folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # IntelliJ IDE files
 # See: https://github.com/github/gitignore/blob/master/Global/JetBrains.gitignore
 .idea/
+.run/
 *.iml
 google-ads/*.iml
 google-ads-examples/*.iml


### PR DESCRIPTION
Starting with version 2020.1 Beta 2, IntelliJ IDEA users may
store run configurations in a separate `.run` folder instead
of under `.idea`.

https://blog.jetbrains.com/idea/2020/03/intellij-idea-2020-1-beta2/