### PR TITLE
Docs changes for 37.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+37.0.0 - 2025-05-30
+-------------------
+- Remove support for v17 of the Google Ads API.
+- Implemented the JReleaser plugin.
+
 36.1.0 - 2025-04-16
 -------------------
 - Add support and examples for Google Ads API v19.1.

--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ This project hosts the Java client library for the Google Ads API.
     <dependency>
       <groupId>com.google.api-ads</groupId>
       <artifactId>google-ads</artifactId>
-      <version>36.1.0</version>
+      <version>37.0.0</version>
     </dependency>
 
 ## Gradle dependency
 
-    implementation 'com.google.api-ads:google-ads:36.1.0'
+    implementation 'com.google.api-ads:google-ads:37.0.0'
 
 ## Documentation
 


### PR DESCRIPTION
Setting this up for a new release that just removes v17. Planning to release this tomorrow as an end-to-end test of our new jreleaser config before v20 is released next week.