### PR TITLE
Switch grpc dependency to minimal required

### DIFF
--- a/buildSrc/src/main/groovy/com.google.api-ads.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/com.google.api-ads.java-conventions.gradle
@@ -153,7 +153,9 @@ dependencies {
   implementation 'com.google.api:gax'
   implementation 'com.google.api:gax-grpc'
   implementation 'com.google.protobuf:protobuf-java'
-  implementation 'io.grpc:grpc-all'
+  implementation 'io.grpc:grpc-stub'
+  implementation 'io.grpc:grpc-protobuf'
+  implementation 'com.google.auth:google-auth-library-oauth2-http:1.2.1'
   annotationProcessor 'com.google.auto.service:auto-service:1.0-rc2'
   testImplementation 'junit:junit:4.13.1'
 }

--- a/buildSrc/src/main/groovy/com.google.api-ads.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/com.google.api-ads.java-conventions.gradle
@@ -155,7 +155,7 @@ dependencies {
   implementation 'com.google.protobuf:protobuf-java'
   implementation 'io.grpc:grpc-stub'
   implementation 'io.grpc:grpc-protobuf'
-  implementation 'com.google.auth:google-auth-library-oauth2-http'
+  implementation 'com.google.auth:google-auth-library-oauth2-http:1.2.1'
   annotationProcessor 'com.google.auto.service:auto-service:1.0-rc2'
   testImplementation 'junit:junit:4.13.1'
 }

--- a/buildSrc/src/main/groovy/com.google.api-ads.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/com.google.api-ads.java-conventions.gradle
@@ -155,7 +155,7 @@ dependencies {
   implementation 'com.google.protobuf:protobuf-java'
   implementation 'io.grpc:grpc-stub'
   implementation 'io.grpc:grpc-protobuf'
-  implementation 'com.google.auth:google-auth-library-oauth2-http:1.2.1'
+  implementation 'com.google.auth:google-auth-library-oauth2-http'
   annotationProcessor 'com.google.auto.service:auto-service:1.0-rc2'
   testImplementation 'junit:junit:4.13.1'
 }

--- a/google-ads/build.gradle
+++ b/google-ads/build.gradle
@@ -74,6 +74,7 @@ dependencies {
   testImplementation 'com.google.api:gax-grpc::testlib'
   testImplementation 'io.grpc:grpc-context:1.30.0'
   testImplementation 'com.google.truth:truth:0.27'
+  implementation 'com.google.auto.value:auto-value-annotations:1.7.3'
   testImplementation 'com.google.auto.value:auto-value-annotations:1.7.3'
   shadeTest 'junit:junit:4.13.1'
 }
@@ -214,6 +215,9 @@ task copyThirdPartySources(type: Copy) {
       .resolutionResult
       .allDependencies
       .stream()
+      // Avoids failing the build with cryptic errors when a bad dependency is
+      // added.
+      .filter { it.hasProperty("selected") != null}
       // Avoids attempting to download sources for projects in the build.
       .filter { !(it.selected.id instanceof ProjectComponentIdentifier) }
       // Avoids attempting to download sources for Maven BOMs.


### PR DESCRIPTION
#507 suggests that we should use the minimum set of grpc dependencies, rather than grpc-all