### PR TITLE
Remove the usage of eCPC bidding because of its deprecation

### DIFF
--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/shoppingads/AddShoppingProductAd.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/shoppingads/AddShoppingProductAd.java
@@ -237,11 +237,11 @@ public class AddShoppingProductAd {
             // the ads from immediately serving. Set to ENABLED once you've added
             // targeting and the ads are ready to serve.
             .setStatus(CampaignStatus.PAUSED)
-            // Sets the bidding strategy to Manual CPC (with eCPC enabled)
+            // Sets the bidding strategy to Manual CPC (with eCPC disabled)
             // Recommendation: Use one of the automated bidding strategies for Shopping campaigns
             // to help you optimize your advertising spend. More information can be found here:
             // https://support.google.com/google-ads/answer/6309029.
-            .setManualCpc(ManualCpc.newBuilder().setEnhancedCpcEnabled(true).build())
+            .setManualCpc(ManualCpc.newBuilder().setEnhancedCpcEnabled(false).build())
             // Sets the budget.
             .setCampaignBudget(budgetResourceName)
             .build();

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/shoppingads/AddShoppingProductAd.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/shoppingads/AddShoppingProductAd.java
@@ -237,7 +237,10 @@ public class AddShoppingProductAd {
             // the ads from immediately serving. Set to ENABLED once you've added
             // targeting and the ads are ready to serve.
             .setStatus(CampaignStatus.PAUSED)
-            // Sets the bidding strategy to Manual CPC (with eCPC disabled)
+            // Sets the bidding strategy to Manual CPC (with eCPC disabled). eCPC for standard
+            // Shopping campaigns is deprecated. If eCPC is set to true, Google Ads ignores the
+            // the setting and behaves as if the setting was false. See this blog post for more
+            // information: https://ads-developers.googleblog.com/2023/09/google-ads-shopping-campaign-enhanced.html
             // Recommendation: Use one of the automated bidding strategies for Shopping campaigns
             // to help you optimize your advertising spend. More information can be found here:
             // https://support.google.com/google-ads/answer/6309029.

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/shoppingads/AddShoppingProductAd.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/shoppingads/AddShoppingProductAd.java
@@ -240,7 +240,8 @@ public class AddShoppingProductAd {
             // Sets the bidding strategy to Manual CPC (with eCPC disabled). eCPC for standard
             // Shopping campaigns is deprecated. If eCPC is set to true, Google Ads ignores the
             // the setting and behaves as if the setting was false. See this blog post for more
-            // information: https://ads-developers.googleblog.com/2023/09/google-ads-shopping-campaign-enhanced.html
+            // information:
+            // https://ads-developers.googleblog.com/2023/09/google-ads-shopping-campaign-enhanced.html
             // Recommendation: Use one of the automated bidding strategies for Shopping campaigns
             // to help you optimize your advertising spend. More information can be found here:
             // https://support.google.com/google-ads/answer/6309029.

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/shoppingads/AddShoppingProductAd.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/shoppingads/AddShoppingProductAd.java
@@ -239,7 +239,7 @@ public class AddShoppingProductAd {
             .setStatus(CampaignStatus.PAUSED)
             // Sets the bidding strategy to Manual CPC (with eCPC disabled). eCPC for standard
             // Shopping campaigns is deprecated. If eCPC is set to true, Google Ads ignores the
-            // the setting and behaves as if the setting was false. See this blog post for more
+            // setting and behaves as if the setting was false. See this blog post for more
             // information:
             // https://ads-developers.googleblog.com/2023/09/google-ads-shopping-campaign-enhanced.html
             // Recommendation: Use one of the automated bidding strategies for Shopping campaigns


### PR DESCRIPTION
As seen in [this blog announcement](https://ads-developers.googleblog.com/2023/09/google-ads-shopping-campaign-enhanced.html), any Shopping campaigns using Enhanced cost-per-click (eCPC) will behave as if they are using Manual cost-per-click (CPC) bidding.

Because of the change, I'm updating the examples related to the announcement to reflect the new recommended practice.