### PR TITLE
NEW: Add ability to change created GoogleAdsClient (Fixes #174)

### DIFF
--- a/google-ads/src/main/java/com/google/ads/googleads/lib/GoogleAdsClient.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/lib/GoogleAdsClient.java
@@ -552,9 +552,7 @@ public abstract class GoogleAdsClient extends AbstractGoogleAdsClient {
       Primer.getInstance().ifPresent(p -> p.primeCredentialsAsync(getCredentials()));
       // Proceeds with creating the client library instance.
       TransportChannelProvider transportChannelProvider = getTransportChannelProvider();
-      if (transportChannelProvider.needsHeaders()) {
-        transportChannelProvider = transportChannelProvider.withHeaders(getHeaders());
-      }
+      transportChannelProvider = transportChannelProvider.withHeaders(getHeaders());
       if (transportChannelProvider.needsEndpoint()) {
         transportChannelProvider = transportChannelProvider.withEndpoint(getEndpoint());
       }

--- a/google-ads/src/main/java/com/google/ads/googleads/lib/GoogleAdsClient.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/lib/GoogleAdsClient.java
@@ -551,8 +551,8 @@ public abstract class GoogleAdsClient extends AbstractGoogleAdsClient {
       // Provides the credentials to the primer to preemptively get these ready for usage.
       Primer.getInstance().ifPresent(p -> p.primeCredentialsAsync(getCredentials()));
       // Proceeds with creating the client library instance.
-      TransportChannelProvider transportChannelProvider = getTransportChannelProvider();
-      transportChannelProvider = transportChannelProvider.withHeaders(getHeaders());
+      TransportChannelProvider transportChannelProvider =
+          getTransportChannelProvider().withHeaders(getHeaders());
       if (transportChannelProvider.needsEndpoint()) {
         transportChannelProvider = transportChannelProvider.withEndpoint(getEndpoint());
       }

--- a/google-ads/src/test/java/com/google/ads/googleads/lib/GoogleAdsClientTest.java
+++ b/google-ads/src/test/java/com/google/ads/googleads/lib/GoogleAdsClientTest.java
@@ -195,6 +195,28 @@ public class GoogleAdsClientTest {
     assertGoogleAdsClient(client, null, true);
   }
 
+  /** Tests setting the login customer ID after the GoogleAdsClient is already built succeeds. */
+  @Test
+  public void testSetLoginCustomerIdAfterCreatingClient() throws IOException {
+    // Create a properties file in the temporary folder.
+    File propertiesFile = folder.newFile("ads.properties");
+    try (FileWriter propertiesFileWriter = new FileWriter(propertiesFile)) {
+      testProperties.store(propertiesFileWriter, null);
+    }
+
+    // Build a new client from the file.
+    GoogleAdsClient client =
+        GoogleAdsClient.newBuilder()
+            .fromPropertiesFile(propertiesFile)
+            .setTransportChannelProvider(localChannelProvider)
+            .build();
+    // Set a custom loginCustomerId on the previously created GoogleAdsClient.
+    long loginCustomerId = 987654321L;
+    client = client.toBuilder().setLoginCustomerId(loginCustomerId).build();
+    assertGoogleAdsClient(client, loginCustomerId, true);
+    assertEquals(client.getLoginCustomerId().longValue(), loginCustomerId);
+  }
+
   /**
    * Verifies reading config from a Java properties file where the path is specified from the
    * environment variable.

--- a/google-ads/src/test/java/com/google/ads/googleads/lib/GoogleAdsClientTest.java
+++ b/google-ads/src/test/java/com/google/ads/googleads/lib/GoogleAdsClientTest.java
@@ -195,7 +195,10 @@ public class GoogleAdsClientTest {
     assertGoogleAdsClient(client, null, true);
   }
 
-  /** Tests setting the login customer ID after the GoogleAdsClient is already built succeeds. */
+  /**
+   * Tests creating a new GoogleAdsClient with a new login customer ID after the GoogleAdsClient is
+   * already built succeeds.
+   */
   @Test
   public void testSetLoginCustomerIdAfterCreatingClient() throws IOException {
     // Create a properties file in the temporary folder.
@@ -210,7 +213,7 @@ public class GoogleAdsClientTest {
             .fromPropertiesFile(propertiesFile)
             .setTransportChannelProvider(localChannelProvider)
             .build();
-    // Set a custom loginCustomerId on the previously created GoogleAdsClient.
+    // Create a new GoogleAdsClient with a new loginCustomerId.
     long loginCustomerId = 987654321L;
     client = client.toBuilder().setLoginCustomerId(loginCustomerId).build();
     assertGoogleAdsClient(client, loginCustomerId, true);


### PR DESCRIPTION
This PR replaces #430.

Some notes:
- I don't think we have to worry about clobbering custom `TransportChannelProvider` settings. The reason for this is that we do not expose an interface for updating the `TransportChannelProvider` outside of the package. Therefore, if someone is creating a custom `TransportChannelProvider`, they must be doing so by customizing the `GoogleAdsClient`, in which case, they'll need to update this implementation anyhow.
- I have tested that the logging interceptor is updated to reflect the new `loginCustomerId` manually, but I don't think it is possible to write a test for this for two reasons. First, we don't own the `TransportChannelProvider` class, so we aren't able to write a method that exposes the interceptor provider, even with a VisibleForTesting annotation. Second, the interceptor provider is not ever set in the tests because they use `LocalChannelProvider`.
- The reason for my implementation is that the only case that breaks our tests is when the `TransportChannelProvider` is a `LocalChannelProvider` (i.e. all of our tests). I can't use `instance of` here because `LocalChannelProvider` is only available in the testing package.