### PR TITLE
Upgrade shadow plugin to 7.1.2

### DIFF
--- a/google-ads-shadowjar/build.gradle
+++ b/google-ads-shadowjar/build.gradle
@@ -1,14 +1,6 @@
-buildscript {
-  dependencies {
-    // Overrides the log4j dependency used by the shadow plugin during build
-    // execution. This does not impact the runtime classpath of the library.
-    classpath 'org.apache.logging.log4j:log4j-core:2.16.0'
-  }
-}
-
 plugins {
     id 'com.google.api-ads.java-conventions'
-    id 'com.github.johnrengelman.shadow' version '6.1.0'
+    id 'com.github.johnrengelman.shadow' version '7.1.2'
 }
 
 configurations {


### PR DESCRIPTION
https://imperceptiblethoughts.com/shadow/changes/#v7-1-2-2021-12-28

We should've done this when upgrading to Gradle 7. Using 7.1.2 since it avoids issues with earlier versions of log4j.  Also removes the log4j dependency override in `buildscript` dependencies since it is no longer necessary. The new version of the plugin depends on log4j 2.17.1.