### PR TITLE
Remove include of `:google-ads-stubs-v7` in parent project

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -32,7 +32,6 @@ if (!startParameter.projectProperties.containsKey("release")) {
 
 // Keep the stubs modules at the end of this file. The stubs generator will
 // append new modules here as required. There should *not* be a newline at EOF.
-include ':google-ads-stubs-v7'
 include ':google-ads-stubs-v8'
 include ':google-ads-stubs-v9'
 include ':google-ads-stubs-v10'


### PR DESCRIPTION
v7 support was removed from the library in release 17.0.0, but we missed
removing this line. As a result the artifacts published to Maven
include the v7 stubs library, even though v7 is no longer accessible
or supported in `google-ads-java`. For example, `GoogleAdsAllVersions`
no longer contains a `getVersion7()` method.