### PR TITLE
Added @Internal annotation

### DIFF
--- a/buildSrc/src/main/groovy/com.google.api-ads.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/com.google.api-ads.java-conventions.gradle
@@ -162,6 +162,7 @@ disableUnlessPublishing(tasks.sourcesJar)
 class ExampleRunnerTask extends JavaExec {
 
   // The base package for all examples.
+  @Internal
   private String basePackage = 'com.google.ads.googleads.examples.'
 
   // Hints for failed executions.


### PR DESCRIPTION
Added annotation so that gradle does not complain.

See more here https://docs.gradle.org/7.4.2/userguide/validation_problems.html#missing_annotation

Without annotation I was getting:

```
➜  google-ads-examples git:(main) ✗ gradle -q runExample --example="basicoperations.GetCampaigns --customerId XXXX"

FAILURE: Build failed with an exception.

* What went wrong:
A problem was found with the configuration of task ':google-ads-examples:runExample' (type 'ExampleRunnerTask').
  - In plugin 'com.google.api-ads.nexus-publish' type 'ExampleRunnerTask' property 'basePackage' is missing an input or output annotation.
    
    Reason: A property without annotation isn't considered during up-to-date checking.
    
    Possible solutions:
      1. Add an input or output annotation.
      2. Mark it as @Internal.
    
    Please refer to https://docs.gradle.org/7.4.2/userguide/validation_problems.html#missing_annotation for more details about this problem.

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.

* Get more help at https://help.gradle.org

```