### PR TITLE
Fix runExample task to fail on error.

### DIFF
--- a/buildSrc/src/main/groovy/com.google.api-ads.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/com.google.api-ads.java-conventions.gradle
@@ -245,6 +245,7 @@ class ExampleRunnerTask extends JavaExec {
       logQuietMessage('\n\033[0;31mrunExample exception!\033[0m Did ' +
         'you provide a valid example identifier? ' + exampleInvocation +
         e.message)
+      throw e
     }
   }
 


### PR DESCRIPTION
Currently CI is passing for all examples regardless of error state

Change-Id: Icfa73e81c2e3ea742d717b0b2b584878c5e2ad4f