### PR TITLE
Implement JReleaser plugin for Central Portal migration

### DIFF
--- a/buildSrc/src/main/groovy/com.google.api-ads.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/com.google.api-ads.java-conventions.gradle
@@ -95,7 +95,11 @@ publishing {
   }
   repositories {
     maven {
-      url 'https://oss.sonatype.org/service/local/staging/deploy/maven2'
+      def releaseRepoUrl = 'https://s01.oss.sonatype.org/service/local/staging/deploy/maven2'
+      def snapshotRepoUrl = "https://s01.oss.sonatype.org/content/repositories/snapshots/"
+
+      // Set the URL dynamically based on the project version
+      url = project.version.endsWith('SNAPSHOT') ? snapshotRepoUrl : releaseRepoUrl
       name = "sonatype"
       credentials {
         // Avoids storing Sonatype credentials in plain-text. Specify these on

--- a/buildSrc/src/main/groovy/com.google.api-ads.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/com.google.api-ads.java-conventions.gradle
@@ -91,21 +91,11 @@ publishing {
               fromResolutionResult()
           }
       }
-    }
-  }
-  repositories {
-    maven {
-      def releaseRepoUrl = 'https://s01.oss.sonatype.org/service/local/staging/deploy/maven2'
-      def snapshotRepoUrl = "https://s01.oss.sonatype.org/content/repositories/snapshots/"
-
-      // Set the URL dynamically based on the project version
-      url = project.version.endsWith('SNAPSHOT') ? snapshotRepoUrl : releaseRepoUrl
-      name = "sonatype"
-      credentials {
-        // Avoids storing Sonatype credentials in plain-text. Specify these on
-        // the command line: -PsonatypeUser=foo
-        username project.properties.get("sonatypeUser")
-        password project.properties.get("sonatypePassword")
+      repositories {
+        maven {
+          name = 'sonatype'
+          url = uri(layout.buildDirectory.dir("staging-deploy"))
+        }
       }
     }
   }
@@ -169,6 +159,13 @@ ext.configurePom = { publication, nameToSet, descriptionToSet ->
         id = 'devin'
         name = 'Devin Chasanoff'
         email = 'devchas@users.noreply.github.com'
+        organization = 'Google'
+        organizationUrl = 'https://www.google.com'
+      }
+      developer {
+        id = 'sarah'
+        name = 'Sarah Pollack'
+        email = 'sarahbot@users.noreply.github.com'
         organization = 'Google'
         organizationUrl = 'https://www.google.com'
       }

--- a/google-ads/build.gradle
+++ b/google-ads/build.gradle
@@ -29,10 +29,42 @@ plugins {
     id 'com.google.api-ads.java-conventions'
     id 'com.google.protobuf' version '0.8.15'
     id "com.github.hierynomus.license-report" version "0.16.1"
+    id 'org.jreleaser' version '1.18.0'
 }
 
 description = 'Google Ads API client library for Java'
 
+jreleaser {
+    project {
+        gitRootSearch = true // Allow JReleaser to search upwards for .git
+    }
+    signing {
+        active = 'ALWAYS'
+        armored = true
+    }
+    deploy {
+        maven {
+            mavenCentral {
+                sonatype {
+                    /** Warning: this task will auto-publish artifacts to maven
+                     without an UI intervention. Publishing to Maven cannot
+                     be undone. In order to prevent the deploymnt from
+                     auto-publishing you must run this task with the
+                     JRELEASER_MAVENCENTRAL_STAGE parameter set to 'UPLOAD'. */
+                    active = 'ALWAYS'
+                    url = 'https://central.sonatype.com/api/v1/publisher'
+                    stagingRepository('target/staging-deploy')
+                    stage = 'UPLOAD'
+                }
+            }
+            release {
+        github {
+            enabled = false
+        }
+    }
+        }
+    }
+}
 protobuf {
     protoc {
         artifact = 'com.google.protobuf:protoc:3.25.3'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.4-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
I also upgraded Gradle to fix a gradle bug with JReleaser. 

I have not been able to end-to-end test this plugin yet with the release script since the release script pulls from the current Github main branch.