### PR TITLE
Add example code for PMax campaigns to add search theme signal

### DIFF
--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/advancedoperations/AddPerformanceMaxCampaign.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/advancedoperations/AddPerformanceMaxCampaign.java
@@ -558,7 +558,7 @@ public class AddPerformanceMaxCampaign {
     List<MutateOperation> mutateOperations = new ArrayList<>();
 
     if (audienceId != null) {
-      // Create an audience asset group signal.
+      // Creates an audience asset group signal.
       // To learn more about Audience Signals, see:
       // https://developers.google.com/google-ads/api/performance-max/asset-group-signals#audiences
       // [START add_performance_max_campaign_9]

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/advancedoperations/AddPerformanceMaxCampaign.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/advancedoperations/AddPerformanceMaxCampaign.java
@@ -25,6 +25,7 @@ import com.google.ads.googleads.v17.common.ImageAsset;
 import com.google.ads.googleads.v17.common.LanguageInfo;
 import com.google.ads.googleads.v17.common.LocationInfo;
 import com.google.ads.googleads.v17.common.MaximizeConversionValue;
+import com.google.ads.googleads.v17.common.SearchThemeInfo;
 import com.google.ads.googleads.v17.common.TextAsset;
 import com.google.ads.googleads.v17.enums.AdvertisingChannelTypeEnum.AdvertisingChannelType;
 import com.google.ads.googleads.v17.enums.AssetFieldTypeEnum.AssetFieldType;
@@ -194,10 +195,8 @@ public class AddPerformanceMaxCampaign {
             assetGroupResourceName,
             headlineAssetResourceNames,
             descriptionAssetResourceNames));
-    if (audienceId != null) {
-      mutateOperations.addAll(
-          createAssetGroupSignalOperations(customerId, assetGroupResourceName, audienceId));
-    }
+    mutateOperations.addAll(
+        createAssetGroupSignalOperations(customerId, assetGroupResourceName, audienceId));
 
     try (GoogleAdsServiceClient googleAdsServiceClient =
         googleAdsClient.getLatestVersion().createGoogleAdsServiceClient()) {
@@ -550,7 +549,6 @@ public class AddPerformanceMaxCampaign {
   }
   // [END add_performance_max_campaign_8]
 
-  // [START add_performance_max_campaign_9]
   /**
    * Creates a list of MutateOperations that create {@link
    * com.google.ads.googleads.v17.resources.AssetGroupSignal} objects.
@@ -558,22 +556,46 @@ public class AddPerformanceMaxCampaign {
   private List<MutateOperation> createAssetGroupSignalOperations(
       long customerId, String assetGroupResourceName, Long audienceId) {
     List<MutateOperation> mutateOperations = new ArrayList<>();
-    AssetGroupSignal assetGroupSignal =
-        AssetGroupSignal.newBuilder()
-            .setAssetGroup(assetGroupResourceName)
-            .setAudience(
-                AudienceInfo.newBuilder()
-                    .setAudience(ResourceNames.audience(customerId, audienceId)))
-            .build();
-    // Adds an operation to the list to create the asset group signal.
+
+    if (audienceId != null) {
+      // Create an audience asset group signal.
+      // To learn more about Audience Signals, see:
+      // https://developers.google.com/google-ads/api/performance-max/asset-group-signals#audiences
+      // [START add_performance_max_campaign_9]
+      AssetGroupSignal audienceSignal = AssetGroupSignal.newBuilder()
+          .setAssetGroup(assetGroupResourceName)
+          .setAudience(
+              AudienceInfo.newBuilder()
+                  .setAudience(ResourceNames.audience(customerId, audienceId)))
+          .build();
+
+      mutateOperations.add(
+          MutateOperation.newBuilder()
+              .setAssetGroupSignalOperation(
+                  AssetGroupSignalOperation.newBuilder().setCreate(audienceSignal))
+              .build());
+      // [END add_performance_max_campaign_9]
+    }
+
+    // Create a search theme asset group signal.
+    // To learn more about Search Themes Signals, see:
+    // https://developers.google.com/google-ads/api/performance-max/asset-group-signals#search_themes
+    // [START add_performance_max_campaign_10]
+    AssetGroupSignal searchThemeSignal = AssetGroupSignal.newBuilder()
+        .setAssetGroup(assetGroupResourceName)
+        .setSearchTheme(
+            SearchThemeInfo.newBuilder().setText("travel").build())
+        .build();
+
     mutateOperations.add(
         MutateOperation.newBuilder()
             .setAssetGroupSignalOperation(
-                AssetGroupSignalOperation.newBuilder().setCreate(assetGroupSignal))
+                AssetGroupSignalOperation.newBuilder().setCreate(searchThemeSignal))
             .build());
+    // [END add_performance_max_campaign_10]
+
     return mutateOperations;
   }
-  // [END add_performance_max_campaign_9]
 
   /**
    * Prints the details of a MutateGoogleAdsResponse.

--- a/google-ads-examples/src/main/java/com/google/ads/googleads/examples/advancedoperations/AddPerformanceMaxCampaign.java
+++ b/google-ads-examples/src/main/java/com/google/ads/googleads/examples/advancedoperations/AddPerformanceMaxCampaign.java
@@ -577,7 +577,7 @@ public class AddPerformanceMaxCampaign {
       // [END add_performance_max_campaign_9]
     }
 
-    // Create a search theme asset group signal.
+    // Creates a search theme asset group signal.
     // To learn more about Search Themes Signals, see:
     // https://developers.google.com/google-ads/api/performance-max/asset-group-signals#search_themes
     // [START add_performance_max_campaign_10]


### PR DESCRIPTION
Referred to this [PR](https://github.com/googleads/google-ads-python/pull/883) from the Python client library.

---

**Context**: currently the `advancedoperations.AddPerformanceMaxCampaign` example only contains code samples to add the audience signal as an asset group signal. We also support adding search themes as an asset group signal, which is documented [here](https://developers.google.com/google-ads/api/performance-max/asset-group-signals#search_themes). With that we want to modify our code example to include it.

**Changes**:

1. Added code to demonstrate adding a search theme asset group signal.
2. Updated the document links in comments.
3. Updated the positions of utility comments (`[START/END add_performance_max_campaign_*]`) to prepare for devsite updates.