### PR TITLE
Bump the release version for the Java Client release to add the google-ads-bom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+40.0.0 - 2025-09-03
+-------------------
+- Add the google-ads-bom module to assist users with dependency management.
+
 39.0.0 - 2025-08-06
 -------------------
 - Add support and examples for v21 of the Google Ads API.

--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ This project hosts the Java client library for the Google Ads API.
     <dependency>
       <groupId>com.google.api-ads</groupId>
       <artifactId>google-ads</artifactId>
-      <version>39.0.0</version>
+      <version>40.0.0</version>
     </dependency>
 
 ## Gradle dependency
 
-    implementation 'com.google.api-ads:google-ads:39.0.0'
+    implementation 'com.google.api-ads:google-ads:40.0.0'
 
 ## Documentation
 


### PR DESCRIPTION

I bumped the major version since this is adding an entirely new module.