### PR TITLE
Avoid NPE in GetKeywords example

### DIFF
--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/basicoperations/GetKeywords.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/basicoperations/GetKeywords.java
@@ -49,7 +49,7 @@ public class GetKeywords {
     private Long adGroupId;
 
     @Parameter(names = ArgumentNames.OMIT_UNSELECTED_RESOURCE_NAMES, arity = 1)
-    private Boolean omitUnselectedResourceNames;
+    private Boolean omitUnselectedResourceNames = false;
   }
 
   public static void main(String[] args) throws IOException {


### PR DESCRIPTION
Sets the default value if the user does not pass the
`--omitUnselectedResourceNames` parameter.