### PR TITLE
Retain GoogleAdsClient max inbound metadata and message size settings

### DIFF
--- a/google-ads/src/main/java/com/google/ads/googleads/lib/GoogleAdsClient.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/lib/GoogleAdsClient.java
@@ -70,6 +70,18 @@ public abstract class GoogleAdsClient extends AbstractGoogleAdsClient {
   /** The default endpoint for Google Ads API services. */
   private static final String DEFAULT_ENDPOINT = "googleads.googleapis.com:443";
 
+  /**
+   * Default max inbound metadata (headers) size. Inbound headers for the Google Ads API may exceed
+   * the default max of 8KB.
+   */
+  @VisibleForTesting static final Integer DEFAULT_INBOUND_METADATA_SIZE = 16 * 1024 * 1024;
+
+  /**
+   * Default max inbound message (response) size. Large response will often exceed the default of
+   * 4MB.
+   */
+  @VisibleForTesting static final Integer DEFAULT_INBOUND_MESSAGE_SIZE = 64 * 1024 * 1024;
+
   static {
     // Alpha feature to optimize the client startup time.
     Primer.primeBasicsIfEnabled();
@@ -88,12 +100,8 @@ public abstract class GoogleAdsClient extends AbstractGoogleAdsClient {
                             new RequestLogger(),
                             clientBuilder.getHeaders(),
                             clientBuilder.getEndpoint())))
-            // Issue 131: inbound headers may exceed default (8kb) max header size.
-            // Sets max header size to 16MB, which should be more than necessary.
-            .setMaxInboundMetadataSize(16 * 1024 * 1024)
-            // Sets max response size to 64MB, since large responses will often exceed the default
-            // (4MB).
-            .setMaxInboundMessageSize(64 * 1024 * 1024)
+            .setMaxInboundMetadataSize(DEFAULT_INBOUND_METADATA_SIZE)
+            .setMaxInboundMessageSize(DEFAULT_INBOUND_MESSAGE_SIZE)
             .build();
     clientBuilder
         .setEndpoint(DEFAULT_ENDPOINT)
@@ -584,6 +592,8 @@ public abstract class GoogleAdsClient extends AbstractGoogleAdsClient {
                         ImmutableList.of(
                             new LoggingInterceptor(
                                 new RequestLogger(), getHeaders(), getEndpoint())))
+                .setMaxInboundMetadataSize(DEFAULT_INBOUND_METADATA_SIZE)
+                .setMaxInboundMessageSize(DEFAULT_INBOUND_MESSAGE_SIZE)
                 .build();
       }
       if (transportChannelProvider.needsHeaders()) {

--- a/google-ads/src/main/java/com/google/ads/googleads/lib/GoogleAdsClient.java
+++ b/google-ads/src/main/java/com/google/ads/googleads/lib/GoogleAdsClient.java
@@ -74,13 +74,13 @@ public abstract class GoogleAdsClient extends AbstractGoogleAdsClient {
    * Default max inbound metadata (headers) size. Inbound headers for the Google Ads API may exceed
    * the default max of 8KB.
    */
-  @VisibleForTesting static final Integer DEFAULT_INBOUND_METADATA_SIZE = 16 * 1024 * 1024;
+  @VisibleForTesting static final Integer DEFAULT_MAX_INBOUND_METADATA_SIZE = 16 * 1024 * 1024;
 
   /**
    * Default max inbound message (response) size. Large response will often exceed the default of
    * 4MB.
    */
-  @VisibleForTesting static final Integer DEFAULT_INBOUND_MESSAGE_SIZE = 64 * 1024 * 1024;
+  @VisibleForTesting static final Integer DEFAULT_MAX_INBOUND_MESSAGE_SIZE = 64 * 1024 * 1024;
 
   static {
     // Alpha feature to optimize the client startup time.
@@ -100,8 +100,8 @@ public abstract class GoogleAdsClient extends AbstractGoogleAdsClient {
                             new RequestLogger(),
                             clientBuilder.getHeaders(),
                             clientBuilder.getEndpoint())))
-            .setMaxInboundMetadataSize(DEFAULT_INBOUND_METADATA_SIZE)
-            .setMaxInboundMessageSize(DEFAULT_INBOUND_MESSAGE_SIZE)
+            .setMaxInboundMetadataSize(DEFAULT_MAX_INBOUND_METADATA_SIZE)
+            .setMaxInboundMessageSize(DEFAULT_MAX_INBOUND_MESSAGE_SIZE)
             .build();
     clientBuilder
         .setEndpoint(DEFAULT_ENDPOINT)
@@ -592,8 +592,8 @@ public abstract class GoogleAdsClient extends AbstractGoogleAdsClient {
                         ImmutableList.of(
                             new LoggingInterceptor(
                                 new RequestLogger(), getHeaders(), getEndpoint())))
-                .setMaxInboundMetadataSize(DEFAULT_INBOUND_METADATA_SIZE)
-                .setMaxInboundMessageSize(DEFAULT_INBOUND_MESSAGE_SIZE)
+                .setMaxInboundMetadataSize(DEFAULT_MAX_INBOUND_METADATA_SIZE)
+                .setMaxInboundMessageSize(DEFAULT_MAX_INBOUND_MESSAGE_SIZE)
                 .build();
       }
       if (transportChannelProvider.needsHeaders()) {

--- a/google-ads/src/test/java/com/google/ads/googleads/lib/GoogleAdsClientTest.java
+++ b/google-ads/src/test/java/com/google/ads/googleads/lib/GoogleAdsClientTest.java
@@ -39,6 +39,7 @@ import com.google.ads.googleads.v10.services.SearchGoogleAdsStreamRequest;
 import com.google.ads.googleads.v10.services.SearchGoogleAdsStreamResponse;
 import com.google.api.gax.grpc.GaxGrpcProperties;
 import com.google.api.gax.grpc.GrpcStatusCode;
+import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider;
 import com.google.api.gax.grpc.testing.LocalChannelProvider;
 import com.google.api.gax.grpc.testing.MockServiceHelper;
 import com.google.api.gax.rpc.ApiClientHeaderProvider;
@@ -190,10 +191,7 @@ public class GoogleAdsClientTest {
 
     // Build a new client from the file.
     GoogleAdsClient client =
-        GoogleAdsClient.newBuilder()
-            .fromPropertiesFile(propertiesFile)
-            .setTransportChannelProvider(localChannelProvider)
-            .build();
+        GoogleAdsClient.newBuilder().fromPropertiesFile(propertiesFile).build();
     assertGoogleAdsClient(client, null, true);
   }
 
@@ -253,7 +251,7 @@ public class GoogleAdsClientTest {
 
   /** Tests building a client without the use of a properties file. */
   @Test
-  public void buildWithoutPropertiesFile_supportsAllFields() throws IOException {
+  public void buildWithoutPropertiesFile_supportsAllFields() {
     Credentials credentials =
         UserCredentials.newBuilder()
             .setClientId(CLIENT_ID)
@@ -265,7 +263,6 @@ public class GoogleAdsClientTest {
             .setCredentials(credentials)
             .setDeveloperToken(DEVELOPER_TOKEN)
             .setLoginCustomerId(LOGIN_CUSTOMER_ID)
-            .setTransportChannelProvider(localChannelProvider)
             .build();
     assertGoogleAdsClient(client, true);
   }
@@ -886,6 +883,20 @@ public class GoogleAdsClientTest {
           "Scope",
           Collections.singleton("https://www.googleapis.com/auth/adwords"),
           serviceAccountCredentials.getScopes());
+    }
+
+    if (client.getTransportChannelProvider() == client.getDefaultTransportChannelProvider()) {
+      InstantiatingGrpcChannelProvider channelProvider =
+          (InstantiatingGrpcChannelProvider) client.getTransportChannelProvider();
+      assertEquals(
+          "Max inbound metadata size",
+          GoogleAdsClient.DEFAULT_INBOUND_METADATA_SIZE,
+          channelProvider.getMaxInboundMetadataSize());
+      assertEquals(
+          "Max inbound message size",
+          GoogleAdsClient.DEFAULT_INBOUND_MESSAGE_SIZE,
+          // For some reason, this setting is only available on the builder.
+          channelProvider.toBuilder().getMaxInboundMessageSize());
     }
 
     assertEquals("Developer token", DEVELOPER_TOKEN, client.getDeveloperToken());

--- a/google-ads/src/test/java/com/google/ads/googleads/lib/GoogleAdsClientTest.java
+++ b/google-ads/src/test/java/com/google/ads/googleads/lib/GoogleAdsClientTest.java
@@ -890,11 +890,11 @@ public class GoogleAdsClientTest {
           (InstantiatingGrpcChannelProvider) client.getTransportChannelProvider();
       assertEquals(
           "Max inbound metadata size",
-          GoogleAdsClient.DEFAULT_INBOUND_METADATA_SIZE,
+          GoogleAdsClient.DEFAULT_MAX_INBOUND_METADATA_SIZE,
           channelProvider.getMaxInboundMetadataSize());
       assertEquals(
           "Max inbound message size",
-          GoogleAdsClient.DEFAULT_INBOUND_MESSAGE_SIZE,
+          GoogleAdsClient.DEFAULT_MAX_INBOUND_MESSAGE_SIZE,
           // For some reason, this setting is only available on the builder.
           channelProvider.toBuilder().getMaxInboundMessageSize());
     }


### PR DESCRIPTION
Fixes #565 