### PR TITLE
Fixup publishing.

### DIFF
--- a/buildSrc/src/main/groovy/com.google.api-ads.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/com.google.api-ads.java-conventions.gradle
@@ -60,6 +60,8 @@ publishing {
   publications {
     maven(MavenPublication) {
       from(components.java)
+      suppressPomMetadataWarningsFor('testFixturesApiElements')
+      suppressPomMetadataWarningsFor('testFixturesRuntimeElements')
     }
   }
   repositories {
@@ -154,7 +156,7 @@ dependencies {
   api 'io.grpc:grpc-stub'
   api 'io.grpc:grpc-protobuf'
   api 'com.google.auth:google-auth-library-oauth2-http'
-  implementation platform('com.google.cloud:google-cloud-shared-dependencies:2.4.0')
+  api platform('com.google.cloud:google-cloud-shared-dependencies:2.4.0')
   implementation 'com.google.guava:guava:30.0-android'
   implementation 'com.google.auto.service:auto-service:1.0-rc2'
   annotationProcessor 'com.google.auto.service:auto-service:1.0-rc2'

--- a/buildSrc/src/main/groovy/com.google.api-ads.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/com.google.api-ads.java-conventions.gradle
@@ -60,8 +60,6 @@ publishing {
   publications {
     maven(MavenPublication) {
       from(components.java)
-      suppressPomMetadataWarningsFor('testFixturesApiElements')
-      suppressPomMetadataWarningsFor('testFixturesRuntimeElements')
     }
   }
   repositories {
@@ -77,6 +75,9 @@ publishing {
     }
   }
 }
+
+components.java.withVariantsFromConfiguration(configurations.testFixturesApiElements) { skip() }
+components.java.withVariantsFromConfiguration(configurations.testFixturesRuntimeElements) { skip() }
 
 // Provide a helpful error message for missing sonatype credentials.
 tasks.findAll {


### PR DESCRIPTION
Avoids spurious warnings about losing testFixtures from maven publication.
Also declares BOM as API dependency so that dependents can read this.

Change-Id: Iba153ab3b40bfde7f6b4f7dbbe8ae96440833e14