### PR TITLE
Avoid deprecated API usage in ExceptionTransformingUnaryCallable

### DIFF
--- a/google-ads-stubs-lib/src/main/java/com/google/ads/googleads/lib/GrpcGoogleAdsCallableFactory.java
+++ b/google-ads-stubs-lib/src/main/java/com/google/ads/googleads/lib/GrpcGoogleAdsCallableFactory.java
@@ -68,7 +68,8 @@ public class GrpcGoogleAdsCallableFactory implements GrpcStubCallableFactory {
       ClientContext clientContext) {
     UnaryCallable<RequestT, ResponseT> callable =
         GrpcCallableFactory.createBaseUnaryCallable(grpcCallSettings, callSettings, clientContext);
-    return new ExceptionTransformingUnaryCallable<>(callable, googleAdsExceptionTransformation);
+    return new ExceptionTransformingUnaryCallable<>(
+        callable, googleAdsExceptionTransformation, clientContext.getExecutor());
   }
 
   @Override

--- a/google-ads/src/test/java/com/google/ads/googleads/lib/callables/ExceptionTransformingUnaryCallableTest.java
+++ b/google-ads/src/test/java/com/google/ads/googleads/lib/callables/ExceptionTransformingUnaryCallableTest.java
@@ -23,6 +23,7 @@ import com.google.api.core.SettableApiFuture;
 import com.google.api.gax.grpc.GrpcCallContext;
 import com.google.api.gax.rpc.ApiCallContext;
 import com.google.api.gax.rpc.UnaryCallable;
+import com.google.common.util.concurrent.MoreExecutors;
 import java.util.concurrent.ExecutionException;
 import org.junit.Before;
 import org.junit.Test;
@@ -58,7 +59,7 @@ public class ExceptionTransformingUnaryCallableTest {
     // Sets up the class we're going to test.
     callable =
         new ExceptionTransformingUnaryCallable(
-            mockCallable, new GoogleAdsExceptionTransformation());
+            mockCallable, new GoogleAdsExceptionTransformation(), MoreExecutors.directExecutor());
 
     // Mocks out the gRPC callable implementation.
     innerFuture = SettableApiFuture.create();


### PR DESCRIPTION
With this change, the exception transformer will execute using the same Executor (thread pool) used by the API call.