### PR TITLE
Add note about RPC_DEADLINE_TOO_SHORT to SetCustomClientTimeouts

### DIFF
--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/misc/SetCustomClientTimeouts.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/misc/SetCustomClientTimeouts.java
@@ -109,6 +109,9 @@ public class SetCustomClientTimeouts {
                       .setQuery("SELECT campaign.id FROM campaign")
                       .build(),
                   // Sets the timeout to use.
+                  // Note: This overrides the default value and can lead to
+                  // RequestError.RPC_DEADLINE_TOO_SHORT errors when too small. We recommend
+                  // to do it only if necessary.
                   GrpcCallContext.createDefault()
                       .withTimeout(Duration.ofMillis(CLIENT_TIMEOUT_MILLIS)));
       // Iterates over all rows in all messages and collects the campaign IDs.


### PR DESCRIPTION
Mirrors change from PHP in
https://github.com/googleads/google-ads-php/pull/832.