### PR TITLE
Refresh the OAuth credentials proactively

### DIFF
--- a/google-ads/src/main/java/com/google/ads/googleads/lib/GoogleAdsClient.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/lib/GoogleAdsClient.java
@@ -22,6 +22,7 @@ import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider;
 import com.google.api.gax.rpc.TransportChannelProvider;
 import com.google.auth.Credentials;
 import com.google.auth.oauth2.GoogleCredentials;
+import com.google.auth.oauth2.OAuth2Credentials;
 import com.google.auth.oauth2.ServiceAccountCredentials;
 import com.google.auth.oauth2.UserCredentials;
 import com.google.auto.value.AutoValue;
@@ -548,6 +549,10 @@ public abstract class GoogleAdsClient extends AbstractGoogleAdsClient {
         // action is needed.
       }
 
+      // Refreshes the OAuth credentials if necessary. This also ensures that the credentials are
+      // valid, avoiding https://github.com/googleads/google-ads-java/issues/169
+      refreshCredentialsIfNecessary();
+
       // Provides the credentials to the primer to preemptively get these ready for usage.
       Primer.getInstance().ifPresent(p -> p.primeCredentialsAsync(getCredentials()));
       // Proceeds with creating the client library instance.
@@ -574,6 +579,19 @@ public abstract class GoogleAdsClient extends AbstractGoogleAdsClient {
               + "must be 0 < loginCustomerId < 9,999,999,999, provided: "
               + loginCustomerId);
       return provider;
+    }
+
+    /** Attempts to refresh the OAuth credentials if necessary. */
+    private void refreshCredentialsIfNecessary() {
+      Credentials credentials = getCredentials();
+      if (credentials instanceof OAuth2Credentials) {
+        OAuth2Credentials oAuth2Credentials = (OAuth2Credentials) credentials;
+        try {
+          oAuth2Credentials.refreshIfExpired();
+        } catch (IOException e) {
+          throw new OAuthException(e);
+        }
+      }
     }
 
     @VisibleForTesting

--- a/google-ads/src/main/java/com/google/ads/googleads/lib/OAuthException.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/lib/OAuthException.java
@@ -1,0 +1,25 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.ads.googleads.lib;
+
+import java.io.IOException;
+
+/** Defines an exception that occured when configuring OAuth. */
+public class OAuthException extends RuntimeException {
+
+  public OAuthException(IOException cause) {
+    super(cause);
+  }
+}


### PR DESCRIPTION
This should help prevent hitting infinite retry loop when the credentials are invalid, specifically #169 

Change-Id: If07b968bfb6fb7ca81c76f0a68a2ac0333d1dae5