### PR TITLE
Fixes to enable publishing the library with gradle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+15.0.1 - 2021-08-12
+-------------------
+- Added headline 4 and 5.
+
 15.0.0 - 2021-08-12
 -------------------
 - Added and updated examples for Google Ads API v8.1.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,3 @@
-15.0.1 - 2021-08-12
--------------------
-- Added headline 4 and 5.
-
 15.0.0 - 2021-08-12
 -------------------
 - Added and updated examples for Google Ads API v8.1.

--- a/buildSrc/src/main/groovy/com.google.api-ads.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/com.google.api-ads.java-conventions.gradle
@@ -35,7 +35,7 @@ repositories {
 }
 
 group = 'com.google.api-ads'
-version = '15.0.0'
+version = '15.0.1'
 java.sourceCompatibility = JavaVersion.VERSION_1_8
 java.targetCompatibility = JavaVersion.VERSION_1_8
 

--- a/buildSrc/src/main/groovy/com.google.api-ads.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/com.google.api-ads.java-conventions.gradle
@@ -36,7 +36,7 @@ repositories {
 }
 
 group = 'com.google.api-ads'
-version = '15.0.1'
+version = '15.0.0'
 java.sourceCompatibility = JavaVersion.VERSION_1_8
 java.targetCompatibility = JavaVersion.VERSION_1_8
 

--- a/buildSrc/src/main/groovy/com.google.api-ads.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/com.google.api-ads.java-conventions.gradle
@@ -24,6 +24,7 @@ import java.util.regex.Matcher
 plugins {
   id 'java-library'
   id 'maven-publish'
+  id 'signing'
 }
 
 // The order of the repositories here is important. If mavenLocal() is first,
@@ -81,6 +82,57 @@ tasks.findAll {
         throw new GradleException("Unable to load Sonatype credentials from ${sonatypeCredentialsConfig}.")
       }
     }
+  }
+}
+
+ext.configurePom = { publication, nameToSet, descriptionToSet ->
+  publication.pom {
+    name = nameToSet
+    description = descriptionToSet
+    packaging 'jar'
+    url = 'https://github.com/googleads/google-ads-java'
+    licenses {
+      license {
+        name = 'The Apache License, Version 2.0'
+        url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+      }
+    }
+    scm {
+      connection = 'scm:git:https://github.com/googleads/google-ads-java'
+      developerConnection = 'scm:git:https://github.com/googleads/google-ads-java'
+      url = 'https://github.com/googleads/google-ads-java'
+    }
+    developers {
+      developer {
+        id = 'josh'
+        name = 'Josh Radcliff'
+        email = 'jradcliff@users.noreply.github.com'
+        organization = 'Google'
+        organizationUrl = 'https://www.google.com'
+      }
+      developer {
+        id = 'nick'
+        name = 'Nick Birnie'
+        email = 'nwbirnie@users.noreply.github.com'
+        organization = 'Google'
+        organizationUrl = 'https://www.google.com'
+      }
+      developer {
+        id = 'devin'
+        name = 'Devin Chasanoff'
+        email = 'devchas@users.noreply.github.com'
+        organization = 'Google'
+        organizationUrl = 'https://www.google.com'
+      }
+    }
+  }
+}
+
+// Disables signing tasks except on sonatype deploy. Avoids failing build for
+// users without GPG configured.
+if (project.properties.containsKey("release")) {
+  signing {
+    sign publishing.publications
   }
 }
 

--- a/buildSrc/src/main/groovy/com.google.api-ads.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/com.google.api-ads.java-conventions.gradle
@@ -48,10 +48,38 @@ javadoc {
   options.addStringOption('Xdoclint:none', '-quiet')
 }
 
+final def sonatypeCredentialsConfig = file(System.properties['user.home'] + '/.sonatype-creds')
+
 publishing {
   publications {
     maven(MavenPublication) {
       from(components.java)
+    }
+  }
+  repositories {
+    maven {
+      url 'https://oss.sonatype.org/service/local/staging/deploy/maven2'
+      name = "sonatype"
+
+      if (sonatypeCredentialsConfig.exists()) {
+        def props = new Properties()
+        sonatypeCredentialsConfig.withInputStream { props.load(it) }
+        credentials {
+          username props['username']
+          password props['password']
+        }
+      }
+    }
+  }
+}
+
+// Provide a helpful error message for missing sonatype credentials.
+tasks.findAll {
+  if (it.name.matches("publish.+ToSonatypeRepository")) {
+    it.doFirst {
+      if (!sonatypeCredentialsConfig.exists()) {
+        throw new GradleException("Unable to load Sonatype credentials from ${sonatypeCredentialsConfig}.")
+      }
     }
   }
 }

--- a/google-ads-annotation-processing/build.gradle
+++ b/google-ads-annotation-processing/build.gradle
@@ -33,8 +33,8 @@ publishing {
     publications {
         maven(MavenPublication) { publication ->
             configurePom(publication,
-                    "Google Ads API client library for java - main library",
-                    "Main library for the Google Ads API client library for Java")
+                    "Google Ads API client library for Java - main library",
+                    "Annotations + processor for code generation")
         }
     }
 }

--- a/google-ads-annotation-processing/build.gradle
+++ b/google-ads-annotation-processing/build.gradle
@@ -29,3 +29,12 @@ dependencies {
 
 description = 'Google Ads API client library for Java annotation processor'
 
+publishing {
+    publications {
+        maven(MavenPublication) { publication ->
+            configurePom(publication,
+                    "Google Ads API client library for java - main library",
+                    "Main library for the Google Ads API client library for Java")
+        }
+    }
+}

--- a/google-ads/build.gradle
+++ b/google-ads/build.gradle
@@ -353,8 +353,6 @@ def configurePom(publication, nameToSet, descriptionToSet) {
   }
 }
 
-final def sonatypeCredentialsConfig = file(System.properties['user.home'] + '/.sonatype-creds')
-
 publishing {
   publications {
     shadow(MavenPublication) { publication ->
@@ -375,22 +373,6 @@ publishing {
           "Provides a jar with all dependencies")
     }
   }
-
-  repositories {
-    maven {
-      url 'https://oss.sonatype.org/service/local/staging/deploy/maven2'
-      name = "sonatype"
-
-      if (sonatypeCredentialsConfig.exists()) {
-        def props = new Properties()
-        sonatypeCredentialsConfig.withInputStream { props.load(it) }
-        credentials {
-          username props['username']
-          password props['password']
-        }
-      }
-    }
-  }
 }
 
 signing {
@@ -406,15 +388,3 @@ gradle.taskGraph.whenReady {
     tasks.findByName("signShadowPublication").enabled = false
   }
 }
-
-// Provide a helpful error message for missing sonatype credentials.
-tasks.findAll {
-  if (it.name.matches("publish.+ToSonatypeRepository")) {
-    it.doFirst {
-      if (!sonatypeCredentialsConfig.exists()) {
-        throw new GradleException("Unable to load Sonatype credentials from ${sonatypeCredentialsConfig}.")
-      }
-    }
-  }
-}
-

--- a/google-ads/build.gradle
+++ b/google-ads/build.gradle
@@ -22,7 +22,6 @@ import com.google.common.collect.Sets
 
 plugins {
   id 'com.google.api-ads.java-conventions'
-  id 'signing'
   id 'com.google.protobuf' version '0.8.15'
   id "com.github.hierynomus.license-report" version "0.15.0"
   id 'com.github.johnrengelman.shadow' version '6.1.0'
@@ -311,50 +310,13 @@ task testShadowJar {
   }
 }
 
-def configurePom(publication, nameToSet, descriptionToSet) {
-  publication.pom {
-    name = nameToSet
-    description = descriptionToSet
-    url = 'https://github.com/googleads/google-ads-java'
-    licenses {
-      license {
-        name = 'The Apache License, Version 2.0'
-        url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-      }
-    }
-    scm {
-      connection = 'scm:git:https://github.com/googleads/google-ads-java'
-      developerConnection = 'scm:git:https://github.com/googleads/google-ads-java'
-      url = 'https://github.com/googleads/google-ads-java'
-    }
-    developers {
-      developer {
-        id = 'josh'
-        name = 'Josh Radcliff'
-        email = 'jradcliff@users.noreply.github.com'
-        organization = 'Google'
-        organizationUrl = 'https://www.google.com'
-      }
-      developer {
-        id = 'nick'
-        name = 'Nick Birnie'
-        email = 'nwbirnie@users.noreply.github.com'
-        organization = 'Google'
-        organizationUrl = 'https://www.google.com'
-      }
-      developer {
-        id = 'devin'
-        name = 'Devin Chasanoff'
-        email = 'devchas@users.noreply.github.com'
-        organization = 'Google'
-        organizationUrl = 'https://www.google.com'
-      }
-    }
-  }
-}
-
 publishing {
   publications {
+    maven(MavenPublication) { publication ->
+      configurePom(publication,
+          "Google Ads API client library for java - main library",
+          "Main library for the Google Ads API client library for Java")
+    }
     shadow(MavenPublication) { publication ->
       project.shadow.component(publication)
       // Publishes the javadoc + sources with the shadowjar.
@@ -372,19 +334,5 @@ publishing {
           "Google Ads API client library for java - shadow jar",
           "Provides a jar with all dependencies")
     }
-  }
-}
-
-signing {
-  sign publishing.publications.shadow
-}
-
-// Disables signing tasks except on sonatype deploy. Avoids failing build for
-// users without GPG configured.
-gradle.taskGraph.whenReady {
-  if (gradle.taskGraph.allTasks
-      .findAll { it.name.matches("publish.+ToSonatypeRepository") }
-      .isEmpty()) {
-    tasks.findByName("signShadowPublication").enabled = false
   }
 }

--- a/google-ads/build.gradle
+++ b/google-ads/build.gradle
@@ -314,7 +314,7 @@ publishing {
   publications {
     maven(MavenPublication) { publication ->
       configurePom(publication,
-          "Google Ads API client library for java - main library",
+          "Google Ads API client library for Java - main library",
           "Main library for the Google Ads API client library for Java")
     }
     shadow(MavenPublication) { publication ->

--- a/settings.gradle
+++ b/settings.gradle
@@ -21,6 +21,9 @@ rootProject.name = 'google-ads-parent'
 
 include ':google-ads-annotation-processing'
 include ':google-ads'
-include ':google-ads-examples'
-include ':google-ads-migration-examples'
 
+// Enables the examples project only if we're not deploying to Sonatype.
+if (!startParameter.projectProperties.containsKey("release")) {
+	include ':google-ads-examples'
+	include ':google-ads-migration-examples'
+}


### PR DESCRIPTION
Moves lots of the shadow jar logic out to java-conventions and reuses this for the other projects.