### PR TITLE
Implements a client for Sonatype Nexus

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -24,3 +24,8 @@ plugins {
 repositories {
     gradlePluginPortal()
 }
+
+dependencies {
+    implementation "com.google.http-client:google-http-client:1.40.1"
+    implementation "com.google.http-client:google-http-client-xml:1.40.1"
+}

--- a/buildSrc/src/main/groovy/com.google.api-ads.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/com.google.api-ads.java-conventions.gradle
@@ -24,7 +24,7 @@ import java.util.regex.Matcher
 
 plugins {
   id 'java-library'
-  id 'maven-publish'
+  id 'com.google.api-ads.nexus-publish'
   id 'java-test-fixtures'
   id 'signing'
 }
@@ -55,26 +55,6 @@ jar {
 
 javadoc {
   options.addStringOption('Xdoclint:none', '-quiet')
-}
-
-publishing {
-  publications {
-    maven(MavenPublication) {
-      from(components.java)
-    }
-  }
-  repositories {
-    maven {
-      url 'https://oss.sonatype.org/service/local/staging/deploy/maven2'
-      name = "sonatype"
-      credentials {
-        // Avoids storing Sonatype credentials in plain-text. Specify these on
-        // the command line: -PsonatypeUser=foo
-        username project.properties.get("sonatypeUser")
-        password project.properties.get("sonatypePassword")
-      }
-    }
-  }
 }
 
 components.java.withVariantsFromConfiguration(configurations.testFixturesApiElements) { skip() }

--- a/buildSrc/src/main/groovy/com.google.api-ads.nexus-publish.gradle
+++ b/buildSrc/src/main/groovy/com.google.api-ads.nexus-publish.gradle
@@ -134,7 +134,8 @@ class SonatypeClient {
         // goes awry.
         try {
             // Guards the creation of a staging repo on the release property.
-            // Ensures that we don't create spurious repositories.
+            // Ensures that we don't create spurious repositories if we're not
+            // running a release.
             if (project.properties.containsKey("release")) {
                 // Avoids creating the staging repository more than once.
                 // Implements double checked locking to initialize STAGING_REPO_URL.
@@ -165,12 +166,14 @@ class SonatypeClient {
     /** Creates a staging repository on Sonatype. */
     private def createStagingRepository() {
         // Implements the REST call to create a staging repository.
-        // See https://support.sonatype.com/hc/en-us/articles/213465868-Uploading-to-a-Staging-Repository-via-REST-API
-        // Note that there are two versions of Nexus v2 and v3 and the OSS instance
-        // uses v2.
+        // Note that there are two versions of Nexus: v2 and v3. The OSS instance
+        // (which hosts our project) uses v2.
+
         // The Nexus docs are here: https://help.sonatype.com/repomanager2
         // The REST docs are here: https://repository.sonatype.org/nexus-restlet1x-plugin/default/docs/index.html
         // Warning: the docs are very patchy!
+        // This implementation is based on:
+        //   https://support.sonatype.com/hc/en-us/articles/213465868-Uploading-to-a-Staging-Repository-via-REST-API
 
         // Configures Google HTTP client.
         // Logging of raw HTTP is handled by the client. Enable it by setting

--- a/buildSrc/src/main/groovy/com.google.api-ads.nexus-publish.gradle
+++ b/buildSrc/src/main/groovy/com.google.api-ads.nexus-publish.gradle
@@ -128,10 +128,15 @@ class SonatypeClient {
      * connection for each artifact.
      */
     def createSonatypeRepositoryUrl() {
-        // Avoids creating the staging repository more than once.
+        // Catches any unexpected exceptions.
+        // In theory nothing should throw and we should gracefully fall back to
+        // auto-staging. Catch-all here ensures that happens even if something
+        // goes awry.
         try {
             // Guards the creation of a staging repo on the release property.
+            // Ensures that we don't create spurious repositories.
             if (project.properties.containsKey("release")) {
+                // Avoids creating the staging repository more than once.
                 // Implements double checked locking to initialize STAGING_REPO_URL.
                 // Initializes the URL on the first execution.
                 if (project.rootProject.ext.STAGING_REPO_URL == null) {
@@ -144,7 +149,10 @@ class SonatypeClient {
                 }
             }
         } catch (Exception ex) {
-            logger.warn("Failed to create new staging repo, falling back to auto-staging")
+            logger.warn("BUG BUG BUG! Failed to create new staging repo. "
+                    + "I'll attempt to deploy with auto-staging. "
+                    + "The release *may* complete as planned. "
+                    + "Please investigate when able.", ex)
             return AUTO_STAGING_URL
         }
     }

--- a/buildSrc/src/main/groovy/com.google.api-ads.nexus-publish.gradle
+++ b/buildSrc/src/main/groovy/com.google.api-ads.nexus-publish.gradle
@@ -126,16 +126,15 @@ class PromoteRequestXmlContent extends XmlHttpContent {
  * Logging of raw HTTP is handled by the the HTTP client (google-java-http-client) which uses JUL.
  *
  * This implementation is based on:
- * https://support.sonatype.com/hc/en-us/articles/213465868-Uploading-to-a-Staging-Repository-via
- * -REST-API
+ * https://support.sonatype.com/hc/en-us/articles/213465868-Uploading-to-a-Staging-Repository-via-REST-API
  *
- * Note that there are two versions of Nexus: v2 and v3. The OSS instance
- * (which hosts our project) uses v2.
+ * Note that there are two versions of Nexus: v2 and v3. The OSS instance (which hosts our project)
+ * uses v2.
  *
  * The Nexus docs are here: https://help.sonatype.com/repomanager2
  * The REST docs are here: https://repository.sonatype
  * .org/nexus-restlet1x-plugin/default/docs/index.html
- * Warning: the docs are very patchy!
+ * The docs are very patchy!
  */
 class SonatypeClient {
 
@@ -155,9 +154,7 @@ class SonatypeClient {
                 }
             })
     /**
-     * Global storage of URLs for a rootProject. Gradle may reuse the demon
-     * (hence its classloader) so we cannot just store this in a simple static
-     * field.
+     * Global storage of URLs for a rootProject.
      */
     private static final STAGING_URL_CACHE = new ConcurrentHashMap();
     private final project
@@ -184,7 +181,8 @@ class SonatypeClient {
             // Ensures that we don't create spurious repositories if we're not
             // running a release.
             if (project.properties.containsKey("release")) {
-                // Creates a staging repository exactly once per root project.
+                // Gradle may reuse the demon (hence its classloader) so this uses a map to store
+                // the staging repo for each build.
                 return STAGING_URL_CACHE.computeIfAbsent(
                         project.rootProject, { project -> this.createStagingRepository() })
             }

--- a/buildSrc/src/main/groovy/com.google.api-ads.nexus-publish.gradle
+++ b/buildSrc/src/main/groovy/com.google.api-ads.nexus-publish.gradle
@@ -25,8 +25,6 @@ plugins {
     id 'maven-publish'
 }
 
-import java.nio.charset.StandardCharsets
-
 import com.google.api.client.http.GenericUrl
 import com.google.api.client.http.HttpHeaders
 import com.google.api.client.http.HttpRequest
@@ -36,8 +34,9 @@ import com.google.api.client.http.xml.XmlHttpContent
 import com.google.api.client.util.Key
 import com.google.api.client.xml.XmlNamespaceDictionary
 import com.google.api.client.xml.XmlObjectParser
-
+import java.nio.charset.StandardCharsets
 import java.util.concurrent.ConcurrentHashMap
+import org.gradle.api.GradleException
 
 // ---------------- Google HTTP client data binding classes --------------------
 // Nexus REST API uses XML over HTTP - yey!
@@ -52,8 +51,7 @@ class AuthHeaders extends HttpHeaders {
         // Generates the base 64 encoded version of user:pass which is specified
         // in headers.
         def encodedCredential = Base64.encoder.encode("${user}:${password}".bytes)
-        this.authorization = "Basic " +
-                new String(encodedCredential, StandardCharsets.UTF_8)
+        this.authorization = "Basic " + new String(encodedCredential, StandardCharsets.UTF_8)
     }
 }
 
@@ -171,15 +169,16 @@ class SonatypeClient {
      * Provides the Sonatype repository URL to use for deploying releases.
      *
      * Attempts to create a named staging repository to avoid using Nexus auto-staging if
-     * possible. Based on the observation that auto-staging's heuristic for which artifacts
+     * possible. If not possible to create a named staging repository, falls back to auto-staging.
+     *
+     * This is motivated by the observation that auto-staging's heuristic for which artifacts
      * belong in the same repository is often confused by Gradle's publish mechanism, which
      * appears to create a new TCP connection for each artifact. This also appears to be flaky
      * based on the sonatype server load.
      */
     def discoverSonatypeRepositoryUrl() {
         try {
-            // Ensures that we don't create spurious repositories if we're not
-            // running a release.
+            // Ensures that we don't create spurious repositories if we're not running a release.
             if (project.properties.containsKey("release")) {
                 // Gradle may reuse the demon (hence its classloader) so this uses a map to store
                 // the staging repo for each build.
@@ -190,9 +189,9 @@ class SonatypeClient {
                 return AUTO_STAGING_URL
             }
         } catch (Exception ex) {
-            // Handles unexpected exception by falling back to auto-staging.
-            logger.warn("BUG BUG BUG! Failed to create new staging repo. I'll attempt to deploy " +
-                    "with auto-staging. The release *may* complete as planned. You can proceed by" +
+            // Handles issues by falling back to auto-staging.
+            logger.warn("Failed to create new staging repo. Attempting to deploy with " +
+                    "auto-staging. The release *may* complete as planned. You can proceed by" +
                     " making sure that all release artifacts are present in the auto-staging " +
                     "repository. Please investigate why staging failed to create.", ex)
             return AUTO_STAGING_URL
@@ -209,21 +208,21 @@ class SonatypeClient {
             logger.warn("Found multiple staging profiles, using the first one")
         }
         def stagingStartUrl = new GenericUrl(stagingProfileUrls[0] + "/start")
-        def content = new PromoteRequestXmlContent(NAMESPACE_DICTIONARY, generateStagingRepoDescription())
+        def content = new PromoteRequestXmlContent(
+                NAMESPACE_DICTIONARY, generateStagingRepoDescription())
         def response = REQUEST_FACTORY
                 .buildPostRequest(stagingStartUrl, content)
                 .setHeaders(authHeaders)
                 .execute()
-        // Checks the response and returns the repository URL, falling back to
-        // auto-staging if something went wrong.
+        // Checks the response and returns the repository URL, falling back to auto-staging if
+        // something went wrong.
         if (response.getStatusCode() == 201) { // HTTP 201 = Created
             def parsed = response.parseAs(PromoteRequestXmlContent.PromoteRequest.class)
             logger.info("Staging repository created with ID ${parsed.data.stagedRepositoryId}")
             return DEPLOY_BY_REPO_URL_STEM + parsed.data.stagedRepositoryId
         } else {
-            logger.warn("Nexus failed to create staging repo: " +
+            throw new GradleException("Nexus failed to create staging repo: " +
                     "${response.getStatusCode()}: ${response.getStatusMessage()}")
-            return AUTO_STAGING_URL
         }
     }
 

--- a/buildSrc/src/main/groovy/com.google.api-ads.nexus-publish.gradle
+++ b/buildSrc/src/main/groovy/com.google.api-ads.nexus-publish.gradle
@@ -130,8 +130,7 @@ class PromoteRequestXmlContent extends XmlHttpContent {
  * uses v2.
  *
  * The Nexus docs are here: https://help.sonatype.com/repomanager2
- * The REST docs are here: https://repository.sonatype
- * .org/nexus-restlet1x-plugin/default/docs/index.html
+ * The REST docs are here: https://repository.sonatype.org/nexus-restlet1x-plugin/default/docs/index.html
  * The docs are very patchy!
  */
 class SonatypeClient {
@@ -214,8 +213,8 @@ class SonatypeClient {
                 .buildPostRequest(stagingStartUrl, content)
                 .setHeaders(authHeaders)
                 .execute()
-        // Checks the response and returns the repository URL, falling back to auto-staging if
-        // something went wrong.
+        // Checks the response and returns the repository URL, throwing if we
+        // didn't get a valid response.
         if (response.getStatusCode() == 201) { // HTTP 201 = Created
             def parsed = response.parseAs(PromoteRequestXmlContent.PromoteRequest.class)
             logger.info("Staging repository created with ID ${parsed.data.stagedRepositoryId}")

--- a/buildSrc/src/main/groovy/com.google.api-ads.nexus-publish.gradle
+++ b/buildSrc/src/main/groovy/com.google.api-ads.nexus-publish.gradle
@@ -185,6 +185,9 @@ class SonatypeClient {
                 // the staging repo for each build.
                 return STAGING_URL_CACHE.computeIfAbsent(
                         project.rootProject, { project -> this.createStagingRepository() })
+            } else {
+                logger.debug("Release not enabled, defaulting to auto-staging")
+                return AUTO_STAGING_URL
             }
         } catch (Exception ex) {
             // Handles unexpected exception by falling back to auto-staging.

--- a/buildSrc/src/main/groovy/com.google.api-ads.nexus-publish.gradle
+++ b/buildSrc/src/main/groovy/com.google.api-ads.nexus-publish.gradle
@@ -39,7 +39,12 @@ import com.google.api.client.util.Key
 import com.google.api.client.xml.XmlNamespaceDictionary
 import com.google.api.client.xml.XmlObjectParser
 
-/** Defines data binding class for sending HTTP basic auth headers. */
+import java.util.concurrent.ConcurrentHashMap
+
+// ---------------- Google HTTP client data binding classes --------------------
+// Uses the powerful data-binding in Google HTTP client to avoid handling XML.
+
+/** Defines data binding class for HTTP basic auth headers. */
 class AuthHeaders extends HttpHeaders {
     @Key("Authorization")
     public String authorization
@@ -68,52 +73,99 @@ class AuthHeaders extends HttpHeaders {
  *     </promoteRequest>
  * </pre>
  */
-class PromoteRequest {
-    @Key
-    public PromoteRequestData data
-
-    PromoteRequest() {}
-
-    PromoteRequest(String description) {
-        data = new PromoteRequestData(description)
+class PromoteRequestXmlContent extends XmlHttpContent {
+    PromoteRequestXmlContent(namespaceDictionary, description) {
+        super(namespaceDictionary,
+                "promoteRequest",
+                new PromoteRequest(description))
     }
 
-    static class PromoteRequestData {
-        /** Appears next to the staging repo in the Nexus UI. */
+    /** Defines top-level payload of PromoteRequest. */
+    static class PromoteRequest {
         @Key
-        public String description
+        public PromoteRequestData data
 
-        /** Returned by Nexus. This is the newly created repository ID. */
-        @Key
-        public String stagedRepositoryId
+        PromoteRequest() {}
 
-        PromoteRequestData() {}
+        PromoteRequest(String description) {
+            data = new PromoteRequestData(description)
+        }
 
-        PromoteRequestData(String description) {
-            this.description = description
+        static class PromoteRequestData {
+            /** Appears next to the staging repo in the Nexus UI. */
+            @Key
+            public String description
+
+            /** Returned by Nexus. This is the newly created repository ID. */
+            @Key
+            public String stagedRepositoryId
+
+            PromoteRequestData() {}
+
+            PromoteRequestData(String description) {
+                this.description = description
+            }
         }
     }
 }
-
 
 // Global variables for the created repository URL are stored in the root
 // project. It isn't declared in SonatypeClient, since Gradle may reuse the
 // VM instance (and its classloader) and so would reuse the previous
 // staging repository ID.
-project.rootProject.ext.NEXUS_CLIENT_LOCK = new Object();
-project.rootProject.ext.STAGING_REPO_URL = null
+//project.rootProject.ext.STAGING_REPO_URL = null
 
-/** Defines a class which implements a client for Sonatype Nexus. */
+// -------------------------- Nexus client implementation ----------------------
+
+
+/**
+ * Implements a client for Sonatype Nexus.
+ *
+ * Pass --info to gradle to see the HTTP traffic.
+ * Logging of raw HTTP is handled by the the HTTP client (google-java-http-client) which uses JUL.
+ *
+ * This implementation is based on:
+ * https://support.sonatype.com/hc/en-us/articles/213465868-Uploading-to-a-Staging-Repository-via
+ * -REST-API
+ *
+ * Note that there are two versions of Nexus: v2 and v3. The OSS instance
+ * (which hosts our project) uses v2.
+ *
+ * The Nexus docs are here: https://help.sonatype.com/repomanager2
+ * The REST docs are here: https://repository.sonatype
+ * .org/nexus-restlet1x-plugin/default/docs/index.html
+ * Warning: the docs are very patchy!
+ */
 class SonatypeClient {
 
     private static final logger = org.slf4j.LoggerFactory.getLogger(SonatypeClient.class)
-    private static final AUTO_STAGING_URL = "https://oss.sonatype.org/service/local/staging/deploy/maven2"
-    private static final DEPLOY_BY_REPO_URL_STEM = "https://oss.sonatype.org/service/local/staging/deployByRepositoryId/"
-    private static final STAGING_START_URL = "https://oss.sonatype.org/service/local/staging/profiles/171a30b2ab63be/start"
+    private static final AUTO_STAGING_URL = "https://oss.sonatype" +
+            ".org/service/local/staging/deploy/maven2"
+    private static final DEPLOY_BY_REPO_URL_STEM = "https://oss.sonatype" +
+            ".org/service/local/staging/deployByRepositoryId/"
+    // Uses the Staging Profile on Nexus that Sonatype folks created.
+    // Hard-codes the ID since there is only one. Retrieve this with:
+    // curl -X GET \
+    //   --header 'Authorization: Basic <base64 encoded user:pass>' \
+    //   'https://oss.sonatype.org/service/local/staging/profiles'
+    // Needs to be updated if we move to a new Nexus instance.
+    private static final STAGING_START_URL = new GenericUrl("https://oss.sonatype" +
+            ".org/service/local/staging/profiles/171a30b2ab63be/start")
+    private static final NAMESPACE_DICTIONARY = new XmlNamespaceDictionary().set("", "")
+    /**
+     * Global storage of URLs for a rootProject. Gradle may reuse the demon
+     * (hence its classloader) so we cannot just store this in a simple static
+     * field.
+     */
+    private static final STAGING_URL_CACHE = new ConcurrentHashMap();
     private final project
+    private final authHeaders
 
     SonatypeClient(project) {
         this.project = project
+        this.authHeaders = new AuthHeaders(
+                project.properties.get("sonatypeUser"),
+                project.properties.get("sonatypePassword"))
     }
 
     /**
@@ -121,11 +173,11 @@ class SonatypeClient {
      *
      * <p/>
      *
-     * Attempts to create a named staging repository to avoid using Nexus
-     * auto-staging if possible. Based on the observation that auto-staging's
-     * heuristic for which artifacts belong in the same repository is often
-     * confused by Gradle's publish mechanism, which appears to create a new TCP
-     * connection for each artifact.
+     * Attempts to create a named staging repository to avoid using Nexus auto-staging if
+     * possible. Based on the observation that auto-staging's heuristic for which artifacts
+     * belong in the same repository is often confused by Gradle's publish mechanism, which
+     * appears to create a new TCP connection for each artifact. This also appears to be flaky
+     * based on the sonatype server load.
      */
     def discoverSonatypeRepositoryUrl() {
         // Catches any unexpected exceptions.
@@ -137,96 +189,60 @@ class SonatypeClient {
             // Ensures that we don't create spurious repositories if we're not
             // running a release.
             if (project.properties.containsKey("release")) {
-                // Avoids creating the staging repository more than once.
-                // Implements double checked locking to initialize STAGING_REPO_URL.
-                // Initializes the URL on the first execution.
-                if (project.rootProject.ext.STAGING_REPO_URL == null) {
-                    synchronized (project.rootProject.ext.NEXUS_CLIENT_LOCK) {
-                        return project.rootProject.ext.STAGING_REPO_URL = createStagingRepository()
-                    }
-                } else {
-                    // On subsequent executions we can use the initialized URL.
-                    return project.rootProject.ext.STAGING_REPO_URL
-                }
+                return STAGING_URL_CACHE.computeIfAbsent(
+                        project.rootProject, { project -> this.createStagingRepository() })
             }
         } catch (Exception ex) {
             // Handles unexpected exception by falling back to auto-staging.
             // Tells the user they should look into this, but it's not blocking
             // for their release (assuming Nexus and Gradle get it right without
             // babysitting).
-            logger.warn("BUG BUG BUG! Failed to create new staging repo. "
-                    + "I'll attempt to deploy with auto-staging. "
-                    + "The release *may* complete as planned. "
-                    + "You can proceed by making sure that all release artifacts are present in the same staging repository. "
-                    + "Please investigate why staging failed to create when able.", ex)
+            logger.warn("BUG BUG BUG! Failed to create new staging repo. I'll attempt to deploy " +
+                    "with auto-staging. The release *may* complete as planned. You can proceed by" +
+                    " making sure that all release artifacts are present in the same staging " +
+                    "repository. Please investigate why staging failed to create.", ex)
             return AUTO_STAGING_URL
         }
     }
 
     /** Creates a staging repository on Sonatype. */
     private def createStagingRepository() {
-        // Implements the REST call to create a staging repository.
-        // Note that there are two versions of Nexus: v2 and v3. The OSS instance
-        // (which hosts our project) uses v2.
-
-        // The Nexus docs are here: https://help.sonatype.com/repomanager2
-        // The REST docs are here: https://repository.sonatype.org/nexus-restlet1x-plugin/default/docs/index.html
-        // Warning: the docs are very patchy!
-        // This implementation is based on:
-        //   https://support.sonatype.com/hc/en-us/articles/213465868-Uploading-to-a-Staging-Repository-via-REST-API
-
-        // Configures Google HTTP client.
-        // Logging of raw HTTP is handled by the client. Enable it by setting
-        //   -Djava.util.logging.config.file=$(readlink -f logging.properties)
-        // Create logging.properties with the contents:
-        //   handlers=java.util.logging.ConsoleHandler
-        //   java.util.logging.ConsoleHandler.level=ALL
-        //   com.google.api.client.http.level=ALL
-        def namespaceDictionary = new XmlNamespaceDictionary().set("", "")
+        logger.info("Creating staging repository")
         def requestFactory = new NetHttpTransport()
                 .createRequestFactory(new HttpRequestInitializer() {
                     @Override
                     void initialize(HttpRequest request) throws IOException {
-                        request.setParser(new XmlObjectParser(namespaceDictionary))
+                        request.setParser(new XmlObjectParser(NAMESPACE_DICTIONARY))
                     }
                 })
-        def authHeaders = new AuthHeaders(
-                project.properties.get("sonatypeUser"),
-                project.properties.get("sonatypePassword"))
-        // Uses the Staging Profile on Nexus that Sonatype folks created.
-        // Hard-codes the ID since there is only one. Retrieve this with:
-        // curl -X GET \
-        //   --header 'Authorization: Basic <base64 encoded user:pass>' \
-        //   'https://oss.sonatype.org/service/local/staging/profiles'
-        // Needs to be updated if we move to a new Nexus instance.
-        def startStagingUrl = new GenericUrl(STAGING_START_URL)
-        // Creates and executes a request to add a new staging repository.
-        def content = new XmlHttpContent(
-                namespaceDictionary,
-                "promoteRequest",
-                new PromoteRequest(
-                        "Release of Google Ads API v${project.version} " +
-                                "on ${InetAddress.getLocalHost().getCanonicalHostName()} " +
-                                "${new Date()}"))
-        logger.info("Creating staging repository")
+        def content = new PromoteRequestXmlContent(NAMESPACE_DICTIONARY, generateStagingRepoName())
         def response = requestFactory
-                .buildPostRequest(startStagingUrl, content)
+                .buildPostRequest(STAGING_START_URL, content)
                 .setHeaders(authHeaders)
                 .execute()
         // Checks the response and returns the repository URL, falling back to
         // auto-staging if something went wrong.
         if (response.getStatusCode() == 201) { // HTTP 201 = Created
-            def parsed = response.parseAs(PromoteRequest.class)
+            def parsed = response.parseAs(PromoteRequestXmlContent.PromoteRequest.class)
             logger.info("Staging repository created with ID ${parsed.data.stagedRepositoryId}")
             return DEPLOY_BY_REPO_URL_STEM + parsed.data.stagedRepositoryId
         } else {
-            logger.info("Unable to create staging repository, falling back to auto-staging")
+            logger.warn("Nexus failed to create staging repo: " +
+                    "${response.getStatusCode()}: ${response.getStatusMessage()}")
             return AUTO_STAGING_URL
         }
     }
+
+    private def generateStagingRepoName() {
+        return "Release of Google Ads API v${project.version} " +
+                "on ${InetAddress.getLocalHost().getCanonicalHostName()} " +
+                "${new Date()}"
+    }
 }
 
-// Configures gradle's native publishing now that debacle is done.
+// ----------------------- Gradle project configuration ------------------------
+
+// Configures gradle's native publishing now that debacle is over.
 publishing {
     publications {
         maven(MavenPublication) {

--- a/buildSrc/src/main/groovy/com.google.api-ads.nexus-publish.gradle
+++ b/buildSrc/src/main/groovy/com.google.api-ads.nexus-publish.gradle
@@ -1,0 +1,232 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Defines a plugin which will automatically configure gradle publish.
+ *
+ * <p/>
+ *
+ * Test this class by setting a non-snapshot version in gradle.properties.
+ * Nexus rejects snapshot artifacts with HTTP 400 (and little else).
+ */
+
+plugins {
+    id 'maven-publish'
+}
+
+import java.nio.charset.StandardCharsets
+
+import com.google.api.client.http.GenericUrl
+import com.google.api.client.http.HttpHeaders
+import com.google.api.client.http.HttpRequest
+import com.google.api.client.http.HttpRequestInitializer
+import com.google.api.client.http.javanet.NetHttpTransport
+import com.google.api.client.http.xml.XmlHttpContent
+import com.google.api.client.util.Key
+import com.google.api.client.xml.XmlNamespaceDictionary
+import com.google.api.client.xml.XmlObjectParser
+
+/** Defines data binding class for sending HTTP basic auth headers. */
+class AuthHeaders extends HttpHeaders {
+    @Key("Authorization")
+    public String authorization
+
+    AuthHeaders(String user, String password) {
+        // Generates the base 64 encoded version of user:pass which is specified
+        // in headers.
+        def encodedCredential = Base64.encoder.encode("${user}:${password}".bytes)
+        this.authorization = "Basic " +
+                new String(encodedCredential, StandardCharsets.UTF_8)
+    }
+}
+
+/**
+ * Defines data binding class for Nexus POST request to create staging repo.
+ *
+ * <p/>
+ *
+ * Serializes as XML and will look like the following:
+ *
+ * <pre>
+ *     <promoteRequest>
+ *         <data>
+ *             <description>some description here</description>
+ *         </data>
+ *     </promoteRequest>
+ * </pre>
+ */
+class PromoteRequest {
+    @Key
+    public PromoteRequestData data
+
+    PromoteRequest() {}
+
+    PromoteRequest(String description) {
+        data = new PromoteRequestData(description)
+    }
+
+    static class PromoteRequestData {
+        /** Appears next to the staging repo in the Nexus UI. */
+        @Key
+        public String description
+
+        /** Returned by Nexus. This is the newly created repository ID. */
+        @Key
+        public String stagedRepositoryId
+
+        PromoteRequestData() {}
+
+        PromoteRequestData(String description) {
+            this.description = description
+        }
+    }
+}
+
+
+// Global variables for the created repository URL are stored in the root
+// project. It isn't declared in SonatypeClient, since Gradle may reuse the
+// VM instance (and its classloader) and so would reuse the previous
+// staging repository ID.
+project.rootProject.ext.NEXUS_CLIENT_LOCK = new Object();
+project.rootProject.ext.STAGING_REPO_URL = null
+
+/** Defines a class which implements a client for Sonatype Nexus. */
+class SonatypeClient {
+
+    private static final logger = org.slf4j.LoggerFactory.getLogger(SonatypeClient.class)
+    private static final AUTO_STAGING_URL = "https://oss.sonatype.org/service/local/staging/deploy/maven2"
+    private static final DEPLOY_BY_REPO_URL_STEM = "https://oss.sonatype.org/service/local/staging/deployByRepositoryId/"
+    private static final STAGING_START_URL = "https://oss.sonatype.org/service/local/staging/profiles/171a30b2ab63be/start"
+    private final project
+
+    SonatypeClient(project) {
+        this.project = project
+    }
+
+    /**
+     * Provides the Sonatype repository URL to use for deploying releases.
+     *
+     * <p/>
+     *
+     * Attempts to create a named staging repository to avoid using Nexus
+     * auto-staging if possible. Based on the observation that auto-staging's
+     * heuristic for which artifacts belong in the same repository is often
+     * confused by Gradle's publish mechanism, which appears to create a new TCP
+     * connection for each artifact.
+     */
+    def createSonatypeRepositoryUrl() {
+        // Avoids creating the staging repository more than once.
+        try {
+            // Guards the creation of a staging repo on the release property.
+            if (project.properties.containsKey("release")) {
+                // Implements double checked locking to initialize STAGING_REPO_URL.
+                // Initializes the URL on the first execution.
+                if (project.rootProject.ext.STAGING_REPO_URL == null) {
+                    synchronized (project.rootProject.ext.NEXUS_CLIENT_LOCK) {
+                        return project.rootProject.ext.STAGING_REPO_URL = createStagingRepository()
+                    }
+                } else {
+                    // On subsequent executions we can use the initialized URL.
+                    return project.rootProject.ext.STAGING_REPO_URL
+                }
+            }
+        } catch (Exception ex) {
+            logger.warn("Failed to create new staging repo, falling back to auto-staging")
+            return AUTO_STAGING_URL
+        }
+    }
+
+    /** Creates a staging repository on Sonatype. */
+    private def createStagingRepository() {
+        // Implements the REST call to create a staging repository.
+        // See https://support.sonatype.com/hc/en-us/articles/213465868-Uploading-to-a-Staging-Repository-via-REST-API
+        // Note that there are two versions of Nexus v2 and v3 and the OSS instance
+        // uses v2.
+        // The Nexus docs are here: https://help.sonatype.com/repomanager2
+        // The REST docs are here: https://repository.sonatype.org/nexus-restlet1x-plugin/default/docs/index.html
+        // Warning: the docs are very patchy!
+
+        // Configures Google HTTP client.
+        // Logging of raw HTTP is handled by the client. Enable it by setting
+        //   -Djava.util.logging.config.file=$(readlink -f logging.properties)
+        // Create logging.properties with the contents:
+        //   handlers=java.util.logging.ConsoleHandler
+        //   java.util.logging.ConsoleHandler.level=ALL
+        //   com.google.api.client.http.level=ALL
+        def namespaceDictionary = new XmlNamespaceDictionary().set("", "")
+        def requestFactory = new NetHttpTransport()
+                .createRequestFactory(new HttpRequestInitializer() {
+                    @Override
+                    void initialize(HttpRequest request) throws IOException {
+                        request.setParser(new XmlObjectParser(namespaceDictionary))
+                    }
+                })
+        def authHeaders = new AuthHeaders(
+                project.properties.get("sonatypeUser"),
+                project.properties.get("sonatypePassword"))
+        // Uses the Staging Profile on Nexus that Sonatype folks created.
+        // Hard-codes the ID since there is only one. Retrieve this with:
+        // curl -X GET \
+        //   --header 'Authorization: Basic <base64 encoded user:pass>' \
+        //   'https://oss.sonatype.org/service/local/staging/profiles'
+        // Needs to be updated if we move to a new Nexus instance.
+        def startStagingUrl = new GenericUrl(STAGING_START_URL)
+        // Creates and executes a request to add a new staging repository.
+        def content = new XmlHttpContent(
+                namespaceDictionary,
+                "promoteRequest",
+                new PromoteRequest(
+                        "Release of Google Ads API v${project.version} " +
+                                "on ${InetAddress.getLocalHost().getCanonicalHostName()} " +
+                                "${new Date()}"))
+        logger.info("Creating staging repository")
+        def response = requestFactory
+                .buildPostRequest(startStagingUrl, content)
+                .setHeaders(authHeaders)
+                .execute()
+        // Checks the response and returns the repository URL, falling back to
+        // auto-staging if something went wrong.
+        if (response.getStatusCode() == 201) { // HTTP 201 = Created
+            def parsed = response.parseAs(PromoteRequest.class)
+            logger.info("Staging repository created with ID ${parsed.data.stagedRepositoryId}")
+            return DEPLOY_BY_REPO_URL_STEM + parsed.data.stagedRepositoryId
+        } else {
+            logger.info("Unable to create staging repository, falling back to auto-staging")
+            return AUTO_STAGING_URL
+        }
+    }
+}
+
+// Configures gradle's native publishing now that debacle is done.
+publishing {
+    publications {
+        maven(MavenPublication) {
+            from(components.java)
+        }
+    }
+    repositories {
+        maven {
+            url new SonatypeClient(project).createSonatypeRepositoryUrl()
+            name = "sonatype"
+            credentials {
+                // Avoids storing Sonatype credentials in plain-text. Specify these on
+                // the command line: -PsonatypeUser=foo
+                username project.properties.get("sonatypeUser")
+                password project.properties.get("sonatypePassword")
+            }
+        }
+    }
+}

--- a/buildSrc/src/main/groovy/com.google.api-ads.nexus-publish.gradle
+++ b/buildSrc/src/main/groovy/com.google.api-ads.nexus-publish.gradle
@@ -59,6 +59,29 @@ class AuthHeaders extends HttpHeaders {
 }
 
 /**
+ * Defines data-binding to retrieve the staging profiles from sonatype. Staging repositories are
+ * created from a staging profile.
+ */
+class StagingProfiles {
+    @Key
+    public StagingProfilesData data
+
+    static class StagingProfilesData {
+        @Key
+        public List<StagingProfile> stagingProfile
+
+        static class StagingProfile {
+            @Key
+            public String resourceURI
+        }
+    }
+
+    def getStagingProfileUrls() {
+        return data.stagingProfile.collect { it.resourceURI }
+    }
+}
+
+/**
  * Defines data binding class for Nexus POST request to create staging repo.
  *
  * <p/>
@@ -109,14 +132,7 @@ class PromoteRequestXmlContent extends XmlHttpContent {
     }
 }
 
-// Global variables for the created repository URL are stored in the root
-// project. It isn't declared in SonatypeClient, since Gradle may reuse the
-// VM instance (and its classloader) and so would reuse the previous
-// staging repository ID.
-//project.rootProject.ext.STAGING_REPO_URL = null
-
 // -------------------------- Nexus client implementation ----------------------
-
 
 /**
  * Implements a client for Sonatype Nexus.
@@ -139,19 +155,20 @@ class PromoteRequestXmlContent extends XmlHttpContent {
 class SonatypeClient {
 
     private static final logger = org.slf4j.LoggerFactory.getLogger(SonatypeClient.class)
-    private static final AUTO_STAGING_URL = "https://oss.sonatype" +
-            ".org/service/local/staging/deploy/maven2"
-    private static final DEPLOY_BY_REPO_URL_STEM = "https://oss.sonatype" +
-            ".org/service/local/staging/deployByRepositoryId/"
-    // Uses the Staging Profile on Nexus that Sonatype folks created.
-    // Hard-codes the ID since there is only one. Retrieve this with:
-    // curl -X GET \
-    //   --header 'Authorization: Basic <base64 encoded user:pass>' \
-    //   'https://oss.sonatype.org/service/local/staging/profiles'
-    // Needs to be updated if we move to a new Nexus instance.
-    private static final STAGING_START_URL = new GenericUrl("https://oss.sonatype" +
-            ".org/service/local/staging/profiles/171a30b2ab63be/start")
+    private static final AUTO_STAGING_URL =
+            "https://oss.sonatype.org/service/local/staging/deploy/maven2"
+    private static final DEPLOY_BY_REPO_URL_STEM =
+            "https://oss.sonatype.org/service/local/staging/deployByRepositoryId/"
+    private static final STAGING_PROFILES_URL = new GenericUrl(
+            "https://oss.sonatype.org/service/local/staging/profiles")
     private static final NAMESPACE_DICTIONARY = new XmlNamespaceDictionary().set("", "")
+    private static final REQUEST_FACTORY = new NetHttpTransport()
+            .createRequestFactory(new HttpRequestInitializer() {
+                @Override
+                void initialize(HttpRequest request) throws IOException {
+                    request.setParser(new XmlObjectParser(NAMESPACE_DICTIONARY))
+                }
+            })
     /**
      * Global storage of URLs for a rootProject. Gradle may reuse the demon
      * (hence its classloader) so we cannot just store this in a simple static
@@ -180,26 +197,19 @@ class SonatypeClient {
      * based on the sonatype server load.
      */
     def discoverSonatypeRepositoryUrl() {
-        // Catches any unexpected exceptions.
-        // In theory nothing should throw and we should gracefully fall back to
-        // auto-staging. Catch-all here ensures that happens even if something
-        // goes awry.
         try {
-            // Guards the creation of a staging repo on the release property.
             // Ensures that we don't create spurious repositories if we're not
             // running a release.
             if (project.properties.containsKey("release")) {
+                // Creates a staging repository exactly once per root project.
                 return STAGING_URL_CACHE.computeIfAbsent(
                         project.rootProject, { project -> this.createStagingRepository() })
             }
         } catch (Exception ex) {
             // Handles unexpected exception by falling back to auto-staging.
-            // Tells the user they should look into this, but it's not blocking
-            // for their release (assuming Nexus and Gradle get it right without
-            // babysitting).
             logger.warn("BUG BUG BUG! Failed to create new staging repo. I'll attempt to deploy " +
                     "with auto-staging. The release *may* complete as planned. You can proceed by" +
-                    " making sure that all release artifacts are present in the same staging " +
+                    " making sure that all release artifacts are present in the auto-staging " +
                     "repository. Please investigate why staging failed to create.", ex)
             return AUTO_STAGING_URL
         }
@@ -208,16 +218,16 @@ class SonatypeClient {
     /** Creates a staging repository on Sonatype. */
     private def createStagingRepository() {
         logger.info("Creating staging repository")
-        def requestFactory = new NetHttpTransport()
-                .createRequestFactory(new HttpRequestInitializer() {
-                    @Override
-                    void initialize(HttpRequest request) throws IOException {
-                        request.setParser(new XmlObjectParser(NAMESPACE_DICTIONARY))
-                    }
-                })
-        def content = new PromoteRequestXmlContent(NAMESPACE_DICTIONARY, generateStagingRepoName())
-        def response = requestFactory
-                .buildPostRequest(STAGING_START_URL, content)
+        def stagingProfileUrls = getStagingProfileUrls()
+        if (stagingProfileUrls.size() == 0) {
+            throw new GradleException("No staging profiles found")
+        } else if (stagingProfileUrls.size() > 1) {
+            logger.warn("Found multiple staging profiles, using the first one")
+        }
+        def stagingStartUrl = new GenericUrl(stagingProfileUrls[0] + "/start")
+        def content = new PromoteRequestXmlContent(NAMESPACE_DICTIONARY, generateStagingRepoDescription())
+        def response = REQUEST_FACTORY
+                .buildPostRequest(stagingStartUrl, content)
                 .setHeaders(authHeaders)
                 .execute()
         // Checks the response and returns the repository URL, falling back to
@@ -233,7 +243,24 @@ class SonatypeClient {
         }
     }
 
-    private def generateStagingRepoName() {
+    /** Retrieves the staging profiles from Nexus. */
+    private def getStagingProfileUrls() {
+        logger.debug("Retrieving staging profiles")
+        def response = REQUEST_FACTORY
+                .buildGetRequest(STAGING_PROFILES_URL)
+                .setHeaders(authHeaders)
+                .execute()
+        if (response.getStatusCode() == 200) {
+            def parsed = response.parseAs(StagingProfiles.class)
+            return parsed.getStagingProfileUrls()
+        } else {
+            throw new GradleException("Failed to retrieve staging profiles: HTTP " +
+                    "${response.getStatusCode()}: ${response.getStatusMessage()}")
+        }
+    }
+
+    /** Generates a pseudo-unique and human readable description for a staging repo. */
+    private def generateStagingRepoDescription() {
         return "Release of Google Ads API v${project.version} " +
                 "on ${InetAddress.getLocalHost().getCanonicalHostName()} " +
                 "${new Date()}"

--- a/buildSrc/src/main/groovy/com.google.api-ads.nexus-publish.gradle
+++ b/buildSrc/src/main/groovy/com.google.api-ads.nexus-publish.gradle
@@ -17,8 +17,6 @@
 /**
  * Defines a plugin which will automatically configure gradle publish.
  *
- * <p/>
- *
  * Test this class by setting a non-snapshot version in gradle.properties.
  * Nexus rejects snapshot artifacts with HTTP 400 (and little else).
  */
@@ -42,7 +40,8 @@ import com.google.api.client.xml.XmlObjectParser
 import java.util.concurrent.ConcurrentHashMap
 
 // ---------------- Google HTTP client data binding classes --------------------
-// Uses the powerful data-binding in Google HTTP client to avoid handling XML.
+// Nexus REST API uses XML over HTTP - yey!
+// Leverages the data-binding in google-java-http-client to avoid handling XML.
 
 /** Defines data binding class for HTTP basic auth headers. */
 class AuthHeaders extends HttpHeaders {
@@ -81,21 +80,7 @@ class StagingProfiles {
     }
 }
 
-/**
- * Defines data binding class for Nexus POST request to create staging repo.
- *
- * <p/>
- *
- * Serializes as XML and will look like the following:
- *
- * <pre>
- *     <promoteRequest>
- *         <data>
- *             <description>some description here</description>
- *         </data>
- *     </promoteRequest>
- * </pre>
- */
+/** Defines data binding class for Nexus POST request to create staging repo. */
 class PromoteRequestXmlContent extends XmlHttpContent {
     PromoteRequestXmlContent(namespaceDictionary, description) {
         super(namespaceDictionary,
@@ -187,8 +172,6 @@ class SonatypeClient {
 
     /**
      * Provides the Sonatype repository URL to use for deploying releases.
-     *
-     * <p/>
      *
      * Attempts to create a named staging repository to avoid using Nexus auto-staging if
      * possible. Based on the observation that auto-staging's heuristic for which artifacts

--- a/buildSrc/src/main/groovy/com.google.api-ads.nexus-publish.gradle
+++ b/buildSrc/src/main/groovy/com.google.api-ads.nexus-publish.gradle
@@ -127,7 +127,7 @@ class SonatypeClient {
      * confused by Gradle's publish mechanism, which appears to create a new TCP
      * connection for each artifact.
      */
-    def createSonatypeRepositoryUrl() {
+    def discoverSonatypeRepositoryUrl() {
         // Catches any unexpected exceptions.
         // In theory nothing should throw and we should gracefully fall back to
         // auto-staging. Catch-all here ensures that happens even if something
@@ -149,10 +149,15 @@ class SonatypeClient {
                 }
             }
         } catch (Exception ex) {
+            // Handles unexpected exception by falling back to auto-staging.
+            // Tells the user they should look into this, but it's not blocking
+            // for their release (assuming Nexus and Gradle get it right without
+            // babysitting).
             logger.warn("BUG BUG BUG! Failed to create new staging repo. "
                     + "I'll attempt to deploy with auto-staging. "
                     + "The release *may* complete as planned. "
-                    + "Please investigate when able.", ex)
+                    + "You can proceed by making sure that all release artifacts are present in the same staging repository. "
+                    + "Please investigate why staging failed to create when able.", ex)
             return AUTO_STAGING_URL
         }
     }
@@ -227,7 +232,7 @@ publishing {
     }
     repositories {
         maven {
-            url new SonatypeClient(project).createSonatypeRepositoryUrl()
+            url new SonatypeClient(project).discoverSonatypeRepositoryUrl()
             name = "sonatype"
             credentials {
                 // Avoids storing Sonatype credentials in plain-text. Specify these on


### PR DESCRIPTION
By default when you deploy a release to Nexus, it uses a feature known as auto-staging. This uses a heuristic to determine how subsequent PUT requests are aggregated into common staging repositories. Invariably Gradle's publish plugin confuses this, possibly because it creates new TCP connections for every artifact (you can see this when running with --debug), or maybe because the Nexus server is overloaded. Rather than coerce the children into playing nice, this change creates a plugin which creates a named staging repository and deploys the release into it.

The plugin functionality boils down to:

1. Discover the staging profiles on Nexus with a GET request.
1. Create a new staging repository with a POST request.
2. Override the nexus URL given to the maven-publish plugin with https://oss.sonatype.org/service/local/staging/deployByRepositoryId/<the repo ID we just created>.

There's more detailed documentation in the code. The implementation was based on these docs: https://support.sonatype.com/hc/en-us/articles/213465868-Uploading-to-a-Staging-Repository-via-REST-API

Change-Id: I19767b3ccd99461b167997ea15730f109dff9443