### PR TITLE
Upgrade log4j to 2.15.0 in examples projects

### DIFF
--- a/google-ads-examples/build.gradle
+++ b/google-ads-examples/build.gradle
@@ -45,7 +45,7 @@ dependencies {
   implementation 'org.apache.commons:commons-lang3:3.11'
   implementation 'com.beust:jcommander:1.72'
   implementation 'joda-time:joda-time:2.8.2'
-  runtimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl:2.11.1'
+  runtimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl:2.15.0'
   testImplementation 'org.reflections:reflections:0.9.11'
   testImplementation 'org.mockito:mockito-core:2.27.0'
   testImplementation 'org.hamcrest:hamcrest:2.2'

--- a/google-ads-migration-examples/build.gradle
+++ b/google-ads-migration-examples/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     implementation 'com.google.api-ads:adwords-axis:4.4.0'
     implementation 'com.beust:jcommander:1.72'
     implementation 'joda-time:joda-time:2.8.2'
-    runtimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl:2.11.1'
+    runtimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl:2.15.0'
     testImplementation 'org.mockito:mockito-core:2.27.0'
 }
 


### PR DESCRIPTION
Addresses vulnerability:

https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228
